### PR TITLE
feat: add Wappalyzer signatures

### DIFF
--- a/src/signatures/index.ts
+++ b/src/signatures/index.ts
@@ -19,25 +19,47 @@ import { swiperSignature } from "./technologies/spiwer.js";
 import { microsoftAspSignature } from "./technologies/microsoft_asp.js";
 import { microsoftIisSignature } from "./technologies/microsoft_iis.js";
 import { gsapSignature } from "./technologies/gsap.js";
+import { contactForm7Signature } from "./technologies/contact_form_7.js";
+import { reactSignature } from "./technologies/react.js";
+import { lodashSignature } from "./technologies/lodash.js";
+import { modernizrSignature } from "./technologies/modernizr.js";
+import { vueJsSignature } from "./technologies/vue_js.js";
+import { openSslSignature } from "./technologies/openssl.js";
+import { yoastSeoSignature } from "./technologies/yoast_seo.js";
+import { microsoftHttpApiSignature } from "./technologies/microsoft_httpapi.js";
+import { animateCssSignature } from "./technologies/animate_css.js";
+import { fancyBoxSignature } from "./technologies/fancybox.js";
+import { siteKitSignature } from "./technologies/site_kit.js";
 
 export const signatures: Signature[] = [
   apacheHttpServerSignature,
   awsElbSignature,
+  animateCssSignature,
   bootstrapSignature,
+  contactForm7Signature,
   corejsSignature,
   gsapSignature,
   jquerySignature,
   jqueryCookieSignature,
   jqueryMigrateSignature,
   jqueryUiSignature,
+  lodashSignature,
+  fancyBoxSignature,
+  microsoftHttpApiSignature,
   microsoftAspSignature,
   microsoftIisSignature,
+  modernizrSignature,
   mysqlSignature,
   nginxSignature,
   nextjsSignature,
+  openSslSignature,
   phpSignature,
+  reactSignature,
+  siteKitSignature,
   slickSignature,
   swiperSignature,
+  vueJsSignature,
   wordpressSignature,
+  yoastSeoSignature,
   yawsHttpServerSignature,
 ];

--- a/src/signatures/technologies/animate_css.ts
+++ b/src/signatures/technologies/animate_css.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const animateCssSignature: Signature = {
+  name: "Animate.css",
+  description:
+    "Animate.css is a ready-to-use library collection of CSS3 animation effects.",
+  rule: {
+    confidence: "high",
+    urls: ["(?:/([\\d.]+))?/animate\\.min\\.css"],
+    bodies: ["animate__animated"],
+  },
+};

--- a/src/signatures/technologies/contact_form_7.ts
+++ b/src/signatures/technologies/contact_form_7.ts
@@ -1,0 +1,19 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const contactForm7Signature: Signature = {
+  name: "Contact Form 7",
+  description:
+    "Contact Form 7 is a WordPress plugin which can manage multiple contact forms. The form supports Ajax-powered submitting, CAPTCHA, Akismet spam filtering.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "/wp-content/plugins/contact-form-7/.+\\.js(?:\\?ver=(\\d+(?:\\.\\d+)+))?",
+    ],
+    bodies: ["/wp-content/plugins/contact-form-7/"],
+    javascriptVariables: {
+      wpcf7: "",
+    },
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/fancybox.ts
+++ b/src/signatures/technologies/fancybox.ts
@@ -1,0 +1,20 @@
+import type { Signature } from "../_types.js";
+import { jquerySignature } from "./jquery.js";
+
+export const fancyBoxSignature: Signature = {
+  name: "FancyBox",
+  description:
+    "FancyBox is a tool for displaying images, html content and multi-media in a Mac-style 'lightbox' that floats overtop of web page.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "jquery\\.fancybox(?:\\.pack|\\.min)?\\.js(?:\\?v=([\\d.]+))?$",
+    ],
+    javascriptVariables: {
+      "$.fancybox.version": "(.+)",
+      "Fancybox.version": "(.+)",
+      "jQuery.fancybox.version": "(.+)",
+    },
+  },
+  impliedSoftwares: [jquerySignature.name],
+};

--- a/src/signatures/technologies/lodash.ts
+++ b/src/signatures/technologies/lodash.ts
@@ -1,0 +1,17 @@
+import type { Signature } from "../_types.js";
+
+export const lodashSignature: Signature = {
+  name: "Lodash",
+  description:
+    "Lodash is a JavaScript library which provides utility functions for common programming tasks using the functional programming paradigm.",
+  cpe: "cpe:/a:lodash:lodash",
+  rule: {
+    confidence: "high",
+    urls: ["lodash.*\\.js"],
+    javascriptVariables: {
+      "_.VERSION": "(.+)",
+      "_.differenceBy": "",
+      "_.templateSettings.imports._.templateSettings.imports._.VERSION": "(.+)",
+    },
+  },
+};

--- a/src/signatures/technologies/microsoft_httpapi.ts
+++ b/src/signatures/technologies/microsoft_httpapi.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const microsoftHttpApiSignature: Signature = {
+  name: "Microsoft HTTPAPI",
+  description: "Microsoft HTTPAPI is a Windows HTTP Server API implementation.",
+  rule: {
+    confidence: "high",
+    headers: {
+      Server: "Microsoft-HTTPAPI(?:/([\\d.]+))?",
+    },
+  },
+};

--- a/src/signatures/technologies/modernizr.ts
+++ b/src/signatures/technologies/modernizr.ts
@@ -1,0 +1,17 @@
+import type { Signature } from "../_types.js";
+
+export const modernizrSignature: Signature = {
+  name: "Modernizr",
+  description:
+    "Modernizr is a JavaScript library that detects the features available in a user's browser.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "/([\\d.]+)/modernizr.*\\.js",
+      "modernizr(?:\\.([\\d.]+))?.*\\.js",
+    ],
+    javascriptVariables: {
+      "Modernizr._version": "(.+)",
+    },
+  },
+};

--- a/src/signatures/technologies/nextjs.ts
+++ b/src/signatures/technologies/nextjs.ts
@@ -1,4 +1,5 @@
 import type { Signature } from "../_types.js";
+import { reactSignature } from "./react.js";
 
 export const nextjsSignature: Signature = {
   name: "Next.js",
@@ -8,11 +9,12 @@ export const nextjsSignature: Signature = {
   rule: {
     confidence: "high",
     headers: {
-      "x-powered-by": "^Next\\.js (\\d+\\.\\d+\\.\\d+)?",
+      "x-powered-by": "^Next\\.js ?([0-9.]+)?",
     },
     javascriptVariables: {
       __NEXT_DATA__: "",
       "next.version": "(.+)$",
     },
   },
+  impliedSoftwares: [reactSignature.name],
 };

--- a/src/signatures/technologies/openssl.ts
+++ b/src/signatures/technologies/openssl.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+
+export const openSslSignature: Signature = {
+  name: "OpenSSL",
+  description:
+    "OpenSSL is a software library for applications that secure communications over computer networks against eavesdropping or need to identify the party at the other end.",
+  cpe: "cpe:/a:openssl:openssl",
+  rule: {
+    confidence: "high",
+    headers: {
+      Server: "OpenSSL(?:/([\\d.]+[a-z]?))?",
+    },
+  },
+};

--- a/src/signatures/technologies/react.ts
+++ b/src/signatures/technologies/react.ts
@@ -1,0 +1,22 @@
+import type { Signature } from "../_types.js";
+
+export const reactSignature: Signature = {
+  name: "React",
+  description:
+    "React is an open-source JavaScript library for building user interfaces or UI components.",
+  cpe: "cpe:/a:facebook:react",
+  rule: {
+    confidence: "high",
+    urls: [
+      "react(?:-with-addons)?[.-](\\d+(?:\\.\\d+)+)[^/]*\\.js",
+      "/([\\d.]+)/react(?:\\.min)?\\.js",
+      "react\\b.*\\.js",
+    ],
+    bodies: ["<[^>]+data-react", "create-react-app", "react-root"],
+    javascriptVariables: {
+      "React.version": "([\\d.]+)",
+      ReactOnRails: "",
+      __REACT_ON_RAILS_EVENT_HANDLERS_RAN_ONCE__: "",
+    },
+  },
+};

--- a/src/signatures/technologies/site_kit.ts
+++ b/src/signatures/technologies/site_kit.ts
@@ -1,0 +1,13 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const siteKitSignature: Signature = {
+  name: "Site Kit",
+  description:
+    "Site Kit is a one-stop solution for WordPress users to use everything Google has to offer to make them successful on the web.",
+  rule: {
+    confidence: "high",
+    bodies: ["Site Kit by Google ?([\\d.]+)?"],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/vue_js.ts
+++ b/src/signatures/technologies/vue_js.ts
@@ -1,0 +1,23 @@
+import type { Signature } from "../_types.js";
+
+export const vueJsSignature: Signature = {
+  name: "Vue.js",
+  description:
+    "Vue.js is an open-source model-view-viewmodel JavaScript framework for building user interfaces and single-page applications.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "vue[.-]([\\d.]*\\d)[^/]*\\.js",
+      "(?:/([\\d.]+))?/vue(?:\\.min)?\\.js",
+    ],
+    bodies: ["<[^>]+\\sdata-v(?:ue)?-", "vue-app"],
+    javascriptVariables: {
+      Vue: "",
+      "Vue.version": "(.+)",
+      VueRoot: "",
+      __VUE_HOT_MAP__: "",
+      __VUE__: "",
+      vueDLL: "",
+    },
+  },
+};

--- a/src/signatures/technologies/yoast_seo.ts
+++ b/src/signatures/technologies/yoast_seo.ts
@@ -1,0 +1,17 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const yoastSeoSignature: Signature = {
+  name: "Yoast SEO",
+  description:
+    "Yoast SEO is a search engine optimisation plugin for WordPress and other platforms.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<!-- This site is optimized with the Yoast (?:WordPress )?SEO plugin v([^\\s]+) -",
+      "<!-- This site is optimized with the Yoast SEO Premium plugin v(?:[^\\s]+) \\\\(Yoast SEO v([^\\s]+)\\\\) -",
+      "yoast-schema-graph",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};


### PR DESCRIPTION
## Summary
- add signatures for Contact Form 7, React, Lodash, Modernizr, Vue.js, OpenSSL, Yoast SEO, Microsoft HTTPAPI, Animate.css, FancyBox, and Site Kit
- register new signatures and align Next.js to imply React
