### PR TITLE
feat: add wappalyzer signatures

### DIFF
--- a/src/signatures/index.ts
+++ b/src/signatures/index.ts
@@ -174,6 +174,36 @@ import { adobeClientDataLayerSignature } from "./technologies/adobe_client_data_
 import { mailchimpForWooCommerceSignature } from "./technologies/mailchimp_for_woocommerce.js";
 import { recaptchaV2ForContactForm7Signature } from "./technologies/recaptcha_v2_for_contact_form_7.js";
 import { miniServSignature } from "./technologies/miniserv.js";
+import { windowsServerSignature } from "./technologies/windows_server.js";
+import { facebookLoginSignature } from "./technologies/facebook_login.js";
+import { nodeJsSignature } from "./technologies/node_js.js";
+import { dreamWeaverSignature } from "./technologies/dreamweaver.js";
+import { cartFunctionalitySignature } from "./technologies/cart_functionality.js";
+import { lazySizesSignature } from "./technologies/lazy_sizes.js";
+import { javaSignature } from "./technologies/java.js";
+import { ubuntuSignature } from "./technologies/ubuntu.js";
+import { laravelSignature } from "./technologies/laravel.js";
+import { wpPageNaviSignature } from "./technologies/wp_page_navi.js";
+import { emotionSignature } from "./technologies/emotion.js";
+import { lightboxSignature } from "./technologies/lightbox.js";
+import { envoySignature } from "./technologies/envoy.js";
+import { nuxtJsSignature } from "./technologies/nuxt_js.js";
+import { rubySignature } from "./technologies/ruby.js";
+import { rubyOnRailsSignature } from "./technologies/ruby_on_rails.js";
+import { owlCarouselSignature } from "./technologies/owl_carousel.js";
+import { particlesJsSignature } from "./technologies/particles_js.js";
+import { pleskSignature } from "./technologies/plesk.js";
+import { splideSignature } from "./technologies/splide.js";
+import { select2Signature } from "./technologies/select2.js";
+import { unixSignature } from "./technologies/unix.js";
+import { underscoreJsSignature } from "./technologies/underscore_js.js";
+import { shopifySignature } from "./technologies/shopify.js";
+import { aBlogCmsSignature } from "./technologies/a_blog_cms.js";
+import { centOsSignature } from "./technologies/centos.js";
+import { codeIgniterSignature } from "./technologies/codeigniter.js";
+import { f5BigIpSignature } from "./technologies/f5_bigip.js";
+import { isotopeSignature } from "./technologies/isotope.js";
+import { expressSignature } from "./technologies/express.js";
 
 export const signatures: Signature[] = [
   addToAnySignature,
@@ -350,4 +380,34 @@ export const signatures: Signature[] = [
   yawsHttpServerSignature,
   mustacheSignature,
   zurbFoundationSignature,
+  windowsServerSignature,
+  facebookLoginSignature,
+  nodeJsSignature,
+  dreamWeaverSignature,
+  cartFunctionalitySignature,
+  lazySizesSignature,
+  javaSignature,
+  ubuntuSignature,
+  laravelSignature,
+  wpPageNaviSignature,
+  emotionSignature,
+  lightboxSignature,
+  envoySignature,
+  nuxtJsSignature,
+  rubySignature,
+  rubyOnRailsSignature,
+  owlCarouselSignature,
+  particlesJsSignature,
+  pleskSignature,
+  splideSignature,
+  select2Signature,
+  unixSignature,
+  underscoreJsSignature,
+  shopifySignature,
+  aBlogCmsSignature,
+  centOsSignature,
+  codeIgniterSignature,
+  f5BigIpSignature,
+  isotopeSignature,
+  expressSignature,
 ];

--- a/src/signatures/technologies/a_blog_cms.ts
+++ b/src/signatures/technologies/a_blog_cms.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+import { phpSignature } from "./php.js";
+
+export const aBlogCmsSignature: Signature = {
+  name: "a-blog cms",
+  description: "a-blog cms is a content management system.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<meta[^>]+name=[\"']generator[\"'][^>]+content=[\"']a-blog cms",
+    ],
+  },
+  impliedSoftwares: [phpSignature.name],
+};

--- a/src/signatures/technologies/cart_functionality.ts
+++ b/src/signatures/technologies/cart_functionality.ts
@@ -1,0 +1,32 @@
+import type { Signature } from "../_types.js";
+
+export const cartFunctionalitySignature: Signature = {
+  name: "Cart Functionality",
+  description:
+    "Websites that have a shopping cart or checkout page, either using a known ecommerce platform or a custom solution.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "/(?:cart|order|basket|trolley|bag|shoppingbag|checkout)",
+      "googlecommerce\\.com/trustedstores/api/js",
+    ],
+    bodies: [
+      "href=[\"'][^\"']*/cart",
+      "href=[\"'][^\"']*/order",
+      "href=[\"'][^\"']*/basket",
+      "href=[\"'][^\"']*/trolley",
+      "href=[\"'][^\"']*/bag/",
+      "href=[\"'][^\"']*/shoppingbag",
+      "href=[\"'][^\"']*/checkout",
+      "href=[\"'][^\"']*/winkelwagen",
+      "aria-controls=[\"']cart[\"']",
+      "class=[\"'][^\"']*shopping-bag",
+      "class=[\"'][^\"']*shopping-cart",
+      "class=[\"'][^\"']*checkout",
+      "class=[\"'][^\"']*winkelwagen",
+    ],
+    javascriptVariables: {
+      "google_tag_params.ecomm_pagetype": "",
+    },
+  },
+};

--- a/src/signatures/technologies/centos.ts
+++ b/src/signatures/technologies/centos.ts
@@ -4,7 +4,7 @@ export const centOsSignature: Signature = {
   name: "CentOS",
   description:
     "CentOS is a Linux distribution that provides a free, community-supported computing platform functionally compatible with its upstream source, Red Hat Enterprise Linux (RHEL).",
-  cpe: "cpe:2.3:o:centos:centos:*:*:*:*:*:*:*:*",
+  cpe: "cpe:/o:centos:centos",
   rule: {
     confidence: "high",
     headers: {

--- a/src/signatures/technologies/centos.ts
+++ b/src/signatures/technologies/centos.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+
+export const centOsSignature: Signature = {
+  name: "CentOS",
+  description:
+    "CentOS is a Linux distribution that provides a free, community-supported computing platform functionally compatible with its upstream source, Red Hat Enterprise Linux (RHEL).",
+  cpe: "cpe:2.3:o:centos:centos:*:*:*:*:*:*:*:*",
+  rule: {
+    confidence: "high",
+    headers: {
+      server: "CentOS",
+      "x-powered-by": "CentOS",
+    },
+  },
+};

--- a/src/signatures/technologies/codeigniter.ts
+++ b/src/signatures/technologies/codeigniter.ts
@@ -4,7 +4,7 @@ import { phpSignature } from "./php.js";
 export const codeIgniterSignature: Signature = {
   name: "CodeIgniter",
   description: "CodeIgniter is an open-source PHP web framework.",
-  cpe: "cpe:2.3:a:codeigniter:codeigniter:*:*:*:*:*:*:*:*",
+  cpe: "cpe:/a:codeigniter:codeigniter",
   rule: {
     confidence: "high",
     cookies: {

--- a/src/signatures/technologies/codeigniter.ts
+++ b/src/signatures/technologies/codeigniter.ts
@@ -1,0 +1,19 @@
+import type { Signature } from "../_types.js";
+import { phpSignature } from "./php.js";
+
+export const codeIgniterSignature: Signature = {
+  name: "CodeIgniter",
+  description: "CodeIgniter is an open-source PHP web framework.",
+  cpe: "cpe:2.3:a:codeigniter:codeigniter:*:*:*:*:*:*:*:*",
+  rule: {
+    confidence: "high",
+    cookies: {
+      ci_csrf_token: ".+",
+      ci_session: ".+",
+      exp_last_activity: ".+",
+      exp_tracker: ".+",
+    },
+    bodies: ["<input[^>]+name=\"ci_csrf_token\""],
+  },
+  impliedSoftwares: [phpSignature.name],
+};

--- a/src/signatures/technologies/dreamweaver.ts
+++ b/src/signatures/technologies/dreamweaver.ts
@@ -1,0 +1,18 @@
+import type { Signature } from "../_types.js";
+
+export const dreamWeaverSignature: Signature = {
+  name: "DreamWeaver",
+  description:
+    "Dreamweaver is a development tool for creating, publishing, and managing websites and mobile content.",
+  cpe: "cpe:2.3:a:adobe:dreamweaver:*:*:*:*:*:*:*:*",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<!--[^>]*(?:InstanceBeginEditable|Dreamweaver([^>]+)target|DWLayoutDefaultTable)",
+      "<!-- #BeginTemplate\\s\"[\\d_\\w/]+\\.dwt",
+      "MM_preloadImages",
+      "MM_showHideLayers",
+      "MM_showMenu",
+    ],
+  },
+};

--- a/src/signatures/technologies/dreamweaver.ts
+++ b/src/signatures/technologies/dreamweaver.ts
@@ -4,7 +4,7 @@ export const dreamWeaverSignature: Signature = {
   name: "DreamWeaver",
   description:
     "Dreamweaver is a development tool for creating, publishing, and managing websites and mobile content.",
-  cpe: "cpe:2.3:a:adobe:dreamweaver:*:*:*:*:*:*:*:*",
+  cpe: "cpe:/a:adobe:dreamweaver",
   rule: {
     confidence: "high",
     bodies: [

--- a/src/signatures/technologies/emotion.ts
+++ b/src/signatures/technologies/emotion.ts
@@ -1,0 +1,10 @@
+import type { Signature } from "../_types.js";
+
+export const emotionSignature: Signature = {
+  name: "Emotion",
+  description: "Emotion is a library designed for writing CSS styles with JavaScript.",
+  rule: {
+    confidence: "high",
+    bodies: ["data-emotion", "data-emotion-css"],
+  },
+};

--- a/src/signatures/technologies/envoy.ts
+++ b/src/signatures/technologies/envoy.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+
+export const envoySignature: Signature = {
+  name: "Envoy",
+  description:
+    "Envoy is an open-source edge and service proxy, designed for cloud-native applications.",
+  cpe: "cpe:2.3:a:envoyproxy:envoy:*:*:*:*:*:*:*:*",
+  rule: {
+    confidence: "high",
+    headers: {
+      server: "^envoy$",
+      "x-envoy-upstream-service-time": "",
+    },
+  },
+};

--- a/src/signatures/technologies/envoy.ts
+++ b/src/signatures/technologies/envoy.ts
@@ -4,7 +4,7 @@ export const envoySignature: Signature = {
   name: "Envoy",
   description:
     "Envoy is an open-source edge and service proxy, designed for cloud-native applications.",
-  cpe: "cpe:2.3:a:envoyproxy:envoy:*:*:*:*:*:*:*:*",
+  cpe: "cpe:/a:envoyproxy:envoy",
   rule: {
     confidence: "high",
     headers: {

--- a/src/signatures/technologies/express.ts
+++ b/src/signatures/technologies/express.ts
@@ -5,7 +5,7 @@ export const expressSignature: Signature = {
   name: "Express",
   description:
     "Express is a web application framework for Node.js, released as free and open-source software under the MIT License. It is designed for building web applications and APIs.",
-  cpe: "cpe:2.3:a:expressjs:express:*:*:*:*:*:*:*:*",
+  cpe: "cpe:/a:expressjs:express",
   rule: {
     confidence: "high",
     headers: {

--- a/src/signatures/technologies/express.ts
+++ b/src/signatures/technologies/express.ts
@@ -1,0 +1,16 @@
+import type { Signature } from "../_types.js";
+import { nodeJsSignature } from "./node_js.js";
+
+export const expressSignature: Signature = {
+  name: "Express",
+  description:
+    "Express is a web application framework for Node.js, released as free and open-source software under the MIT License. It is designed for building web applications and APIs.",
+  cpe: "cpe:2.3:a:expressjs:express:*:*:*:*:*:*:*:*",
+  rule: {
+    confidence: "high",
+    headers: {
+      "x-powered-by": "^Express(?:$|,)",
+    },
+  },
+  impliedSoftwares: [nodeJsSignature.name],
+};

--- a/src/signatures/technologies/f5_bigip.ts
+++ b/src/signatures/technologies/f5_bigip.ts
@@ -4,7 +4,7 @@ export const f5BigIpSignature: Signature = {
   name: "F5 BigIP",
   description:
     "F5's BIG-IP is a family of products covering software and hardware designed around application availability, access control, and security solutions.",
-  cpe: "cpe:2.3:a:f5:big-ip:*:*:*:*:*:*:*:*",
+  cpe: "cpe:/a:f5:big-ip",
   rule: {
     confidence: "high",
     headers: {

--- a/src/signatures/technologies/f5_bigip.ts
+++ b/src/signatures/technologies/f5_bigip.ts
@@ -1,0 +1,24 @@
+import type { Signature } from "../_types.js";
+
+export const f5BigIpSignature: Signature = {
+  name: "F5 BigIP",
+  description:
+    "F5's BIG-IP is a family of products covering software and hardware designed around application availability, access control, and security solutions.",
+  cpe: "cpe:2.3:a:f5:big-ip:*:*:*:*:*:*:*:*",
+  rule: {
+    confidence: "high",
+    headers: {
+      server: "^big-?ip$",
+    },
+    cookies: {
+      F5_HT_shrinked: ".+",
+      F5_ST: ".+",
+      F5_fullWT: ".+",
+      LastMRH_Session: ".+",
+      MRHSHint: ".+",
+      MRHSequence: ".+",
+      MRHSession: ".+",
+      TIN: ".+",
+    },
+  },
+};

--- a/src/signatures/technologies/facebook_login.ts
+++ b/src/signatures/technologies/facebook_login.ts
@@ -1,0 +1,13 @@
+import type { Signature } from "../_types.js";
+
+export const facebookLoginSignature: Signature = {
+  name: "Facebook Login",
+  description:
+    "Facebook Login is a way for people to create accounts and log into your app across multiple platforms.",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      "FB.getLoginStatus": "",
+    },
+  },
+};

--- a/src/signatures/technologies/isotope.ts
+++ b/src/signatures/technologies/isotope.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+
+export const isotopeSignature: Signature = {
+  name: "Isotope",
+  description:
+    "Isotope.js is a JavaScript library that makes it easy to sort, filter, and add Masonry layouts to items on a webpage.",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      Isotope: "",
+      init_isotope: "",
+    },
+  },
+};

--- a/src/signatures/technologies/java.ts
+++ b/src/signatures/technologies/java.ts
@@ -4,7 +4,7 @@ export const javaSignature: Signature = {
   name: "Java",
   description:
     "Java is a class-based, object-oriented programming language that is designed to have as few implementation dependencies as possible.",
-  cpe: "cpe:2.3:a:oracle:jre:*:*:*:*:*:*:*:*",
+  cpe: "cpe:/a:oracle:jre",
   rule: {
     confidence: "high",
     cookies: {

--- a/src/signatures/technologies/java.ts
+++ b/src/signatures/technologies/java.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+
+export const javaSignature: Signature = {
+  name: "Java",
+  description:
+    "Java is a class-based, object-oriented programming language that is designed to have as few implementation dependencies as possible.",
+  cpe: "cpe:2.3:a:oracle:jre:*:*:*:*:*:*:*:*",
+  rule: {
+    confidence: "high",
+    cookies: {
+      JSESSIONID: ".+",
+    },
+  },
+};

--- a/src/signatures/technologies/laravel.ts
+++ b/src/signatures/technologies/laravel.ts
@@ -4,7 +4,7 @@ import { phpSignature } from "./php.js";
 export const laravelSignature: Signature = {
   name: "Laravel",
   description: "Laravel is a free, open-source PHP web framework.",
-  cpe: "cpe:2.3:a:laravel:laravel:*:*:*:*:*:*:*:*",
+  cpe: "cpe:/a:laravel:laravel",
   rule: {
     confidence: "high",
     cookies: {

--- a/src/signatures/technologies/laravel.ts
+++ b/src/signatures/technologies/laravel.ts
@@ -1,0 +1,18 @@
+import type { Signature } from "../_types.js";
+import { phpSignature } from "./php.js";
+
+export const laravelSignature: Signature = {
+  name: "Laravel",
+  description: "Laravel is a free, open-source PHP web framework.",
+  cpe: "cpe:2.3:a:laravel:laravel:*:*:*:*:*:*:*:*",
+  rule: {
+    confidence: "high",
+    cookies: {
+      laravel_session: ".+",
+    },
+    javascriptVariables: {
+      Laravel: "",
+    },
+  },
+  impliedSoftwares: [phpSignature.name],
+};

--- a/src/signatures/technologies/lazy_sizes.ts
+++ b/src/signatures/technologies/lazy_sizes.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+
+export const lazySizesSignature: Signature = {
+  name: "LazySizes",
+  description:
+    "LazySizes is a JavaScript library used to delay the loading of images (iframes, scripts, etc) until they come into view.",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      lazySizes: "",
+      lazySizesConfig: "",
+    },
+  },
+};

--- a/src/signatures/technologies/lightbox.ts
+++ b/src/signatures/technologies/lightbox.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+
+export const lightboxSignature: Signature = {
+  name: "Lightbox",
+  description:
+    "Lightbox is a JavaScript library for displaying images and other content in an overlay.",
+  cpe: "cpe:2.3:a:lightbox_photo_gallery_project:lightbox_photo_gallery:*:*:*:*:*:*:*:*",
+  rule: {
+    confidence: "high",
+    urls: ["lightbox(?:-plus-jquery)?.{0,32}\\.js"],
+    bodies: [
+      "<link [^>]*href=[\"'][^\"']+lightbox(?:\\.min)?\\.css",
+    ],
+  },
+};

--- a/src/signatures/technologies/lightbox.ts
+++ b/src/signatures/technologies/lightbox.ts
@@ -4,7 +4,7 @@ export const lightboxSignature: Signature = {
   name: "Lightbox",
   description:
     "Lightbox is a JavaScript library for displaying images and other content in an overlay.",
-  cpe: "cpe:2.3:a:lightbox_photo_gallery_project:lightbox_photo_gallery:*:*:*:*:*:*:*:*",
+  cpe: "cpe:/a:lightbox_photo_gallery_project:lightbox_photo_gallery",
   rule: {
     confidence: "high",
     urls: ["lightbox(?:-plus-jquery)?.{0,32}\\.js"],

--- a/src/signatures/technologies/node_js.ts
+++ b/src/signatures/technologies/node_js.ts
@@ -1,0 +1,8 @@
+import type { Signature } from "../_types.js";
+
+export const nodeJsSignature: Signature = {
+  name: "Node.js",
+  description:
+    "Node.js is an open-source, cross-platform, JavaScript runtime environment that executes JavaScript code outside a web browser.",
+  cpe: "cpe:2.3:a:nodejs:node.js:*:*:*:*:*:*:*:*",
+};

--- a/src/signatures/technologies/node_js.ts
+++ b/src/signatures/technologies/node_js.ts
@@ -4,5 +4,5 @@ export const nodeJsSignature: Signature = {
   name: "Node.js",
   description:
     "Node.js is an open-source, cross-platform, JavaScript runtime environment that executes JavaScript code outside a web browser.",
-  cpe: "cpe:2.3:a:nodejs:node.js:*:*:*:*:*:*:*:*",
+  cpe: "cpe:/a:nodejs:node.js",
 };

--- a/src/signatures/technologies/nuxt_js.ts
+++ b/src/signatures/technologies/nuxt_js.ts
@@ -1,0 +1,20 @@
+import type { Signature } from "../_types.js";
+import { nodeJsSignature } from "./node_js.js";
+import { vueJsSignature } from "./vue_js.js";
+
+export const nuxtJsSignature: Signature = {
+  name: "Nuxt.js",
+  description: "Nuxt is a Vue framework for developing modern web applications.",
+  rule: {
+    confidence: "high",
+    urls: ["/_nuxt/"],
+    bodies: [
+      "<div [^>]*id=[\"']__nuxt[\"']",
+      "<script [^>]*>window\\.__NUXT__",
+    ],
+    javascriptVariables: {
+      $nuxt: "",
+    },
+  },
+  impliedSoftwares: [vueJsSignature.name, nodeJsSignature.name],
+};

--- a/src/signatures/technologies/owl_carousel.ts
+++ b/src/signatures/technologies/owl_carousel.ts
@@ -1,0 +1,16 @@
+import type { Signature } from "../_types.js";
+import { jquerySignature } from "./jquery.js";
+
+export const owlCarouselSignature: Signature = {
+  name: "OWL Carousel",
+  description:
+    "OWL Carousel is an enabled jQuery plugin that lets you create responsive carousel sliders.",
+  rule: {
+    confidence: "high",
+    urls: ["owl\\.carousel.*\\.js"],
+    bodies: [
+      "<link [^>]*href=[\"'][^\"']+owl\\.carousel(?:\\.min)?\\.css",
+    ],
+  },
+  impliedSoftwares: [jquerySignature.name],
+};

--- a/src/signatures/technologies/particles_js.ts
+++ b/src/signatures/technologies/particles_js.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+
+export const particlesJsSignature: Signature = {
+  name: "particles.js",
+  description: "Particles.js is a JavaScript library for creating particles.",
+  rule: {
+    confidence: "high",
+    urls: ["/particles(?:\\.min)?\\.js"],
+    bodies: ["id=[\"']particles-js[\"']"],
+    javascriptVariables: {
+      particlesJS: "",
+    },
+  },
+};

--- a/src/signatures/technologies/plesk.ts
+++ b/src/signatures/technologies/plesk.ts
@@ -1,0 +1,16 @@
+import type { Signature } from "../_types.js";
+
+export const pleskSignature: Signature = {
+  name: "Plesk",
+  description:
+    "Plesk is a web hosting and server data centre automation software with a control panel developed for Linux and Windows-based retail hosting service providers.",
+  cpe: "cpe:2.3:a:parallels:parallels_plesk_panel:*:*:*:*:*:*:*:*",
+  rule: {
+    confidence: "high",
+    headers: {
+      "x-powered-by": "^Plesk(?:L|W)in",
+      "x-powered-by-plesk": "^Plesk",
+    },
+    urls: ["common\\.js\\?plesk"],
+  },
+};

--- a/src/signatures/technologies/plesk.ts
+++ b/src/signatures/technologies/plesk.ts
@@ -4,7 +4,7 @@ export const pleskSignature: Signature = {
   name: "Plesk",
   description:
     "Plesk is a web hosting and server data centre automation software with a control panel developed for Linux and Windows-based retail hosting service providers.",
-  cpe: "cpe:2.3:a:parallels:parallels_plesk_panel:*:*:*:*:*:*:*:*",
+  cpe: "cpe:/a:parallels:parallels_plesk_panel",
   rule: {
     confidence: "high",
     headers: {

--- a/src/signatures/technologies/ruby.ts
+++ b/src/signatures/technologies/ruby.ts
@@ -3,7 +3,7 @@ import type { Signature } from "../_types.js";
 export const rubySignature: Signature = {
   name: "Ruby",
   description: "Ruby is an open-source object-oriented programming language.",
-  cpe: "cpe:2.3:a:ruby-lang:ruby:*:*:*:*:*:*:*:*",
+  cpe: "cpe:/a:ruby-lang:ruby",
   rule: {
     confidence: "high",
     headers: {

--- a/src/signatures/technologies/ruby.ts
+++ b/src/signatures/technologies/ruby.ts
@@ -1,0 +1,13 @@
+import type { Signature } from "../_types.js";
+
+export const rubySignature: Signature = {
+  name: "Ruby",
+  description: "Ruby is an open-source object-oriented programming language.",
+  cpe: "cpe:2.3:a:ruby-lang:ruby:*:*:*:*:*:*:*:*",
+  rule: {
+    confidence: "high",
+    headers: {
+      server: "(?:Mongrel|WEBrick|Ruby)",
+    },
+  },
+};

--- a/src/signatures/technologies/ruby_on_rails.ts
+++ b/src/signatures/technologies/ruby_on_rails.ts
@@ -5,7 +5,7 @@ export const rubyOnRailsSignature: Signature = {
   name: "Ruby on Rails",
   description:
     "Ruby on Rails is a server-side web application framework written in Ruby under the MIT License.",
-  cpe: "cpe:2.3:a:rubyonrails:rails:*:*:*:*:*:*:*:*",
+  cpe: "cpe:/a:rubyonrails:rails",
   rule: {
     confidence: "high",
     headers: {

--- a/src/signatures/technologies/ruby_on_rails.ts
+++ b/src/signatures/technologies/ruby_on_rails.ts
@@ -1,0 +1,28 @@
+import type { Signature } from "../_types.js";
+import { rubySignature } from "./ruby.js";
+
+export const rubyOnRailsSignature: Signature = {
+  name: "Ruby on Rails",
+  description:
+    "Ruby on Rails is a server-side web application framework written in Ruby under the MIT License.",
+  cpe: "cpe:2.3:a:rubyonrails:rails:*:*:*:*:*:*:*:*",
+  rule: {
+    confidence: "high",
+    headers: {
+      server: "mod_(?:rails|rack)",
+      "x-powered-by": "mod_(?:rails|rack)",
+    },
+    cookies: {
+      _session_id: ".+",
+    },
+    urls: ["/assets/application-[a-z\\d]{32}/\\.js"],
+    bodies: [
+      "<meta[^>]+name=[\"']csrf-param[\"'][^>]+content=[\"']authenticity_token[\"']",
+    ],
+    javascriptVariables: {
+      ReactOnRails: "",
+      __REACT_ON_RAILS_EVENT_HANDLERS_RAN_ONCE__: "",
+    },
+  },
+  impliedSoftwares: [rubySignature.name],
+};

--- a/src/signatures/technologies/select2.ts
+++ b/src/signatures/technologies/select2.ts
@@ -1,0 +1,16 @@
+import type { Signature } from "../_types.js";
+import { jquerySignature } from "./jquery.js";
+
+export const select2Signature: Signature = {
+  name: "Select2",
+  description:
+    "Select2 is a jQuery based replacement for select boxes. It supports searching, remote data sets, and infinite scrolling of results.",
+  rule: {
+    confidence: "high",
+    urls: ["select2(?:\\.min|\\.full)?\\.js"],
+    javascriptVariables: {
+      "jQuery.fn.select2": "",
+    },
+  },
+  impliedSoftwares: [jquerySignature.name],
+};

--- a/src/signatures/technologies/shopify.ts
+++ b/src/signatures/technologies/shopify.ts
@@ -1,0 +1,34 @@
+import type { Signature } from "../_types.js";
+
+export const shopifySignature: Signature = {
+  name: "Shopify",
+  description:
+    "Shopify is a subscription-based software that allows anyone to set up an online store and sell their products. Shopify store owners can also sell in physical locations using Shopify POS, a point-of-sale app and accompanying hardware.",
+  rule: {
+    confidence: "high",
+    headers: {
+      "x-shopid": ".+",
+      "x-shopify-stage": ".+",
+    },
+    cookies: {
+      _shopify_s: ".+",
+      _shopify_y: ".+",
+    },
+    urls: [
+      "sdks\\.shopifycdn\\.com",
+      "cdn\\.shopify\\.com",
+      "^https?//.+\\.myshopify\\.com",
+    ],
+    bodies: [
+      "shopify-checkout-api-token",
+      "shopify-digital-wallet",
+      "href=[\"'][^\"']*(?:cdn\\.|\\.my)shopify\\.com",
+    ],
+    javascriptVariables: {
+      SHOPIFY_API_BASE_URL: "",
+      Shopify: ".+",
+      ShopifyAPI: "",
+      ShopifyCustomer: "",
+    },
+  },
+};

--- a/src/signatures/technologies/splide.ts
+++ b/src/signatures/technologies/splide.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+
+export const splideSignature: Signature = {
+  name: "Splide",
+  description:
+    "Splide.js is a lightweight, responsive, and customizable slider and carousel library for JavaScript.",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      "Splide.STATES": "",
+      "Splide.name": "i",
+    },
+  },
+};

--- a/src/signatures/technologies/ubuntu.ts
+++ b/src/signatures/technologies/ubuntu.ts
@@ -4,7 +4,7 @@ export const ubuntuSignature: Signature = {
   name: "Ubuntu",
   description:
     "Ubuntu is a free and open-source operating system on Linux for the enterprise server, desktop, cloud, and IoT.",
-  cpe: "cpe:2.3:o:canonical:ubuntu_linux:*:*:*:*:*:*:*:*",
+  cpe: "cpe:/o:canonical:ubuntu_linux",
   rule: {
     confidence: "high",
     headers: {

--- a/src/signatures/technologies/ubuntu.ts
+++ b/src/signatures/technologies/ubuntu.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+
+export const ubuntuSignature: Signature = {
+  name: "Ubuntu",
+  description:
+    "Ubuntu is a free and open-source operating system on Linux for the enterprise server, desktop, cloud, and IoT.",
+  cpe: "cpe:2.3:o:canonical:ubuntu_linux:*:*:*:*:*:*:*:*",
+  rule: {
+    confidence: "high",
+    headers: {
+      server: "Ubuntu",
+      "x-powered-by": "Ubuntu",
+    },
+  },
+};

--- a/src/signatures/technologies/underscore_js.ts
+++ b/src/signatures/technologies/underscore_js.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+
+export const underscoreJsSignature: Signature = {
+  name: "Underscore.js",
+  description:
+    "Underscore.js is a JavaScript library which provides utility functions for common programming tasks. It is comparable to features provided by Prototype.js and the Ruby language, but opts for a functional programming design instead of extending object prototypes.",
+  rule: {
+    confidence: "high",
+    urls: ["underscore.*\\.js(?:\\?ver=([\\d.]+))?"],
+    javascriptVariables: {
+      "_.VERSION": "^(.+)$",
+      "_.restArguments": "",
+    },
+  },
+};

--- a/src/signatures/technologies/unix.ts
+++ b/src/signatures/technologies/unix.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const unixSignature: Signature = {
+  name: "UNIX",
+  description: "Unix is a family of multitasking, multiuser computer operating systems.",
+  rule: {
+    confidence: "high",
+    headers: {
+      server: "Unix",
+    },
+  },
+};

--- a/src/signatures/technologies/windows_server.ts
+++ b/src/signatures/technologies/windows_server.ts
@@ -1,0 +1,13 @@
+import type { Signature } from "../_types.js";
+
+export const windowsServerSignature: Signature = {
+  name: "Windows Server",
+  description:
+    "Windows Server is a brand name for a group of server operating systems.",
+  rule: {
+    confidence: "high",
+    headers: {
+      server: "Win32|Win64",
+    },
+  },
+};

--- a/src/signatures/technologies/wp_page_navi.ts
+++ b/src/signatures/technologies/wp_page_navi.ts
@@ -1,0 +1,13 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const wpPageNaviSignature: Signature = {
+  name: "WP-PageNavi",
+  description:
+    "WP-PageNavi is a WordPress plugin which adds a more advanced paging navigation interface to your WordPress blog.",
+  rule: {
+    confidence: "high",
+    bodies: ["/wp-content/plugins/wp-pagenavi/"],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};


### PR DESCRIPTION
## Summary

- add Wappalyzer-based signatures for 30 technologies
- register new signatures in index

## Notes

- Node.js signature mirrors Wappalyzer (no detection rules; implied by frameworks)