### PR TITLE
feat: add Wappalyzer signatures

### DIFF
--- a/src/signatures/index.ts
+++ b/src/signatures/index.ts
@@ -204,6 +204,56 @@ import { codeIgniterSignature } from "./technologies/codeigniter.js";
 import { f5BigIpSignature } from "./technologies/f5_bigip.js";
 import { isotopeSignature } from "./technologies/isotope.js";
 import { expressSignature } from "./technologies/express.js";
+import { muiSignature } from "./technologies/mui.js";
+import { ewwwImageOptimizerSignature } from "./technologies/ewww_image_optimizer.js";
+import { typescriptSignature } from "./technologies/typescript.js";
+import { wixSignature } from "./technologies/wix.js";
+import { makeShopSignature } from "./technologies/makeshop.js";
+import { cowboySignature } from "./technologies/cowboy.js";
+import { erlangSignature } from "./technologies/erlang.js";
+import { liteSpeedSignature } from "./technologies/litespeed.js";
+import { almaLinuxSignature } from "./technologies/almalinux.js";
+import { hubSpotCmsHubSignature } from "./technologies/hubspot_cms_hub.js";
+import { dayJsSignature } from "./technologies/day_js.js";
+import { markoSignature } from "./technologies/marko.js";
+import { googleSignInSignature } from "./technologies/google_sign_in.js";
+import { salesforceSignature } from "./technologies/salesforce.js";
+import { polylangSignature } from "./technologies/polylang.js";
+import { kestrelSignature } from "./technologies/kestrel.js";
+import { redHatSignature } from "./technologies/red_hat.js";
+import { smashBalloonInstagramFeedSignature } from "./technologies/smash_balloon_instagram_feed.js";
+import { preactSignature } from "./technologies/preact.js";
+import { javaServerFacesSignature } from "./technologies/javaserver_faces.js";
+import { riotSignature } from "./technologies/riot.js";
+import { metaSliderSignature } from "./technologies/metaslider.js";
+import { uiKitSignature } from "./technologies/uikit.js";
+import { zoneJsSignature } from "./technologies/zone_js.js";
+import { tablePressSignature } from "./technologies/tablepress.js";
+import { zendeskSignature } from "./technologies/zendesk.js";
+import { cakePhpSignature } from "./technologies/cakephp.js";
+import { alertifyJsSignature } from "./technologies/alertifyjs.js";
+import { adobeFlashSignature } from "./technologies/adobe_flash.js";
+import { materialDesignLiteSignature } from "./technologies/material_design_lite.js";
+import { vuetifySignature } from "./technologies/vuetify.js";
+import { rankMathSeoSignature } from "./technologies/rankmath_seo.js";
+import { wpRocketSignature } from "./technologies/wp_rocket.js";
+import { tippyJsSignature } from "./technologies/tippy_js.js";
+import { wpFastestCacheSignature } from "./technologies/wp_fastest_cache.js";
+import { joomlaSignature } from "./technologies/joomla.js";
+import { inertiaJsSignature } from "./technologies/inertia_js.js";
+import { wordPressSuperCacheSignature } from "./technologies/wordpress_super_cache.js";
+import { squirrelMailSignature } from "./technologies/squirrelmail.js";
+import { ziggySignature } from "./technologies/ziggy.js";
+import { w3TotalCacheSignature } from "./technologies/w3_total_cache.js";
+import { smartSlider3Signature } from "./technologies/smart_slider_3.js";
+import { wpBakerySignature } from "./technologies/wpbakery.js";
+import { roundCubeSignature } from "./technologies/roundcube.js";
+import { ecCubeSignature } from "./technologies/ec_cube.js";
+import { sitecoreSignature } from "./technologies/sitecore.js";
+import { twentySeventeenSignature } from "./technologies/twenty_seventeen.js";
+import { debianSignature } from "./technologies/debian.js";
+import { lozadJsSignature } from "./technologies/lozad_js.js";
+import { elementUiSignature } from "./technologies/element_ui.js";
 
 export const signatures: Signature[] = [
   addToAnySignature,
@@ -410,4 +460,54 @@ export const signatures: Signature[] = [
   f5BigIpSignature,
   isotopeSignature,
   expressSignature,
+  muiSignature,
+  ewwwImageOptimizerSignature,
+  typescriptSignature,
+  wixSignature,
+  makeShopSignature,
+  cowboySignature,
+  erlangSignature,
+  liteSpeedSignature,
+  almaLinuxSignature,
+  hubSpotCmsHubSignature,
+  dayJsSignature,
+  markoSignature,
+  googleSignInSignature,
+  salesforceSignature,
+  polylangSignature,
+  kestrelSignature,
+  redHatSignature,
+  smashBalloonInstagramFeedSignature,
+  preactSignature,
+  javaServerFacesSignature,
+  riotSignature,
+  metaSliderSignature,
+  uiKitSignature,
+  zoneJsSignature,
+  tablePressSignature,
+  zendeskSignature,
+  cakePhpSignature,
+  alertifyJsSignature,
+  adobeFlashSignature,
+  materialDesignLiteSignature,
+  vuetifySignature,
+  rankMathSeoSignature,
+  wpRocketSignature,
+  tippyJsSignature,
+  wpFastestCacheSignature,
+  joomlaSignature,
+  inertiaJsSignature,
+  wordPressSuperCacheSignature,
+  squirrelMailSignature,
+  ziggySignature,
+  w3TotalCacheSignature,
+  smartSlider3Signature,
+  wpBakerySignature,
+  roundCubeSignature,
+  ecCubeSignature,
+  sitecoreSignature,
+  twentySeventeenSignature,
+  debianSignature,
+  lozadJsSignature,
+  elementUiSignature,
 ];

--- a/src/signatures/technologies/adobe_flash.ts
+++ b/src/signatures/technologies/adobe_flash.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+
+export const adobeFlashSignature: Signature = {
+  name: "Adobe Flash",
+  description: "Adobe Flash is a multimedia software platform used for production of animations, rich web applications and embedded web browser video players.",
+  cpe: "cpe:2.3:a:adobe:flash:*:*:*:*:*:*:*:*",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "application/x-shockwave-flash",
+      "\\.(?:swf)",
+    ],
+  },
+};

--- a/src/signatures/technologies/adobe_flash.ts
+++ b/src/signatures/technologies/adobe_flash.ts
@@ -3,7 +3,7 @@ import type { Signature } from "../_types.js";
 export const adobeFlashSignature: Signature = {
   name: "Adobe Flash",
   description: "Adobe Flash is a multimedia software platform used for production of animations, rich web applications and embedded web browser video players.",
-  cpe: "cpe:2.3:a:adobe:flash:*:*:*:*:*:*:*:*",
+  cpe: "cpe:/a:adobe:flash",
   rule: {
     confidence: "high",
     bodies: [

--- a/src/signatures/technologies/alertifyjs.ts
+++ b/src/signatures/technologies/alertifyjs.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+
+export const alertifyJsSignature: Signature = {
+  name: "AlertifyJS",
+  description: "AlertifyJS is a JavaScript framework for developing browser dialogs and notifications.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "/alertify/alertify\\.min\\.js",
+    ],
+    javascriptVariables: {
+      "alertify.defaults.autoReset": "",
+    },
+  },
+};

--- a/src/signatures/technologies/almalinux.ts
+++ b/src/signatures/technologies/almalinux.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const almaLinuxSignature: Signature = {
+  name: "AlmaLinux",
+  description: "AlmaLinux is an open-source, community-driven Linux operating system that fills the gap left by the discontinuation of the CentOS Linux stable release.",
+  rule: {
+    confidence: "high",
+    headers: {
+      "Server": "AlmaLinux",
+    },
+  },
+};

--- a/src/signatures/technologies/cakephp.ts
+++ b/src/signatures/technologies/cakephp.ts
@@ -4,7 +4,7 @@ import { phpSignature } from "./php.js";
 export const cakePhpSignature: Signature = {
   name: "CakePHP",
   description: "CakePHP is an open-source web framework. It follows the model-view-controller (MVC) approach and is written in PHP.",
-  cpe: "cpe:2.3:a:cakephp:cakephp:*:*:*:*:*:*:*:*",
+  cpe: "cpe:/a:cakephp:cakephp",
   rule: {
     confidence: "high",
     cookies: {

--- a/src/signatures/technologies/cakephp.ts
+++ b/src/signatures/technologies/cakephp.ts
@@ -1,0 +1,18 @@
+import type { Signature } from "../_types.js";
+import { phpSignature } from "./php.js";
+
+export const cakePhpSignature: Signature = {
+  name: "CakePHP",
+  description: "CakePHP is an open-source web framework. It follows the model-view-controller (MVC) approach and is written in PHP.",
+  cpe: "cpe:2.3:a:cakephp:cakephp:*:*:*:*:*:*:*:*",
+  rule: {
+    confidence: "high",
+    cookies: {
+      "cakephp": "",
+    },
+    bodies: [
+      "<meta[^>]+name=[\"']application-name[\"'][^>]+content=[\"']CakePHP",
+    ],
+  },
+  impliedSoftwares: [phpSignature.name],
+};

--- a/src/signatures/technologies/cowboy.ts
+++ b/src/signatures/technologies/cowboy.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+import { erlangSignature } from "./erlang.js";
+
+export const cowboySignature: Signature = {
+  name: "Cowboy",
+  description: "Cowboy is a small, fast, modular HTTP server written in Erlang.",
+  rule: {
+    confidence: "high",
+    headers: {
+      "Server": "^Cowboy$",
+    },
+  },
+  impliedSoftwares: [erlangSignature.name],
+};

--- a/src/signatures/technologies/day_js.ts
+++ b/src/signatures/technologies/day_js.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const dayJsSignature: Signature = {
+  name: "Day.js",
+  description: "Day.js is a minimalist JavaScript library that parses, validates, manipulates, and displays dates and times.",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      "dayjs": "",
+    },
+  },
+};

--- a/src/signatures/technologies/debian.ts
+++ b/src/signatures/technologies/debian.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+
+export const debianSignature: Signature = {
+  name: "Debian",
+  description: "Debian is a free and open-source Linux distribution.",
+  cpe: "cpe:2.3:o:debian:debian_linux:*:*:*:*:*:*:*:*",
+  rule: {
+    confidence: "high",
+    headers: {
+      "Server": "Debian",
+      "X-Powered-By": "(?:Debian|dotdeb|(potato|woody|sarge|etch|lenny|squeeze|wheezy|jessie|stretch|buster|sid))",
+    },
+  },
+};

--- a/src/signatures/technologies/debian.ts
+++ b/src/signatures/technologies/debian.ts
@@ -3,7 +3,7 @@ import type { Signature } from "../_types.js";
 export const debianSignature: Signature = {
   name: "Debian",
   description: "Debian is a free and open-source Linux distribution.",
-  cpe: "cpe:2.3:o:debian:debian_linux:*:*:*:*:*:*:*:*",
+  cpe: "cpe:/o:debian:debian_linux",
   rule: {
     confidence: "high",
     headers: {

--- a/src/signatures/technologies/ec_cube.ts
+++ b/src/signatures/technologies/ec_cube.ts
@@ -4,7 +4,7 @@ import { phpSignature } from "./php.js";
 export const ecCubeSignature: Signature = {
   name: "EC-CUBE",
   description: "EC-CUBE is an open source package used to build ecommerce sites.",
-  cpe: "cpe:2.3:a:lockon:ec-cube:*:*:*:*:*:*:*:*",
+  cpe: "cpe:/a:lockon:ec-cube",
   rule: {
     confidence: "high",
     urls: [

--- a/src/signatures/technologies/ec_cube.ts
+++ b/src/signatures/technologies/ec_cube.ts
@@ -1,0 +1,16 @@
+import type { Signature } from "../_types.js";
+import { phpSignature } from "./php.js";
+
+export const ecCubeSignature: Signature = {
+  name: "EC-CUBE",
+  description: "EC-CUBE is an open source package used to build ecommerce sites.",
+  cpe: "cpe:2.3:a:lockon:ec-cube:*:*:*:*:*:*:*:*",
+  rule: {
+    confidence: "high",
+    urls: [
+      "eccube\\.js",
+      "win_op\\.js",
+    ],
+  },
+  impliedSoftwares: [phpSignature.name],
+};

--- a/src/signatures/technologies/element_ui.ts
+++ b/src/signatures/technologies/element_ui.ts
@@ -1,0 +1,13 @@
+import type { Signature } from "../_types.js";
+import { vueJsSignature } from "./vue_js.js";
+
+export const elementUiSignature: Signature = {
+  name: "Element UI",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<(?:div|button) class=\"el-(?:table-column|table-filter|popper|pagination|pager|select-group|form|form-item|color-predefine|color-hue-slider|color-svpanel|color-alpha-slider|color-dropdown|color-picker|badge|tree|tree-node|select|message|dialog|checkbox|checkbox-button|checkbox-group|container|steps|carousel|menu|menu-item|submenu|menu-item-group|button|button-group|card|table|select-dropdown|row|tabs|notification|radio|progress|progress-bar|tag|popover|tooltip|cascader|cascader-menus|cascader-menu|time-spinner|spinner|spinner-inner|transfer|transfer-panel|rate|slider|dropdown|dropdown-menu|textarea|input|input-group|popup-parent|radio-group|main|breadcrumb|time-range-picker|date-range-picker|year-table|date-editor|range-editor|time-spinner|date-picker|time-panel|date-table|month-table|picker-panel|collapse|collapse-item|alert|select-dropdown|select-dropdown__empty|select-dropdown__wrap|select-dropdown__list|scrollbar|switch|carousel|upload|upload-dragger|upload-list|upload-cover|aside|input-number|header|message-box|footer|radio-button|step|autocomplete|autocomplete-suggestion|loading-parent|loading-mask|loading-spinner|)",
+    ],
+  },
+  impliedSoftwares: [vueJsSignature.name],
+};

--- a/src/signatures/technologies/erlang.ts
+++ b/src/signatures/technologies/erlang.ts
@@ -1,0 +1,13 @@
+import type { Signature } from "../_types.js";
+
+export const erlangSignature: Signature = {
+  name: "Erlang",
+  description: "Erlang is a general-purpose, concurrent, functional programming language, and a garbage-collected runtime system.",
+  cpe: "cpe:2.3:a:erlang:erlang%2fotp:*:*:*:*:*:*:*:*",
+  rule: {
+    confidence: "high",
+    headers: {
+      "Server": "Erlang(?: OTP/(?:[\\d.ABR-]+))?",
+    },
+  },
+};

--- a/src/signatures/technologies/erlang.ts
+++ b/src/signatures/technologies/erlang.ts
@@ -3,7 +3,7 @@ import type { Signature } from "../_types.js";
 export const erlangSignature: Signature = {
   name: "Erlang",
   description: "Erlang is a general-purpose, concurrent, functional programming language, and a garbage-collected runtime system.",
-  cpe: "cpe:2.3:a:erlang:erlang%2fotp:*:*:*:*:*:*:*:*",
+  cpe: "cpe:/a:erlang:erlang%2fotp",
   rule: {
     confidence: "high",
     headers: {

--- a/src/signatures/technologies/ewww_image_optimizer.ts
+++ b/src/signatures/technologies/ewww_image_optimizer.ts
@@ -1,0 +1,20 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const ewwwImageOptimizerSignature: Signature = {
+  name: "EWWW Image Optimizer",
+  description: "EWWW Image Optimizer is an image optimization WordPress plugin designed to improve the performance of your website.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "/wp-content/plugins/ewww-image-optimizer/",
+    ],
+    urls: [
+      "/wp-content/plugins/ewww-image-optimizer/",
+    ],
+    javascriptVariables: {
+      "ewww_webp_supported": "",
+    },
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/google_sign_in.ts
+++ b/src/signatures/technologies/google_sign_in.ts
@@ -1,0 +1,17 @@
+import type { Signature } from "../_types.js";
+
+export const googleSignInSignature: Signature = {
+  name: "Google Sign-in",
+  description: "Google Sign-In is a secure authentication system that reduces the burden of login for users by enabling them to sign in with their Google account.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "accounts\\.google\\.com/o/oauth2",
+      "<meta[^>]+name=[\"']google-signin-client_id[\"']",
+      "<meta[^>]+name=[\"']google-signin-scope[\"']",
+    ],
+    urls: [
+      "accounts\\.google\\.com/gsi/client",
+    ],
+  },
+};

--- a/src/signatures/technologies/hubspot_cms_hub.ts
+++ b/src/signatures/technologies/hubspot_cms_hub.ts
@@ -1,0 +1,16 @@
+import type { Signature } from "../_types.js";
+
+export const hubSpotCmsHubSignature: Signature = {
+  name: "HubSpot CMS Hub",
+  description: "CMS Hub is a content management platform by HubSpot for marketers to manage, optimize, and track content performance on websites, blogs, and landing pages.",
+  rule: {
+    confidence: "high",
+    headers: {
+      "x-hs-hub-id": "",
+      "x-powered-by": "HubSpot",
+    },
+    bodies: [
+      "<meta[^>]+name=[\"']generator[\"'][^>]+content=[\"']HubSpot",
+    ],
+  },
+};

--- a/src/signatures/technologies/inertia_js.ts
+++ b/src/signatures/technologies/inertia_js.ts
@@ -1,0 +1,16 @@
+import type { Signature } from "../_types.js";
+
+export const inertiaJsSignature: Signature = {
+  name: "Inertia.js",
+  description: "Inertia.js is a protocol for creating monolithic single-page applications.",
+  rule: {
+    confidence: "high",
+    headers: {
+      "Vary": "X-Inertia",
+      "X-Inertia": "",
+    },
+    bodies: [
+      "data-page=[\"'][^\"']*component[^\"']*props[^\"']*url",
+    ],
+  },
+};

--- a/src/signatures/technologies/javaserver_faces.ts
+++ b/src/signatures/technologies/javaserver_faces.ts
@@ -1,0 +1,16 @@
+import type { Signature } from "../_types.js";
+import { javaSignature } from "./java.js";
+
+export const javaServerFacesSignature: Signature = {
+  name: "JavaServer Faces",
+  rule: {
+    confidence: "high",
+    headers: {
+      "X-Powered-By": "JSF(?:/([\\d.]+))?",
+    },
+    bodies: [
+      "javax\\.faces\\.ViewState",
+    ],
+  },
+  impliedSoftwares: [javaSignature.name],
+};

--- a/src/signatures/technologies/joomla.ts
+++ b/src/signatures/technologies/joomla.ts
@@ -1,0 +1,26 @@
+import type { Signature } from "../_types.js";
+import { phpSignature } from "./php.js";
+
+export const joomlaSignature: Signature = {
+  name: "Joomla",
+  description: "Joomla is a free and open-source content management system for publishing web content.",
+  cpe: "cpe:2.3:a:joomla:joomla:*:*:*:*:*:*:*:*",
+  rule: {
+    confidence: "high",
+    headers: {
+      "X-Content-Encoded-By": "Joomla! ([\\d.]+)",
+    },
+    bodies: [
+      "(?:<div[^>]+id=\"wrapper_r\"|<(?:link|script)[^>]+(?:feed|components)/com_|<table[^>]+class=\"pill)",
+      "<meta[^>]+name=[\"']generator[\"'][^>]+content=[\"']Joomla!(?: ([\\d.]+))?",
+    ],
+    urls: [
+      "option=com_",
+    ],
+    javascriptVariables: {
+      "Joomla": "",
+      "jcomments": "",
+    },
+  },
+  impliedSoftwares: [phpSignature.name],
+};

--- a/src/signatures/technologies/joomla.ts
+++ b/src/signatures/technologies/joomla.ts
@@ -4,7 +4,7 @@ import { phpSignature } from "./php.js";
 export const joomlaSignature: Signature = {
   name: "Joomla",
   description: "Joomla is a free and open-source content management system for publishing web content.",
-  cpe: "cpe:2.3:a:joomla:joomla:*:*:*:*:*:*:*:*",
+  cpe: "cpe:/a:joomla:joomla",
   rule: {
     confidence: "high",
     headers: {

--- a/src/signatures/technologies/kestrel.ts
+++ b/src/signatures/technologies/kestrel.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+import { microsoftAspSignature } from "./microsoft_asp.js";
+
+export const kestrelSignature: Signature = {
+  name: "Kestrel",
+  description: "Kestrel is a cross-platform web server for ASP.NET Core.",
+  rule: {
+    confidence: "high",
+    headers: {
+      "Server": "^Kestrel",
+    },
+  },
+  impliedSoftwares: [microsoftAspSignature.name],
+};

--- a/src/signatures/technologies/litespeed.ts
+++ b/src/signatures/technologies/litespeed.ts
@@ -3,7 +3,7 @@ import type { Signature } from "../_types.js";
 export const liteSpeedSignature: Signature = {
   name: "LiteSpeed",
   description: "LiteSpeed is a high-scalability web server.",
-  cpe: "cpe:2.3:a:litespeedtech:litespeed_web_server:*:*:*:*:*:*:*:*",
+  cpe: "cpe:/a:litespeedtech:litespeed_web_server",
   rule: {
     confidence: "high",
     headers: {

--- a/src/signatures/technologies/litespeed.ts
+++ b/src/signatures/technologies/litespeed.ts
@@ -1,0 +1,13 @@
+import type { Signature } from "../_types.js";
+
+export const liteSpeedSignature: Signature = {
+  name: "LiteSpeed",
+  description: "LiteSpeed is a high-scalability web server.",
+  cpe: "cpe:2.3:a:litespeedtech:litespeed_web_server:*:*:*:*:*:*:*:*",
+  rule: {
+    confidence: "high",
+    headers: {
+      "Server": "^LiteSpeed$",
+    },
+  },
+};

--- a/src/signatures/technologies/lozad_js.ts
+++ b/src/signatures/technologies/lozad_js.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+
+export const lozadJsSignature: Signature = {
+  name: "Lozad.js",
+  description: "Lozad.js is a lightweight lazy-loading library that's just 535 bytes minified and gzipped.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "/lozad\\.min\\.js",
+    ],
+    javascriptVariables: {
+      "lozad": "",
+    },
+  },
+};

--- a/src/signatures/technologies/makeshop.ts
+++ b/src/signatures/technologies/makeshop.ts
@@ -1,0 +1,16 @@
+import type { Signature } from "../_types.js";
+
+export const makeShopSignature: Signature = {
+  name: "MakeShop",
+  description: "MakeShop is a Japanese ecommerce platform.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "gigaplus\\.makeshop\\.jp",
+    ],
+    javascriptVariables: {
+      "MakeShop_TopSearch": "",
+      "makeshop_ga_gtag": "",
+    },
+  },
+};

--- a/src/signatures/technologies/marko.ts
+++ b/src/signatures/technologies/marko.ts
@@ -1,0 +1,23 @@
+import type { Signature } from "../_types.js";
+import { nodeJsSignature } from "./node_js.js";
+
+export const markoSignature: Signature = {
+  name: "Marko",
+  description: "Marko is HTML re-imagined as a language for building dynamic and reactive user interfaces.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "data-marko-key",
+      "data-framework=[\"']marko[\"']",
+    ],
+    urls: [
+      "\\.marko(\\.js)?",
+    ],
+    javascriptVariables: {
+      "markoComponent": "",
+      "markoSections": "",
+      "markoVars": "",
+    },
+  },
+  impliedSoftwares: [nodeJsSignature.name],
+};

--- a/src/signatures/technologies/material_design_lite.ts
+++ b/src/signatures/technologies/material_design_lite.ts
@@ -1,0 +1,18 @@
+import type { Signature } from "../_types.js";
+
+export const materialDesignLiteSignature: Signature = {
+  name: "Material Design Lite",
+  description: "Material Design Lite is a library of components for web developers.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<link[^>]* href=\"[^\"]*material(?:\\.[\\w]+-[\\w]+)?(?:\\.min)?\\.css",
+    ],
+    urls: [
+      "(?:/([\\d.]+))?/material(?:\\.min)?\\.js",
+    ],
+    javascriptVariables: {
+      "MaterialIconToggle": "",
+    },
+  },
+};

--- a/src/signatures/technologies/metaslider.ts
+++ b/src/signatures/technologies/metaslider.ts
@@ -1,0 +1,18 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const metaSliderSignature: Signature = {
+  name: "MetaSlider",
+  description: "MetaSlider is a WordPress plugin for adding responsive sliders and carousels to websites.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "/wp-content/plugins/ml-slider/",
+      "metaslider-pro-public-css",
+    ],
+    urls: [
+      "/wp-content/plugins/ml-slider(?:-pro)?/",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/mui.ts
+++ b/src/signatures/technologies/mui.ts
@@ -1,0 +1,17 @@
+import type { Signature } from "../_types.js";
+import { reactSignature } from "./react.js";
+
+export const muiSignature: Signature = {
+  name: "MUI",
+  description: "MUI (formerly Material UI) is a simple and customizable component library to build faster, beautiful, and more accessible React applications.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "MuiPaper-root",
+      "MuiBox-root",
+      "data-meta=[\"']MuiPaper[\"']",
+      "data-meta=[\"']MuiButton[\"']",
+    ],
+  },
+  impliedSoftwares: [reactSignature.name],
+};

--- a/src/signatures/technologies/polylang.ts
+++ b/src/signatures/technologies/polylang.ts
@@ -1,0 +1,20 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const polylangSignature: Signature = {
+  name: "Polylang",
+  description: "Polylang is a WordPress plugin which allows you to create multilingual WordPress site.",
+  rule: {
+    confidence: "high",
+    headers: {
+      "x-redirected-by": "Polylang(?: (Pro))?",
+    },
+    cookies: {
+      "pll_language": "[a-z]{2}",
+    },
+    bodies: [
+      "pll_switcher",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/preact.ts
+++ b/src/signatures/technologies/preact.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const preactSignature: Signature = {
+  name: "Preact",
+  description: "Preact is a JavaScript library that describes itself as a fast 3kB alternative to React with the same ES6 API.",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      "preact": "",
+    },
+  },
+};

--- a/src/signatures/technologies/rankmath_seo.ts
+++ b/src/signatures/technologies/rankmath_seo.ts
@@ -1,0 +1,19 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const rankMathSeoSignature: Signature = {
+  name: "RankMath SEO",
+  description: "RankMath SEO is a search engine optimization plugin for WordPress.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "/wp-content/plugins/seo-by-rank-math/",
+      "rank-math-schema-pro",
+      "rank-math-schema",
+    ],
+    urls: [
+      "/wp-content/plugins/seo-by-rank-math(?:-pro)?/.+\\.js(?:\\?ver=(\\d+(?:\\.\\d+)+))?",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/red_hat.ts
+++ b/src/signatures/technologies/red_hat.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+
+export const redHatSignature: Signature = {
+  name: "Red Hat",
+  description: "Red Hat is an open-source Linux operating system.",
+  cpe: "cpe:2.3:o:redhat:linux:*:*:*:*:*:*:*:*",
+  rule: {
+    confidence: "high",
+    headers: {
+      "Server": "Red Hat",
+      "X-Powered-By": "Red Hat",
+    },
+  },
+};

--- a/src/signatures/technologies/red_hat.ts
+++ b/src/signatures/technologies/red_hat.ts
@@ -3,7 +3,7 @@ import type { Signature } from "../_types.js";
 export const redHatSignature: Signature = {
   name: "Red Hat",
   description: "Red Hat is an open-source Linux operating system.",
-  cpe: "cpe:2.3:o:redhat:linux:*:*:*:*:*:*:*:*",
+  cpe: "cpe:/o:redhat:linux",
   rule: {
     confidence: "high",
     headers: {

--- a/src/signatures/technologies/riot.ts
+++ b/src/signatures/technologies/riot.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+
+export const riotSignature: Signature = {
+  name: "Riot",
+  description: "Riot is a JavaScript-based user interface library.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "riot(?:\\+compiler)?(?:\\.min)?\\.js",
+    ],
+    javascriptVariables: {
+      "riot": "",
+    },
+  },
+};

--- a/src/signatures/technologies/roundcube.ts
+++ b/src/signatures/technologies/roundcube.ts
@@ -1,0 +1,19 @@
+import type { Signature } from "../_types.js";
+import { phpSignature } from "./php.js";
+
+export const roundCubeSignature: Signature = {
+  name: "RoundCube",
+  description: "RoundCube is free and open-source web-based IMAP email client.",
+  cpe: "cpe:2.3:a:roundcube:webmail:*:*:*:*:*:*:*:*",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<title>RoundCube",
+    ],
+    javascriptVariables: {
+      "rcmail": "",
+      "roundcube": "",
+    },
+  },
+  impliedSoftwares: [phpSignature.name],
+};

--- a/src/signatures/technologies/roundcube.ts
+++ b/src/signatures/technologies/roundcube.ts
@@ -4,7 +4,7 @@ import { phpSignature } from "./php.js";
 export const roundCubeSignature: Signature = {
   name: "RoundCube",
   description: "RoundCube is free and open-source web-based IMAP email client.",
-  cpe: "cpe:2.3:a:roundcube:webmail:*:*:*:*:*:*:*:*",
+  cpe: "cpe:/a:roundcube:webmail",
   rule: {
     confidence: "high",
     bodies: [

--- a/src/signatures/technologies/salesforce.ts
+++ b/src/signatures/technologies/salesforce.ts
@@ -1,0 +1,22 @@
+import type { Signature } from "../_types.js";
+
+export const salesforceSignature: Signature = {
+  name: "Salesforce",
+  description: "Salesforce is a cloud computing service software (SaaS) that specializes in customer relationship management (CRM).",
+  cpe: "cpe:2.3:a:salesforce:*:*:*:*:*:*:*:*:*",
+  rule: {
+    confidence: "high",
+    cookies: {
+      "com.salesforce": "",
+    },
+    bodies: [
+      "brandQuaternaryFgrs",
+    ],
+    javascriptVariables: {
+      "SFDCApp": "",
+      "SFDCCmp": "",
+      "SFDCPage": "",
+      "SFDCSessionVars": "",
+    },
+  },
+};

--- a/src/signatures/technologies/salesforce.ts
+++ b/src/signatures/technologies/salesforce.ts
@@ -3,7 +3,7 @@ import type { Signature } from "../_types.js";
 export const salesforceSignature: Signature = {
   name: "Salesforce",
   description: "Salesforce is a cloud computing service software (SaaS) that specializes in customer relationship management (CRM).",
-  cpe: "cpe:2.3:a:salesforce:*:*:*:*:*:*:*:*:*",
+  cpe: "cpe:/a:salesforce:salesforce",
   rule: {
     confidence: "high",
     cookies: {

--- a/src/signatures/technologies/sitecore.ts
+++ b/src/signatures/technologies/sitecore.ts
@@ -4,7 +4,7 @@ import { microsoftAspSignature } from "./microsoft_asp.js";
 export const sitecoreSignature: Signature = {
   name: "Sitecore",
   description: "Sitecore provides web content management, and multichannel marketing automation software.",
-  cpe: "cpe:2.3:a:sitecore:*:*:*:*:*:*:*:*:*",
+  cpe: "cpe:/a:sitecore:sitecore",
   rule: {
     confidence: "high",
     cookies: {

--- a/src/signatures/technologies/sitecore.ts
+++ b/src/signatures/technologies/sitecore.ts
@@ -1,0 +1,26 @@
+import type { Signature } from "../_types.js";
+import { microsoftAspSignature } from "./microsoft_asp.js";
+
+export const sitecoreSignature: Signature = {
+  name: "Sitecore",
+  description: "Sitecore provides web content management, and multichannel marketing automation software.",
+  cpe: "cpe:2.3:a:sitecore:*:*:*:*:*:*:*:*:*",
+  rule: {
+    confidence: "high",
+    cookies: {
+      "SC_ANALYTICS_GLOBAL_COOKIE": "",
+      "SC_OS_SessionId": "",
+      "sc_expview": "",
+      "sxa_site": "",
+    },
+    bodies: [
+      "/_sitecore/",
+      "/-/media/",
+      "/~/media/.+\\.ashx",
+    ],
+    javascriptVariables: {
+      "SitecoreUtilities": "",
+    },
+  },
+  impliedSoftwares: [microsoftAspSignature.name],
+};

--- a/src/signatures/technologies/smart_slider_3.ts
+++ b/src/signatures/technologies/smart_slider_3.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const smartSlider3Signature: Signature = {
+  name: "Smart Slider 3",
+  description: "Smart Slider 3 is a responsive, SEO optimized WordPress plugin.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "/wp-content/plugins/smart-slider-3(?:-pro)?/",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/smash_balloon_instagram_feed.ts
+++ b/src/signatures/technologies/smash_balloon_instagram_feed.ts
@@ -1,0 +1,17 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const smashBalloonInstagramFeedSignature: Signature = {
+  name: "Smash Balloon Instagram Feed",
+  description: "Instagram Feed displays Instagram posts from your Instagram accounts, either in the same single feed or in multiple different ones. Created by Smash Balloon.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "/wp-content/plugins/instagram-feed/",
+    ],
+    urls: [
+      "/wp-content/plugins/instagram-feed/",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/squirrelmail.ts
+++ b/src/signatures/technologies/squirrelmail.ts
@@ -4,7 +4,7 @@ import { phpSignature } from "./php.js";
 export const squirrelMailSignature: Signature = {
   name: "SquirrelMail",
   description: "SquirrelMail is an open-source web-mail package that is based on PHP language. It provides a web-based email client and a proxy server for IMAP protocol.",
-  cpe: "cpe:2.3:a:squirrelmail:squirrelmail:*:*:*:*:*:*:*:*",
+  cpe: "cpe:/a:squirrelmail:squirrelmail",
   rule: {
     confidence: "high",
     bodies: [

--- a/src/signatures/technologies/squirrelmail.ts
+++ b/src/signatures/technologies/squirrelmail.ts
@@ -1,0 +1,21 @@
+import type { Signature } from "../_types.js";
+import { phpSignature } from "./php.js";
+
+export const squirrelMailSignature: Signature = {
+  name: "SquirrelMail",
+  description: "SquirrelMail is an open-source web-mail package that is based on PHP language. It provides a web-based email client and a proxy server for IMAP protocol.",
+  cpe: "cpe:2.3:a:squirrelmail:squirrelmail:*:*:*:*:*:*:*:*",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<small>SquirrelMail version ([.\\d]+)[^<]*<br",
+    ],
+    urls: [
+      "/src/webmail\\.php(?:$|\\?)",
+    ],
+    javascriptVariables: {
+      "squirrelmail_loginpage_onload": "",
+    },
+  },
+  impliedSoftwares: [phpSignature.name],
+};

--- a/src/signatures/technologies/tablepress.ts
+++ b/src/signatures/technologies/tablepress.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const tablePressSignature: Signature = {
+  name: "TablePress",
+  description: "TablePress is a free and open source plugin for the WordPress publishing platform. It enables you to create and manage tables on your website, without any coding knowledge.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "/wp-content/plugins/tablepress/",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/tippy_js.ts
+++ b/src/signatures/technologies/tippy_js.ts
@@ -1,0 +1,18 @@
+import type { Signature } from "../_types.js";
+
+export const tippyJsSignature: Signature = {
+  name: "Tippy.js",
+  description: "Tippy.js is the complete tooltip, popover, dropdown, and menu solution for the web, powered by Popper.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "data-tippy-stylesheet",
+    ],
+    urls: [
+      "/tippy\\.js(?:@|/)?([\\d\\.]+)?",
+    ],
+    javascriptVariables: {
+      "tippy.defaultProps": "",
+    },
+  },
+};

--- a/src/signatures/technologies/twenty_seventeen.ts
+++ b/src/signatures/technologies/twenty_seventeen.ts
@@ -1,0 +1,20 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const twentySeventeenSignature: Signature = {
+  name: "Twenty Seventeen",
+  description: "Twenty Seventeen is the default WordPress theme for 2017.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "twentyseventeen-style-css",
+    ],
+    urls: [
+      "/wp-content/themes/twentyseventeen/",
+    ],
+    javascriptVariables: {
+      "twentyseventeenScreenReaderText": "",
+    },
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/typescript.ts
+++ b/src/signatures/technologies/typescript.ts
@@ -1,0 +1,6 @@
+import type { Signature } from "../_types.js";
+
+export const typescriptSignature: Signature = {
+  name: "TypeScript",
+  description: "TypeScript is an open-source language that builds on JavaScript by adding static type definitions.",
+};

--- a/src/signatures/technologies/uikit.ts
+++ b/src/signatures/technologies/uikit.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+
+export const uiKitSignature: Signature = {
+  name: "UIKit",
+  description: "UIKit is a front-end framework for developing web interfaces.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<[^>]+class=\"[^\"]*(?:uk-container|uk-section)",
+    ],
+    urls: [
+      "uikit.*\\.js",
+    ],
+  },
+};

--- a/src/signatures/technologies/vuetify.ts
+++ b/src/signatures/technologies/vuetify.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+import { vueJsSignature } from "./vue_js.js";
+
+export const vuetifySignature: Signature = {
+  name: "Vuetify",
+  description: "Vuetify is a reusable semantic component framework for Vue.js that aims to provide clean, semantic and reusable components.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "vuetify-theme-stylesheet",
+      "v-application",
+    ],
+  },
+  impliedSoftwares: [vueJsSignature.name],
+};

--- a/src/signatures/technologies/w3_total_cache.ts
+++ b/src/signatures/technologies/w3_total_cache.ts
@@ -1,0 +1,17 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const w3TotalCacheSignature: Signature = {
+  name: "W3 Total Cache",
+  description: "W3 Total Cache (W3TC) improves SEO and increases website performance while reducing load times by leveraging content delivery network (CDN) integration and the latest best practices.",
+  rule: {
+    confidence: "high",
+    headers: {
+      "X-Powered-By": "W3 Total Cache(?:/([\\d.]+))?",
+    },
+    bodies: [
+      "<!--[^>]+W3 Total Cache",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/wix.ts
+++ b/src/signatures/technologies/wix.ts
@@ -1,0 +1,29 @@
+import type { Signature } from "../_types.js";
+import { reactSignature } from "./react.js";
+
+export const wixSignature: Signature = {
+  name: "Wix",
+  description: "Wix provides cloud-based web development services, allowing users to create HTML5 websites and mobile sites.",
+  rule: {
+    confidence: "high",
+    headers: {
+      "X-Wix-Renderer-Server": "",
+      "X-Wix-Request-Id": "",
+      "X-Wix-Server-Artifact-Id": "",
+    },
+    cookies: {
+      "Domain": "\\.wix\\.com",
+    },
+    bodies: [
+      "<meta[^>]+name=[\"']generator[\"'][^>]+content=[\"']Wix\\.com Website Builder",
+    ],
+    urls: [
+      "static\\.parastorage\\.com",
+    ],
+    javascriptVariables: {
+      "wixBiSession": "",
+      "wixPerformanceMeasurements": "",
+    },
+  },
+  impliedSoftwares: [reactSignature.name],
+};

--- a/src/signatures/technologies/wordpress_super_cache.ts
+++ b/src/signatures/technologies/wordpress_super_cache.ts
@@ -1,0 +1,17 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const wordPressSuperCacheSignature: Signature = {
+  name: "WordPress Super Cache",
+  description: "WordPress Super Cache is a static caching plugin for WordPress.",
+  rule: {
+    confidence: "high",
+    headers: {
+      "WP-Super-Cache": "",
+    },
+    bodies: [
+      "<!--[^>]+WP-Super-Cache",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/wp_fastest_cache.ts
+++ b/src/signatures/technologies/wp_fastest_cache.ts
@@ -1,0 +1,20 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const wpFastestCacheSignature: Signature = {
+  name: "WP Fastest Cache",
+  description: "WP Fastest Cache is one of a number of plugins for WordPress designed to accelerate the performance of your website.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "/wp-content/cache/wpfc-minified/",
+    ],
+    urls: [
+      "/wp-content/cache/wpfc-minified/",
+    ],
+    javascriptVariables: {
+      "Wpfcll": "",
+    },
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/wp_rocket.ts
+++ b/src/signatures/technologies/wp_rocket.ts
@@ -1,0 +1,27 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const wpRocketSignature: Signature = {
+  name: "WP Rocket",
+  description: "WP Rocket is a caching and performance optimization plugin to improve the loading speed of WordPress websites.",
+  rule: {
+    confidence: "high",
+    headers: {
+      "X-Powered-By": "WP Rocket(?:/([\\d.]+))?",
+      "X-Rocket-Nginx-Bypass": "",
+    },
+    bodies: [
+      "<!--[^>]+WP Rocket",
+      "wpr-usedcss",
+    ],
+    urls: [
+      "/wp-content/plugins/wp-rocket/",
+    ],
+    javascriptVariables: {
+      "RocketLazyLoadScripts": "",
+      "RocketPreloadLinksConfig": "",
+      "rocket_lazy": "",
+    },
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/wpbakery.ts
+++ b/src/signatures/technologies/wpbakery.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const wpBakerySignature: Signature = {
+  name: "wpBakery",
+  description: "WPBakery is a drag and drop visual page builder plugin for WordPress.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<meta[^>]+name=[\"']generator[\"'][^>]+content=[\"']WPBakery",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/zendesk.ts
+++ b/src/signatures/technologies/zendesk.ts
@@ -1,0 +1,23 @@
+import type { Signature } from "../_types.js";
+
+export const zendeskSignature: Signature = {
+  name: "Zendesk",
+  description: "Zendesk is a cloud-based help desk management solution offering customizable tools to build customer service portal, knowledge base and online communities.",
+  rule: {
+    confidence: "high",
+    headers: {
+      "x-zendesk-user-id": "",
+    },
+    cookies: {
+      "_help_center_session": "",
+      "_zendesk_cookie": "",
+      "_zendesk_shared_session": "",
+    },
+    urls: [
+      "static\\.zdassets\\.com",
+    ],
+    javascriptVariables: {
+      "Zendesk": "",
+    },
+  },
+};

--- a/src/signatures/technologies/ziggy.ts
+++ b/src/signatures/technologies/ziggy.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+import { laravelSignature } from "./laravel.js";
+import { inertiaJsSignature } from "./inertia_js.js";
+
+export const ziggySignature: Signature = {
+  name: "Ziggy",
+  description: "Ziggy is a library that allows using Laravel named routes in JavaScript.",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      "Ziggy": "",
+    },
+  },
+  impliedSoftwares: [laravelSignature.name, inertiaJsSignature.name],
+};

--- a/src/signatures/technologies/zone_js.ts
+++ b/src/signatures/technologies/zone_js.ts
@@ -1,0 +1,13 @@
+import type { Signature } from "../_types.js";
+import { angularSignature } from "./angular.js";
+
+export const zoneJsSignature: Signature = {
+  name: "Zone.js",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      "Zone.root": "",
+    },
+  },
+  impliedSoftwares: [angularSignature.name],
+};


### PR DESCRIPTION
## Summary
- add 50 new technology signatures sourced from Wappalyzer patterns
- include WordPress plugin/theme implications and related framework hints
- register new signatures in the index

## Testing
- not run