### PR TITLE
feat: add more Wappalyzer signatures

### DIFF
--- a/src/signatures/index.ts
+++ b/src/signatures/index.ts
@@ -254,6 +254,56 @@ import { twentySeventeenSignature } from "./technologies/twenty_seventeen.js";
 import { debianSignature } from "./technologies/debian.js";
 import { lozadJsSignature } from "./technologies/lozad_js.js";
 import { elementUiSignature } from "./technologies/element_ui.js";
+import { antDesignSignature } from "./technologies/ant_design.js";
+import { wpOptimizeSignature } from "./technologies/wp_optimize.js";
+import { sweetalertSignature } from "./technologies/sweetalert.js";
+import { gitlabSignature } from "./technologies/gitlab.js";
+import { scrollrevealSignature } from "./technologies/scrollreveal.js";
+import { colormeshopSignature } from "./technologies/colormeshop.js";
+import { civicthemeSignature } from "./technologies/civic_theme.js";
+import { stimulusSignature } from "./technologies/stimulus.js";
+import { decimalSignature } from "./technologies/decimal_js.js";
+import { freebsdSignature } from "./technologies/freebsd.js";
+import { exhibitSignature } from "./technologies/exhibit.js";
+import { twentyFourteenSignature } from "./technologies/twenty_fourteen.js";
+import { storesJpSignature } from "./technologies/stores_jp.js";
+import { cpanelSignature } from "./technologies/cpanel.js";
+import { ecforceSignature } from "./technologies/ecforce.js";
+import { liteYoutubeEmbedSignature } from "./technologies/lite_youtube_embed.js";
+import { theEventsCalendarSignature } from "./technologies/the_events_calendar.js";
+import { loadableComponentsSignature } from "./technologies/loadable_components.js";
+import { machothemesNewsmagSignature } from "./technologies/machothemes_newsmag.js";
+import { ckeditorSignature } from "./technologies/ckeditor.js";
+import { redmineSignature } from "./technologies/redmine.js";
+import { tailwindCssSignature } from "./technologies/tailwind_css.js";
+import { markedSignature } from "./technologies/marked.js";
+import { amazonEc2Signature } from "./technologies/amazon_ec2.js";
+import { elementorHeaderFooterBuilderSignature } from "./technologies/elementor_header_footer_builder.js";
+import { jsobservableSignature } from "./technologies/jsobservable.js";
+import { jsrenderSignature } from "./technologies/jsrender.js";
+import { jsviewsSignature } from "./technologies/jsviews.js";
+import { prettyphotoSignature } from "./technologies/prettyphoto.js";
+import { djangoSignature } from "./technologies/django.js";
+import { wixEcommerceSignature } from "./technologies/wix_ecommerce.js";
+import { swaggerUiSignature } from "./technologies/swagger_ui.js";
+import { blazorSignature } from "./technologies/blazor.js";
+import { jqueryPjaxSignature } from "./technologies/jquery_pjax.js";
+import { gtranslateSignature } from "./technologies/gtranslate.js";
+import { selectizeSignature } from "./technologies/selectize.js";
+import { twentyTwelveSignature } from "./technologies/twenty_twelve.js";
+import { livewireSignature } from "./technologies/livewire.js";
+import { futureShopSignature } from "./technologies/future_shop.js";
+import { rxjsSignature } from "./technologies/rxjs.js";
+import { phpmyadminSignature } from "./technologies/phpmyadmin.js";
+import { hoganSignature } from "./technologies/hogan_js.js";
+import { zeptoSignature } from "./technologies/zepto.js";
+import { jimdoSignature } from "./technologies/jimdo.js";
+import { akismetSignature } from "./technologies/akismet.js";
+import { yamahaRtSignature } from "./technologies/yamaha_rt.js";
+import { popupMakerSignature } from "./technologies/popup_maker.js";
+import { synologyDiskstationSignature } from "./technologies/synology_diskstation.js";
+import { uvicornSignature } from "./technologies/uvicorn.js";
+import { typo3CmsSignature } from "./technologies/typo3_cms.js";
 
 export const signatures: Signature[] = [
   addToAnySignature,
@@ -510,4 +560,54 @@ export const signatures: Signature[] = [
   debianSignature,
   lozadJsSignature,
   elementUiSignature,
+  antDesignSignature,
+  wpOptimizeSignature,
+  sweetalertSignature,
+  gitlabSignature,
+  scrollrevealSignature,
+  colormeshopSignature,
+  civicthemeSignature,
+  stimulusSignature,
+  decimalSignature,
+  freebsdSignature,
+  exhibitSignature,
+  twentyFourteenSignature,
+  storesJpSignature,
+  cpanelSignature,
+  ecforceSignature,
+  liteYoutubeEmbedSignature,
+  theEventsCalendarSignature,
+  loadableComponentsSignature,
+  machothemesNewsmagSignature,
+  ckeditorSignature,
+  redmineSignature,
+  tailwindCssSignature,
+  markedSignature,
+  amazonEc2Signature,
+  elementorHeaderFooterBuilderSignature,
+  jsobservableSignature,
+  jsrenderSignature,
+  jsviewsSignature,
+  prettyphotoSignature,
+  djangoSignature,
+  wixEcommerceSignature,
+  swaggerUiSignature,
+  blazorSignature,
+  jqueryPjaxSignature,
+  gtranslateSignature,
+  selectizeSignature,
+  twentyTwelveSignature,
+  livewireSignature,
+  futureShopSignature,
+  rxjsSignature,
+  phpmyadminSignature,
+  hoganSignature,
+  zeptoSignature,
+  jimdoSignature,
+  akismetSignature,
+  yamahaRtSignature,
+  popupMakerSignature,
+  synologyDiskstationSignature,
+  uvicornSignature,
+  typo3CmsSignature,
 ];

--- a/src/signatures/technologies/akismet.ts
+++ b/src/signatures/technologies/akismet.ts
@@ -1,0 +1,20 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const akismetSignature: Signature = {
+  name: "Akismet",
+  description: "Akismet is a service that filters spam from comments, trackbacks, and contact form messages.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "href[^>]+\\/wp\\-content\\/plugins\\/akismet\\/",
+    ],
+    urls: [
+      "/wp-content/plugins/akismet/.+\\.js(?:\\?ver=(\\d+(?:\\.\\d+)+))?",
+    ],
+    javascriptVariables: {
+      "ak_js.checkValidity": "",
+    },
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/amazon_ec2.ts
+++ b/src/signatures/technologies/amazon_ec2.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const amazonEc2Signature: Signature = {
+  name: "Amazon EC2",
+  description: "Amazon Elastic Compute Cloud is a part of Amazon.com's cloud-computing platform, Amazon Web Services, that allows users to rent virtual computers on which to run their own computer applications.",
+  rule: {
+    confidence: "high",
+    headers: {
+      "Server": "\\(Amazon\\)",
+    },
+  },
+};

--- a/src/signatures/technologies/ant_design.ts
+++ b/src/signatures/technologies/ant_design.ts
@@ -1,0 +1,18 @@
+import type { Signature } from "../_types.js";
+
+export const antDesignSignature: Signature = {
+  name: "Ant Design",
+  description: "Ant Design is a UI library that can be used with data flow solutions and application frameworks in any React ecosystem.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<[^>]*class=\"ant-(?:btn|col|row|layout|breadcrumb|menu|pagination|steps|select|cascader|checkbox|calendar|form|input-number|input|mention|rate|radio|slider|switch|tree-select|time-picker|transfer|upload|avatar|badge|card|carousel|collapse|list|popover|tooltip|table|tabs|tag|timeline|tree|alert|modal|message|notification|progress|popconfirm|spin|anchor|back-top|divider|drawer)",
+      "<i class=\"anticon anticon-",
+      "href[^>]+antd(?:@|/)?([\\d\\.]+)?(?:.+|)?\\.css",
+      "href[^>]+antd",
+    ],
+    javascriptVariables: {
+      "antd.version": "^([\\d\\.]+)$",
+    },
+  },
+};

--- a/src/signatures/technologies/blazor.ts
+++ b/src/signatures/technologies/blazor.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+import { microsoftAspSignature } from "./microsoft_asp.js";
+
+export const blazorSignature: Signature = {
+  name: "Blazor",
+  rule: {
+    confidence: "high",
+    urls: [
+      "blazor\\.server\\.js",
+      "blazor\\.host\\.min\\.js",
+      "blazor\\.webassembly\\.js",
+    ],
+  },
+  impliedSoftwares: [microsoftAspSignature.name],
+};

--- a/src/signatures/technologies/civic_theme.ts
+++ b/src/signatures/technologies/civic_theme.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+
+export const civicthemeSignature: Signature = {
+  name: "CivicTheme",
+  description: "CivicTheme is an open source, inclusive and component-based design system. It was created so governments and corporations can rapidly assemble modern, consistent and compliant digital experiences.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "class[^>]+civictheme\\-image",
+      "class[^>]+civic\\-image",
+      "class[^>]+ct\\-image",
+    ],
+  },
+};

--- a/src/signatures/technologies/ckeditor.ts
+++ b/src/signatures/technologies/ckeditor.ts
@@ -1,0 +1,16 @@
+import type { Signature } from "../_types.js";
+
+export const ckeditorSignature: Signature = {
+  name: "CKEditor",
+  description: "CKEditor is a WYSIWYG rich text editor which enables writing content directly inside of web pages or online applications. Its core code is written in JavaScript and it is developed by CKSource. CKEditor is available under open-source and commercial licenses.",
+  cpe: "cpe:/a:ckeditor:ckeditor",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      "CKEDITOR": "",
+      "CKEDITOR.version": "^([\\d\\.])$",
+      "CKEDITOR_BASEPATH": "",
+      "apex.libVersions.ckeditor5": "^([\\d\\.])$",
+    },
+  },
+};

--- a/src/signatures/technologies/colormeshop.ts
+++ b/src/signatures/technologies/colormeshop.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const colormeshopSignature: Signature = {
+  name: "ColorMeShop",
+  description: "ColorMeShop is an ecommerce platform from Japan.",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      "Colorme": "",
+    },
+  },
+};

--- a/src/signatures/technologies/cpanel.ts
+++ b/src/signatures/technologies/cpanel.ts
@@ -1,0 +1,20 @@
+import type { Signature } from "../_types.js";
+
+export const cpanelSignature: Signature = {
+  name: "cPanel",
+  description: "cPanel is a web hosting control panel. The software provides a graphical interface and automation tools designed to simplify the process of hosting a website.",
+  cpe: "cpe:/a:cpanel:cpanel",
+  rule: {
+    confidence: "high",
+    headers: {
+      "Server": "cpsrvd/([\\d.]+)",
+    },
+    cookies: {
+      "cprelogin": "",
+      "cpsession": "",
+    },
+    bodies: [
+      "<!-- cPanel",
+    ],
+  },
+};

--- a/src/signatures/technologies/decimal_js.ts
+++ b/src/signatures/technologies/decimal_js.ts
@@ -1,0 +1,16 @@
+import type { Signature } from "../_types.js";
+
+export const decimalSignature: Signature = {
+  name: "decimal.js",
+  rule: {
+    confidence: "high",
+    urls: [
+      "decimal[.-]([\\d.]*\\d+)(?:\\.min)?\\.js",
+      "/([\\d.]*\\d+)/decimal(?:\\.min)?\\.js",
+      "decimal(?:\\.min)?\\.js(?:\\?ver(?:sion)?=([\\d.]*\\d+))?",
+    ],
+    javascriptVariables: {
+      "Decimal.ROUND_HALF_FLOOR": "",
+    },
+  },
+};

--- a/src/signatures/technologies/django.ts
+++ b/src/signatures/technologies/django.ts
@@ -1,0 +1,22 @@
+import type { Signature } from "../_types.js";
+import { pythonSignature } from "./python.js";
+
+export const djangoSignature: Signature = {
+  name: "Django",
+  description: "Django is a Python-based free and open-source web application framework.",
+  cpe: "cpe:/a:djangoproject:django",
+  rule: {
+    confidence: "high",
+    cookies: {
+      "django_language": "",
+    },
+    bodies: [
+      "(?:powered by <a[^>]+>Django ?([\\d.]+)?<\\/a>|<input[^>]*name=[\"']csrfmiddlewaretoken[\"'][^>]*>)",
+    ],
+    javascriptVariables: {
+      "__admin_media_prefix__": "",
+      "django": "",
+    },
+  },
+  impliedSoftwares: [pythonSignature.name],
+};

--- a/src/signatures/technologies/ecforce.ts
+++ b/src/signatures/technologies/ecforce.ts
@@ -1,0 +1,17 @@
+import type { Signature } from "../_types.js";
+import { rubySignature } from "./ruby.js";
+import { rubyOnRailsSignature } from "./ruby_on_rails.js";
+import { nginxSignature } from "./nginx.js";
+
+export const ecforceSignature: Signature = {
+  name: "EcForce",
+  description: "EcForce is an all-in-one ecommerce platform with all the functions necessary for ecommerce, from landing-page creation to order and customer data management analysis.",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      "EcForce.Models": "",
+      "EcForce.Models.Shop": "",
+    },
+  },
+  impliedSoftwares: [rubySignature.name, rubyOnRailsSignature.name, nginxSignature.name],
+};

--- a/src/signatures/technologies/elementor_header_footer_builder.ts
+++ b/src/signatures/technologies/elementor_header_footer_builder.ts
@@ -1,0 +1,16 @@
+import type { Signature } from "../_types.js";
+import { elementorSignature } from "./elementor.js";
+import { wordpressSignature } from "./wordpress.js";
+import { elementorSignature } from "./elementor.js";
+
+export const elementorHeaderFooterBuilderSignature: Signature = {
+  name: "Elementor Header & Footer Builder",
+  description: "Elementor Header & Footer Builder is a simple yet powerful WordPress plugin that allows you to create a layout with Elementor and set it as.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "href[^>]+\\/wp\\-content\\/plugins\\/header\\-footer\\-elementor\\/",
+    ],
+  },
+  impliedSoftwares: [elementorSignature.name, wordpressSignature.name, elementorSignature.name],
+};

--- a/src/signatures/technologies/exhibit.ts
+++ b/src/signatures/technologies/exhibit.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+
+export const exhibitSignature: Signature = {
+  name: "Exhibit",
+  rule: {
+    confidence: "high",
+    urls: [
+      "exhibit.*\\.js",
+    ],
+    javascriptVariables: {
+      "Exhibit": "",
+      "Exhibit.version": "^(.+)$",
+    },
+  },
+};

--- a/src/signatures/technologies/freebsd.ts
+++ b/src/signatures/technologies/freebsd.ts
@@ -1,0 +1,13 @@
+import type { Signature } from "../_types.js";
+
+export const freebsdSignature: Signature = {
+  name: "FreeBSD",
+  description: "FreeBSD is a free and open-source Unix-like operating system.",
+  cpe: "cpe:/o:freebsd:freebsd",
+  rule: {
+    confidence: "high",
+    headers: {
+      "Server": "FreeBSD(?: ([\\d.]+))?",
+    },
+  },
+};

--- a/src/signatures/technologies/future_shop.ts
+++ b/src/signatures/technologies/future_shop.ts
@@ -1,0 +1,11 @@
+import type { Signature } from "../_types.js";
+
+export const futureShopSignature: Signature = {
+  name: "Future Shop",
+  rule: {
+    confidence: "high",
+    urls: [
+      "future-shop.*\\.js",
+    ],
+  },
+};

--- a/src/signatures/technologies/gitlab.ts
+++ b/src/signatures/technologies/gitlab.ts
@@ -1,0 +1,25 @@
+import type { Signature } from "../_types.js";
+import { rubyOnRailsSignature } from "./ruby_on_rails.js";
+import { vueJsSignature } from "./vue_js.js";
+
+export const gitlabSignature: Signature = {
+  name: "GitLab",
+  description: "GitLab is a web-based DevOps lifecycle tool that provides a Git-repository manager providing wiki, issue-tracking and continuous integration and deployment pipeline features, using an open-source license.",
+  cpe: "cpe:/a:gitlab:gitlab",
+  rule: {
+    confidence: "high",
+    cookies: {
+      "_gitlab_session": "",
+    },
+    bodies: [
+      "<meta content=\"https?://[^/]+/assets/gitlab_logo-",
+      "<header class=\"navbar navbar-fixed-top navbar-gitlab with-horizontal-nav\">",
+      "<meta[^>]+name=[\"']og:site_name[\"'][^>]+content=[\"']^GitLab$",
+    ],
+    javascriptVariables: {
+      "GitLab": "",
+      "gl.dashboardOptions": "",
+    },
+  },
+  impliedSoftwares: [rubyOnRailsSignature.name, vueJsSignature.name],
+};

--- a/src/signatures/technologies/gtranslate.ts
+++ b/src/signatures/technologies/gtranslate.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const gtranslateSignature: Signature = {
+  name: "GTranslate",
+  description: "GTranslate is a website translator which can translate any website to any language automatically.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "href[^>]+\\/wp\\-content\\/plugins\\/gtranslate\\/",
+      "src[^>]+\\/wp\\-content\\/plugins\\/gtranslate\\/",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/hogan_js.ts
+++ b/src/signatures/technologies/hogan_js.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+
+export const hoganSignature: Signature = {
+  name: "Hogan.js",
+  rule: {
+    confidence: "high",
+    urls: [
+      "hogan-[.-]([\\d.]*\\d)[^/]*\\.js",
+      "([\\d.]+)/hogan(?:\\.min)?\\.js",
+    ],
+    javascriptVariables: {
+      "Hogan": "",
+    },
+  },
+};

--- a/src/signatures/technologies/jimdo.ts
+++ b/src/signatures/technologies/jimdo.ts
@@ -1,0 +1,19 @@
+import type { Signature } from "../_types.js";
+
+export const jimdoSignature: Signature = {
+  name: "Jimdo",
+  description: "Jimdo is a website-builder and all-in-one hosting solution, designed to enable users to build their own websites.",
+  rule: {
+    confidence: "high",
+    headers: {
+      "X-Jimdo-Instance": "",
+      "X-Jimdo-Wid": "",
+    },
+    urls: [
+      "\\.jimdo(?:site)?\\.com/",
+    ],
+    javascriptVariables: {
+      "jimdoDolphinData": "",
+    },
+  },
+};

--- a/src/signatures/technologies/jquery_pjax.ts
+++ b/src/signatures/technologies/jquery_pjax.ts
@@ -1,0 +1,23 @@
+import type { Signature } from "../_types.js";
+import { jquerySignature } from "./jquery.js";
+
+export const jqueryPjaxSignature: Signature = {
+  name: "jQuery-pjax",
+  description: "jQuery PJAX is a plugin that uses AJAX and pushState.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<div[^>]+data-pjax-container",
+      "<meta[^>]+name=[\"']pjax-push[\"']",
+      "<meta[^>]+name=[\"']pjax-replace[\"']",
+      "<meta[^>]+name=[\"']pjax-timeout[\"']",
+    ],
+    urls: [
+      "jquery[.-]pjax(?:-([\\d.]))?(?:\\.min)?\\.js(?:\\?ver=([\\d.]+))?",
+    ],
+    javascriptVariables: {
+      "jQuery.pjax": "",
+    },
+  },
+  impliedSoftwares: [jquerySignature.name],
+};

--- a/src/signatures/technologies/jsobservable.ts
+++ b/src/signatures/technologies/jsobservable.ts
@@ -1,0 +1,6 @@
+import type { Signature } from "../_types.js";
+
+export const jsobservableSignature: Signature = {
+  name: "JsObservable",
+  description: "JsObservable is integrated with JsViews and facilitates observable data manipulations that are immediately reflected in the data-bound templates. The library is developed and maintained by Microsoft employee Boris Moore and is used in projects such as Outlook.com and Windows Azure.",
+};

--- a/src/signatures/technologies/jsrender.ts
+++ b/src/signatures/technologies/jsrender.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+import { jsViewsSignature } from "./jsviews.js";
+
+export const jsrenderSignature: Signature = {
+  name: "JsRender",
+  description: "JsRender is the template library. The library is developed and maintained by Microsoft employee Boris Moore and is used in projects such as Outlook.com and Windows Azure.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "([\\d\\.]+)?/jsrender(?:\\.min)?\\.js",
+    ],
+  },
+  impliedSoftwares: [jsViewsSignature.name],
+};

--- a/src/signatures/technologies/jsviews.ts
+++ b/src/signatures/technologies/jsviews.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+import { jsObservableSignature } from "./jsobservable.js";
+import { jsRenderSignature } from "./jsrender.js";
+
+export const jsviewsSignature: Signature = {
+  name: "JsViews",
+  description: "JsViews is the MVVM library which provides two-way data binding for the template. The library is developed and maintained by Microsoft employee Boris Moore and is used in projects such as Outlook.com and Windows Azure.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "([\\d\\.]+)?/jsviews(?:\\.min)?\\.js",
+    ],
+  },
+  impliedSoftwares: [jsObservableSignature.name, jsRenderSignature.name],
+};

--- a/src/signatures/technologies/lite_youtube_embed.ts
+++ b/src/signatures/technologies/lite_youtube_embed.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const liteYoutubeEmbedSignature: Signature = {
+  name: "lite-youtube-embed",
+  description: "The lite-youtube-embed technique renders the YouTube video inside the IFRAME tag only when the play button in clicked thus improving the core web vitals score of your website.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "lite-youtube",
+    ],
+  },
+};

--- a/src/signatures/technologies/livewire.ts
+++ b/src/signatures/technologies/livewire.ts
@@ -1,0 +1,20 @@
+import type { Signature } from "../_types.js";
+import { laravelSignature } from "./laravel.js";
+
+export const livewireSignature: Signature = {
+  name: "Livewire",
+  description: "Livewire is a full-stack Laravel framework for building dynamic interfaces.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<[^>]{1,512}\\bwire:",
+    ],
+    urls: [
+      "livewire(?:\\.min)?\\.js",
+    ],
+    javascriptVariables: {
+      "livewire": "",
+    },
+  },
+  impliedSoftwares: [laravelSignature.name],
+};

--- a/src/signatures/technologies/loadable_components.ts
+++ b/src/signatures/technologies/loadable_components.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+
+export const loadableComponentsSignature: Signature = {
+  name: "Loadable-Components",
+  description: "Loadable-Components is a library to solve the React code-splitting client-side and server-side.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "__LOADABLE_REQUIRED_CHUNKS__",
+    ],
+    javascriptVariables: {
+      "__LOADABLE_LOADED_CHUNKS__": "",
+    },
+  },
+};

--- a/src/signatures/technologies/machothemes_newsmag.ts
+++ b/src/signatures/technologies/machothemes_newsmag.ts
@@ -1,0 +1,17 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const machothemesNewsmagSignature: Signature = {
+  name: "MachoThemes NewsMag",
+  description: "MachoThemes Newsmag is a clean and modern magazine, news or blog WordPress theme.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "href[^>]+\\/wp\\-content\\/themes\\/Newsmag",
+    ],
+    urls: [
+      "/wp-content/themes/Newsmag(?:-child)?/",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/marked.ts
+++ b/src/signatures/technologies/marked.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+
+export const markedSignature: Signature = {
+  name: "Marked",
+  cpe: "cpe:/a:marked_project:marked",
+  rule: {
+    confidence: "high",
+    urls: [
+      "/marked(?:\\.min)?\\.js",
+    ],
+    javascriptVariables: {
+      "marked": "",
+    },
+  },
+};

--- a/src/signatures/technologies/phpmyadmin.ts
+++ b/src/signatures/technologies/phpmyadmin.ts
@@ -1,0 +1,23 @@
+import type { Signature } from "../_types.js";
+import { phpSignature } from "./php.js";
+import { mysqlSignature } from "./mysql.js";
+
+export const phpmyadminSignature: Signature = {
+  name: "phpMyAdmin",
+  description: "PhpMyAdmin is a free and open-source administration tool for MySQL and MariaDB.",
+  cpe: "cpe:/a:phpmyadmin:phpmyadmin",
+  rule: {
+    confidence: "high",
+    headers: {
+      "Set-Cookie": "phpMyAdmin_https",
+    },
+    bodies: [
+      "!\\[CDATA\\[[^<]*PMA_VERSION:\\\"([\\d.]+)",
+      "(?: \\| phpMyAdmin ([\\d.]+)<\\/title>|PMA_sendHeaderLocation\\(|<link [^>]*href=\"[^\"]*phpmyadmin\\.css\\.php)",
+    ],
+    javascriptVariables: {
+      "pma_absolute_uri": "",
+    },
+  },
+  impliedSoftwares: [phpSignature.name, mysqlSignature.name],
+};

--- a/src/signatures/technologies/popup_maker.ts
+++ b/src/signatures/technologies/popup_maker.ts
@@ -1,0 +1,17 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const popupMakerSignature: Signature = {
+  name: "Popup Maker",
+  description: "Popup Maker is a plugin that lets you create popup windows for your WordPress website.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "/wp-content/plugins/popup-maker/(?:.+site(?:\\.min)?\\.js\\?.+ver=(\\d+(?:\\.\\d+)+))?",
+    ],
+    javascriptVariables: {
+      "pum_popups": "",
+    },
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/prettyphoto.ts
+++ b/src/signatures/technologies/prettyphoto.ts
@@ -1,0 +1,22 @@
+import type { Signature } from "../_types.js";
+import { jquerySignature } from "./jquery.js";
+
+export const prettyphotoSignature: Signature = {
+  name: "prettyPhoto",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "(?:<link [^>]*href=\"[^\"]*prettyPhoto(?:\\.min)?\\.css|<a [^>]*rel=\"prettyPhoto)",
+    ],
+    urls: [
+      "jquery\\.prettyPhoto\\.js",
+    ],
+    javascriptVariables: {
+      "pp_alreadyInitialized": "",
+      "pp_descriptions": "",
+      "pp_images": "",
+      "pp_titles": "",
+    },
+  },
+  impliedSoftwares: [jquerySignature.name],
+};

--- a/src/signatures/technologies/redmine.ts
+++ b/src/signatures/technologies/redmine.ts
@@ -1,0 +1,19 @@
+import type { Signature } from "../_types.js";
+import { rubyOnRailsSignature } from "./ruby_on_rails.js";
+
+export const redmineSignature: Signature = {
+  name: "Redmine",
+  description: "Redmine is a free and open-source, web-based project management and issue tracking tool.",
+  cpe: "cpe:/a:redmine:redmine",
+  rule: {
+    confidence: "high",
+    cookies: {
+      "_redmine_session": "",
+    },
+    bodies: [
+      "Powered by <a href=\"[^>]+Redmine",
+      "<meta[^>]+name=[\"']description[\"'][^>]+content=[\"']Redmine",
+    ],
+  },
+  impliedSoftwares: [rubyOnRailsSignature.name],
+};

--- a/src/signatures/technologies/rxjs.ts
+++ b/src/signatures/technologies/rxjs.ts
@@ -1,0 +1,16 @@
+import type { Signature } from "../_types.js";
+
+export const rxjsSignature: Signature = {
+  name: "RxJS",
+  description: "RxJS is a reactive library used to implement reactive programming to deal with async implementation, callbacks, and event-based programs.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "rx(?:\\.\\w+)?(?:\\.compat|\\.global)?(?:\\.min)?\\.js",
+    ],
+    javascriptVariables: {
+      "Rx.CompositeDisposable": "",
+      "Rx.Symbol": "",
+    },
+  },
+};

--- a/src/signatures/technologies/scrollreveal.ts
+++ b/src/signatures/technologies/scrollreveal.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+
+export const scrollrevealSignature: Signature = {
+  name: "scrollreveal",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<[^>]+data-sr(?:-id)",
+    ],
+    urls: [
+      "scrollreveal(?:\\.min)(?:\\.js)",
+    ],
+  },
+};

--- a/src/signatures/technologies/selectize.ts
+++ b/src/signatures/technologies/selectize.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+import { jquerySignature } from "./jquery.js";
+
+export const selectizeSignature: Signature = {
+  name: "Selectize",
+  description: "Selectize is an extensible jQuery-based custom <select> UI control.",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      "Selectize": "",
+      "selectize": "",
+    },
+  },
+  impliedSoftwares: [jquerySignature.name],
+};

--- a/src/signatures/technologies/stimulus.ts
+++ b/src/signatures/technologies/stimulus.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const stimulusSignature: Signature = {
+  name: "Stimulus",
+  description: "A modest JavaScript framework for the HTML you already have.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<[^>]+data-controller",
+    ],
+  },
+};

--- a/src/signatures/technologies/stores_jp.ts
+++ b/src/signatures/technologies/stores_jp.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const storesJpSignature: Signature = {
+  name: "stores.jp",
+  description: "stores.jp is an ecommerce platform which allows users to create their own ecommerce website.",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      "STORES_JP": "",
+    },
+  },
+};

--- a/src/signatures/technologies/swagger_ui.ts
+++ b/src/signatures/technologies/swagger_ui.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const swaggerUiSignature: Signature = {
+  name: "Swagger UI",
+  description: "Swagger UI is a collection of HTML, JavaScript, and CSS assets that dynamically generate documentation from a Swagger-compliant API.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "(?:/([\\d.]+))?/swagger-ui-bundle\\.js",
+    ],
+  },
+};

--- a/src/signatures/technologies/sweetalert.ts
+++ b/src/signatures/technologies/sweetalert.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+
+export const sweetalertSignature: Signature = {
+  name: "SweetAlert",
+  description: "SweetAlert is a beautiful replacement for JavaScript's alert.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<link[^>]+?href=\"[^\"]+sweet-alert(?:\\.min)?\\.css",
+    ],
+    urls: [
+      "sweet(?:-)?alert(?:\\.min)?\\.js",
+    ],
+  },
+};

--- a/src/signatures/technologies/synology_diskstation.ts
+++ b/src/signatures/technologies/synology_diskstation.ts
@@ -1,0 +1,17 @@
+import type { Signature } from "../_types.js";
+
+export const synologyDiskstationSignature: Signature = {
+  name: "Synology DiskStation",
+  description: "DiskStation provides a full-featured network attached storage.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<noscript><div class='syno-no-script'",
+      "<meta[^>]+name=[\"']application-name[\"'][^>]+content=[\"']Synology DiskStation",
+      "<meta[^>]+name=[\"']description[\"'][^>]+content=[\"']^DiskStation provides a full-featured network attached storage",
+    ],
+    urls: [
+      "webapi/entry\\.cgi\\?api=SYNO\\.(?:Core|Filestation)\\.Desktop\\.",
+    ],
+  },
+};

--- a/src/signatures/technologies/tailwind_css.ts
+++ b/src/signatures/technologies/tailwind_css.ts
@@ -1,0 +1,21 @@
+import type { Signature } from "../_types.js";
+
+export const tailwindCssSignature: Signature = {
+  name: "Tailwind CSS",
+  description: "Tailwind is a utility-first CSS framework.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "--tw-(?:rotate|translate|space-x|text-opacity|border-opacity)",
+      "href[^>]+tailwindcss[@|/](?:\\^)?([\\d.]+)(?:/[a-z]+)?/(?:tailwind|base|components|utilities)(?:\\.min)?\\.css",
+      "rel[^>]+stylesheet",
+      "href[^>]+tailwind",
+    ],
+    urls: [
+      "\\.tailwindcss(?:tailwind-config-cdn)?\\.(?:com|js)",
+    ],
+    javascriptVariables: {
+      "tailwind": "",
+    },
+  },
+};

--- a/src/signatures/technologies/the_events_calendar.ts
+++ b/src/signatures/technologies/the_events_calendar.ts
@@ -1,0 +1,21 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const theEventsCalendarSignature: Signature = {
+  name: "The Events Calendar",
+  description: "The Events Calendar is a free event management plugin for WordPress.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "href[^>]+\\/wp\\-content\\/plugins\\/the\\-events\\-calendar\\/",
+    ],
+    urls: [
+      "/wp-content/plugins/the-events-calendar(?:-pro)?/",
+    ],
+    javascriptVariables: {
+      "TribeCalendar": "",
+      "tribe_l10n_datatables": "",
+    },
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/twenty_fourteen.ts
+++ b/src/signatures/technologies/twenty_fourteen.ts
@@ -1,0 +1,18 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const twentyFourteenSignature: Signature = {
+  name: "Twenty Fourteen",
+  description: "Twenty Fourteen is the default WordPress theme for 2014.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "twentyfourteen-style-css",
+      "twentyfourteen-lato-css",
+    ],
+    urls: [
+      "/wp-content/themes/twentyfourteen/",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/twenty_twelve.ts
+++ b/src/signatures/technologies/twenty_twelve.ts
@@ -1,0 +1,17 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const twentyTwelveSignature: Signature = {
+  name: "Twenty Twelve",
+  description: "Twenty Twelve is the default WordPress theme for 2012.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "twentytwelve-style-css",
+    ],
+    urls: [
+      "/wp-content/themes/twentytwelve/",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/typo3_cms.ts
+++ b/src/signatures/technologies/typo3_cms.ts
@@ -1,0 +1,22 @@
+import type { Signature } from "../_types.js";
+import { phpSignature } from "./php.js";
+
+export const typo3CmsSignature: Signature = {
+  name: "TYPO3 CMS",
+  description: "TYPO3 is a free and open-source Web content management system written in PHP.",
+  cpe: "cpe:/a:typo3:typo3",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<link[^>]+ href=\"/?typo3(?:conf|temp)/",
+      "<img[^>]+ src=\"/?typo3(?:conf|temp)/",
+      "<!--\n\tThis website is powered by TYPO3",
+      "<meta[^>]+name=[\"']generator[\"'][^>]+content=[\"']TYPO3\\s+(?:CMS\\s+)?(?:[\\d.]+)?(?:\\s+CMS)?",
+    ],
+    urls: [
+      "^/?typo3(?:conf|temp)/",
+      "/typo3/",
+    ],
+  },
+  impliedSoftwares: [phpSignature.name],
+};

--- a/src/signatures/technologies/uvicorn.ts
+++ b/src/signatures/technologies/uvicorn.ts
@@ -1,0 +1,13 @@
+import type { Signature } from "../_types.js";
+import { pythonSignature } from "./python.js";
+
+export const uvicornSignature: Signature = {
+  name: "Uvicorn",
+  rule: {
+    confidence: "high",
+    headers: {
+      "Server": "uvicorn",
+    },
+  },
+  impliedSoftwares: [pythonSignature.name],
+};

--- a/src/signatures/technologies/wix_ecommerce.ts
+++ b/src/signatures/technologies/wix_ecommerce.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+import { wixSignature } from "./wix.js";
+
+export const wixEcommerceSignature: Signature = {
+  name: "Wix eCommerce",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "wixstores",
+      "wix-viewer-model",
+    ],
+  },
+  impliedSoftwares: [wixSignature.name],
+};

--- a/src/signatures/technologies/wp_optimize.ts
+++ b/src/signatures/technologies/wp_optimize.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const wpOptimizeSignature: Signature = {
+  name: "WP-Optimize",
+  description: "WP-Optimize is an all-in-one WordPress plugin that cleans your database, compresses your large images and caches your site.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<!--[^>]+Cached by WP-Optimize",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/yamaha_rt.ts
+++ b/src/signatures/technologies/yamaha_rt.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const yamahaRtSignature: Signature = {
+  name: "YAMAHA RT",
+  description: "YAMAHA RT is a series of business-grade routes produced by YAMAHA Corporation.",
+  rule: {
+    confidence: "high",
+    headers: {
+      "Server": "YAMAHA-RT",
+    },
+  },
+};

--- a/src/signatures/technologies/zepto.ts
+++ b/src/signatures/technologies/zepto.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+
+export const zeptoSignature: Signature = {
+  name: "Zepto",
+  rule: {
+    confidence: "high",
+    urls: [
+      "zepto.*\\.js",
+    ],
+    javascriptVariables: {
+      "Zepto": "",
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- add signatures for requested frameworks, plugins, and platforms (Ant Design, GitLab, TYPO3 CMS, etc.)
- include WordPress plugin/theme detections and related framework implications
- register all new signatures in the index

## Testing
- not run