### PR TITLE
feat: add wappalyzer signatures

### DIFF
--- a/src/signatures/index.ts
+++ b/src/signatures/index.ts
@@ -304,6 +304,56 @@ import { popupMakerSignature } from "./technologies/popup_maker.js";
 import { synologyDiskstationSignature } from "./technologies/synology_diskstation.js";
 import { uvicornSignature } from "./technologies/uvicorn.js";
 import { typo3CmsSignature } from "./technologies/typo3_cms.js";
+import { metismenuSignature } from "./technologies/metismenu.js";
+import { yiiSignature } from "./technologies/yii.js";
+import { woocommerceStripePaymentGatewaySignature } from "./technologies/woocommerce_stripe_payment_gateway.js";
+import { famethemesOnepressSignature } from "./technologies/famethemes_onepress.js";
+import { hatenaBlogSignature } from "./technologies/hatena_blog.js";
+import { jplayerSignature } from "./technologies/jplayer.js";
+import { muuriSignature } from "./technologies/muuri.js";
+import { graphqlSignature } from "./technologies/graphql.js";
+import { typepadSignature } from "./technologies/typepad.js";
+import { bootstrapTableSignature } from "./technologies/bootstrap_table.js";
+import { svelteSignature } from "./technologies/svelte.js";
+import { jquerySparklinesSignature } from "./technologies/jquery_sparklines.js";
+import { adobeExperienceManagerSignature } from "./technologies/adobe_experience_manager.js";
+import { auraSignature } from "./technologies/aura.js";
+import { salesforceDeskSignature } from "./technologies/salesforce_desk.js";
+import { pulseSecureSignature } from "./technologies/pulse_secure.js";
+import { mooveGdprConsentSignature } from "./technologies/moove_gdpr_consent.js";
+import { opencartSignature } from "./technologies/opencart.js";
+import { outlookWebAppSignature } from "./technologies/outlook_web_app.js";
+import { svgSupportSignature } from "./technologies/svg_support.js";
+import { pureCssSignature } from "./technologies/pure_css.js";
+import { winkSignature } from "./technologies/wink.js";
+import { superpwaSignature } from "./technologies/superpwa.js";
+import { jetpackSignature } from "./technologies/jetpack.js";
+import { jssSignature } from "./technologies/jss.js";
+import { linkedinSignInSignature } from "./technologies/linkedin_sign_in.js";
+import { microsoftVisualStudioSignature } from "./technologies/microsoft_visual_studio.js";
+import { siteoriginVantageSignature } from "./technologies/siteorigin_vantage.js";
+import { highlightSignature } from "./technologies/highlight_js.js";
+import { playSignature } from "./technologies/play.js";
+import { scalaSignature } from "./technologies/scala.js";
+import { twentySixteenSignature } from "./technologies/twenty_sixteen.js";
+import { embedplusSignature } from "./technologies/embedplus.js";
+import { meteorSignature } from "./technologies/meteor.js";
+import { mongodbSignature } from "./technologies/mongodb.js";
+import { caddySignature } from "./technologies/caddy.js";
+import { sonarqubesSignature } from "./technologies/sonarqubes.js";
+import { elementskitSignature } from "./technologies/elementskit.js";
+import { twitterTypeaheadSignature } from "./technologies/twitter_typeahead_js.js";
+import { remixSignature } from "./technologies/remix.js";
+import { apacheTrafficServerSignature } from "./technologies/apache_traffic_server.js";
+import { salesforceServiceCloudSignature } from "./technologies/salesforce_service_cloud.js";
+import { tengineSignature } from "./technologies/tengine.js";
+import { hclDominoSignature } from "./technologies/hcl_domino.js";
+import { amazonWebstoreSignature } from "./technologies/amazon_webstore.js";
+import { craftCmsSignature } from "./technologies/craft_cms.js";
+import { gliderSignature } from "./technologies/glider_js.js";
+import { coreuiSignature } from "./technologies/coreui.js";
+import { redisSignature } from "./technologies/redis.js";
+import { themegraphyGraphySignature } from "./technologies/themegraphy_graphy.js";
 
 export const signatures: Signature[] = [
   addToAnySignature,
@@ -610,4 +660,54 @@ export const signatures: Signature[] = [
   synologyDiskstationSignature,
   uvicornSignature,
   typo3CmsSignature,
+  metismenuSignature,
+  yiiSignature,
+  woocommerceStripePaymentGatewaySignature,
+  famethemesOnepressSignature,
+  hatenaBlogSignature,
+  jplayerSignature,
+  muuriSignature,
+  graphqlSignature,
+  typepadSignature,
+  bootstrapTableSignature,
+  svelteSignature,
+  jquerySparklinesSignature,
+  adobeExperienceManagerSignature,
+  auraSignature,
+  salesforceDeskSignature,
+  pulseSecureSignature,
+  mooveGdprConsentSignature,
+  opencartSignature,
+  outlookWebAppSignature,
+  svgSupportSignature,
+  pureCssSignature,
+  winkSignature,
+  superpwaSignature,
+  jetpackSignature,
+  jssSignature,
+  linkedinSignInSignature,
+  microsoftVisualStudioSignature,
+  siteoriginVantageSignature,
+  highlightSignature,
+  playSignature,
+  scalaSignature,
+  twentySixteenSignature,
+  embedplusSignature,
+  meteorSignature,
+  mongodbSignature,
+  caddySignature,
+  sonarqubesSignature,
+  elementskitSignature,
+  twitterTypeaheadSignature,
+  remixSignature,
+  apacheTrafficServerSignature,
+  salesforceServiceCloudSignature,
+  tengineSignature,
+  hclDominoSignature,
+  amazonWebstoreSignature,
+  craftCmsSignature,
+  gliderSignature,
+  coreuiSignature,
+  redisSignature,
+  themegraphyGraphySignature,
 ];

--- a/src/signatures/technologies/adobe_experience_manager.ts
+++ b/src/signatures/technologies/adobe_experience_manager.ts
@@ -1,0 +1,23 @@
+import type { Signature } from "../_types.js";
+import { javaSignature } from "./java.js";
+
+export const adobeExperienceManagerSignature: Signature = {
+  name: "Adobe Experience Manager",
+  description: "Adobe Experience Manager (AEM) is a content management solution for building websites, mobile apps and forms.",
+  cpe: "cpe:/a:adobe:experience_manager",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<div class=\"[^\"]*parbase",
+      "<div[^>]+data-component-path=\"[^\"+]jcr:",
+      "<div class=\"[^\"]*aem-Grid",
+    ],
+    urls: [
+      "/etc/designs/",
+      "/etc/clientlibs/",
+      "/etc\\.clientlibs/",
+      "aem-(?:GridColumn|apps/)",
+    ],
+  },
+  impliedSoftwares: [javaSignature.name],
+};

--- a/src/signatures/technologies/amazon_webstore.ts
+++ b/src/signatures/technologies/amazon_webstore.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const amazonWebstoreSignature: Signature = {
+  name: "Amazon Webstore",
+  description: "Amazon Webstore is an all-in-one hosted ecommerce website solution.",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      "amzn": "",
+    },
+  },
+};

--- a/src/signatures/technologies/apache_traffic_server.ts
+++ b/src/signatures/technologies/apache_traffic_server.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const apacheTrafficServerSignature: Signature = {
+  name: "Apache Traffic Server",
+  cpe: "cpe:/a:apache:traffic_server",
+  rule: {
+    confidence: "high",
+    headers: {
+      "Server": "ATS/?([\\d.]+)?",
+    },
+  },
+};

--- a/src/signatures/technologies/aura.ts
+++ b/src/signatures/technologies/aura.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const auraSignature: Signature = {
+  name: "Aura",
+  description: "Aura is an open-source UI framework built by Salesforce for developing dynamic web apps for mobile and desktop devices.",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      "Aura.app": "siteforce\\:communityApp",
+    },
+  },
+};

--- a/src/signatures/technologies/bootstrap_table.ts
+++ b/src/signatures/technologies/bootstrap_table.ts
@@ -1,0 +1,16 @@
+import type { Signature } from "../_types.js";
+import { jquerySignature } from "./jquery.js";
+
+export const bootstrapTableSignature: Signature = {
+  name: "Bootstrap Table",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<link[^>]+href=\"[^>]*bootstrap-table(?:\\.min)?\\.css",
+    ],
+    urls: [
+      "bootstrap-table(?:\\.min)?\\.js",
+    ],
+  },
+  impliedSoftwares: [jquerySignature.name],
+};

--- a/src/signatures/technologies/caddy.ts
+++ b/src/signatures/technologies/caddy.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const caddySignature: Signature = {
+  name: "Caddy",
+  cpe: "cpe:/a:caddyserver:caddy",
+  rule: {
+    confidence: "high",
+    headers: {
+      "Server": "^Caddy$",
+    },
+  },
+};

--- a/src/signatures/technologies/coreui.ts
+++ b/src/signatures/technologies/coreui.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+
+export const coreuiSignature: Signature = {
+  name: "CoreUI",
+  description: "CoreUI provides cloud hosting, web and mobile design, animations, wireframes, and UX testing services.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "webpackJsonp@coreui/coreui",
+    ],
+    javascriptVariables: {
+      "coreui": "",
+    },
+  },
+};

--- a/src/signatures/technologies/craft_cms.ts
+++ b/src/signatures/technologies/craft_cms.ts
@@ -1,0 +1,18 @@
+import type { Signature } from "../_types.js";
+import { yiiSignature } from "./yii.js";
+
+export const craftCmsSignature: Signature = {
+  name: "Craft CMS",
+  description: "Craft CMS is a content management system for building bespoke websites.",
+  cpe: "cpe:/a:craftcms:craft_cms",
+  rule: {
+    confidence: "high",
+    headers: {
+      "X-Powered-By": "\\bCraft CMS\\b",
+    },
+    cookies: {
+      "CraftSessionId": "",
+    },
+  },
+  impliedSoftwares: [yiiSignature.name],
+};

--- a/src/signatures/technologies/elementskit.ts
+++ b/src/signatures/technologies/elementskit.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+import { elementorSignature } from "./elementor.js";
+
+export const elementskitSignature: Signature = {
+  name: "ElementsKit",
+  description: "ElementsKit is an addon for Elementor that adds additional customisation options to the page builder.",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      "ElementsKit_Helper": "",
+      "elementskit": "",
+    },
+  },
+  impliedSoftwares: [elementorSignature.name],
+};

--- a/src/signatures/technologies/embedplus.ts
+++ b/src/signatures/technologies/embedplus.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const embedplusSignature: Signature = {
+  name: "EmbedPlus",
+  description: "EmbedPlus is a WordPress plugin for YouTube allows you to embed gallery, channel, playlist, or even live stream on your webpage.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "/wp-content/plugins/youtube-embed-plus(?:-pro)?/.+\\.js(?:\\?ver=(\\d+(?:\\.\\d+)+))?",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/famethemes_onepress.ts
+++ b/src/signatures/technologies/famethemes_onepress.ts
@@ -1,0 +1,16 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const famethemesOnepressSignature: Signature = {
+  name: "FameThemes OnePress",
+  description: "FameThemes OnePress is a free portfolio one page WordPress theme suited for an individual or digital agency.",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      "OnePress_Plus": "",
+      "onepressIsMobile": "",
+      "onepress_js_settings": "",
+    },
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/glider_js.ts
+++ b/src/signatures/technologies/glider_js.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const gliderSignature: Signature = {
+  name: "Glider.js",
+  description: "Glider.js is a fast, lightweight, responsive, dependency-free scrollable list with customisable paging controls.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "(?:/|@)?([\\d\\.]{2,})?/glider\\.min\\.js",
+    ],
+  },
+};

--- a/src/signatures/technologies/graphql.ts
+++ b/src/signatures/technologies/graphql.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const graphqlSignature: Signature = {
+  name: "GraphQL",
+  description: "GraphQL is a query language for APIs and a runtime for fulfilling those queries with your existing data.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<meta[^>]+name=[\"']store-config[\"'][^>]+content=[\"']graphqlMethod",
+    ],
+  },
+};

--- a/src/signatures/technologies/hatena_blog.ts
+++ b/src/signatures/technologies/hatena_blog.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const hatenaBlogSignature: Signature = {
+  name: "Hatena Blog",
+  description: "Hatena Blog is one of the traditional blog platforms in Japan.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "cdn\\.blog\\.st-hatena\\.com/",
+    ],
+  },
+};

--- a/src/signatures/technologies/hcl_domino.ts
+++ b/src/signatures/technologies/hcl_domino.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+import { javaSignature } from "./java.js";
+
+export const hclDominoSignature: Signature = {
+  name: "HCL Domino",
+  description: "HCL Domino, formerly called IBM Domino (1995) and Lotus Domino (1989), is an enterprise server application development platform.",
+  cpe: "cpe:/a:ibm:lotus_domino",
+  rule: {
+    confidence: "high",
+    headers: {
+      "Server": "^Lotus-Domino$",
+    },
+  },
+  impliedSoftwares: [javaSignature.name],
+};

--- a/src/signatures/technologies/highlight_js.ts
+++ b/src/signatures/technologies/highlight_js.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+
+export const highlightSignature: Signature = {
+  name: "Highlight.js",
+  rule: {
+    confidence: "high",
+    urls: [
+      "/(?:([\\d.])+/)?highlight(?:\\.min)?\\.js",
+    ],
+    javascriptVariables: {
+      "hljs.highlightBlock": "",
+      "hljs.listLanguages": "",
+    },
+  },
+};

--- a/src/signatures/technologies/jetpack.ts
+++ b/src/signatures/technologies/jetpack.ts
@@ -1,0 +1,17 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const jetpackSignature: Signature = {
+  name: "Jetpack",
+  description: "Jetpack is a popular WordPress plugin created by Automattic, the people behind WordPress.com.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "href[^>]+\\/wp\\-content\\/plugins\\/jetpack\\/",
+    ],
+    urls: [
+      "/wp-content/plugins/jetpack/",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/jplayer.ts
+++ b/src/signatures/technologies/jplayer.ts
@@ -1,0 +1,18 @@
+import type { Signature } from "../_types.js";
+import { jquerySignature } from "./jquery.js";
+
+export const jplayerSignature: Signature = {
+  name: "jPlayer",
+  description: "jPlayer is a cross-browser JavaScript library developed as a jQuery plugin which facilitates the embedding of web based media, notably HTML5 audio and video in addition to Adobe Flash based media.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "/jquery\\.jplayer\\.min\\.js",
+      "jquery\\.jplayer\\.min\\.js",
+    ],
+    javascriptVariables: {
+      "jPlayerPlaylist": "",
+    },
+  },
+  impliedSoftwares: [jquerySignature.name],
+};

--- a/src/signatures/technologies/jquery_sparklines.ts
+++ b/src/signatures/technologies/jquery_sparklines.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+import { jquerySignature } from "./jquery.js";
+
+export const jquerySparklinesSignature: Signature = {
+  name: "jQuery Sparklines",
+  description: "jQuery Sparklines is a plugin that generates sparklines (small inline charts) directly in the browser using data supplied either inline in the HTML, or via javascript.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "jquery\\.sparkline.*\\.js",
+    ],
+  },
+  impliedSoftwares: [jquerySignature.name],
+};

--- a/src/signatures/technologies/jss.ts
+++ b/src/signatures/technologies/jss.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const jssSignature: Signature = {
+  name: "JSS",
+  description: "JSS is an authoring tool for CSS which allows you to use JavaScript to describe styles in a declarative, conflict-free and reusable way.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "data-jss",
+    ],
+  },
+};

--- a/src/signatures/technologies/linkedin_sign_in.ts
+++ b/src/signatures/technologies/linkedin_sign_in.ts
@@ -1,0 +1,16 @@
+import type { Signature } from "../_types.js";
+
+export const linkedinSignInSignature: Signature = {
+  name: "Linkedin Sign-in",
+  description: "Linkedin Sign-In is an authentication system that reduces the burden of login for users, by enabling them to sign in with their Linkedin account.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "platform\\.linkedin\\.com/(?:.*)?in\\.js(?:\\?version)?([\\d.]+)?",
+    ],
+    javascriptVariables: {
+      "OnLinkedInAuth": "",
+      "onLinkedInLoad": "",
+    },
+  },
+};

--- a/src/signatures/technologies/meteor.ts
+++ b/src/signatures/technologies/meteor.ts
@@ -1,0 +1,18 @@
+import type { Signature } from "../_types.js";
+import { mongoDbSignature } from "./mongodb.js";
+import { nodeJsSignature } from "./node_js.js";
+
+export const meteorSignature: Signature = {
+  name: "Meteor",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<link[^>]+__meteor-css__",
+    ],
+    javascriptVariables: {
+      "Meteor": "",
+      "Meteor.release": "^METEOR@([\\d.]+)",
+    },
+  },
+  impliedSoftwares: [mongoDbSignature.name, nodeJsSignature.name],
+};

--- a/src/signatures/technologies/metismenu.ts
+++ b/src/signatures/technologies/metismenu.ts
@@ -1,0 +1,18 @@
+import type { Signature } from "../_types.js";
+import { jquerySignature } from "./jquery.js";
+
+export const metismenuSignature: Signature = {
+  name: "metisMenu",
+  description: "metisMenu is a collapsible jQuery menu plugin.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "(?:/|\\.)metisMenu(?:js)?(?:\\.min)?\\.js(?:\\?([\\d\\.]+))?",
+    ],
+    javascriptVariables: {
+      "MetisMenu": "",
+      "metisMenu": "",
+    },
+  },
+  impliedSoftwares: [jquerySignature.name],
+};

--- a/src/signatures/technologies/microsoft_visual_studio.ts
+++ b/src/signatures/technologies/microsoft_visual_studio.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const microsoftVisualStudioSignature: Signature = {
+  name: "Microsoft Visual Studio",
+  description: "Microsoft Visual Studio is an integrated development environment from Microsoft.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<meta[^>]+name=[\"']generator[\"'][^>]+content=[\"']^Microsoft\\sVisual\\sStudio",
+    ],
+  },
+};

--- a/src/signatures/technologies/mongodb.ts
+++ b/src/signatures/technologies/mongodb.ts
@@ -1,0 +1,7 @@
+import type { Signature } from "../_types.js";
+
+export const mongodbSignature: Signature = {
+  name: "MongoDB",
+  description: "MongoDB is a document-oriented NoSQL database used for high volume data storage.",
+  cpe: "cpe:/a:mongodb:mongodb",
+};

--- a/src/signatures/technologies/moove_gdpr_consent.ts
+++ b/src/signatures/technologies/moove_gdpr_consent.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const mooveGdprConsentSignature: Signature = {
+  name: "Moove GDPR Consent",
+  description: "Moove GDPR Consent is a GDPR Cookie Compliance plugin for Wordpress.",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      "moove_frontend_gdpr_scripts": "",
+    },
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/muuri.ts
+++ b/src/signatures/technologies/muuri.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const muuriSignature: Signature = {
+  name: "Muuri",
+  description: "Muuri is a JavaScript layout engine that allows you to build all kinds of layouts and make them responsive, sortable, filterable, draggable and/or animated.",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      "Muuri": "",
+    },
+  },
+};

--- a/src/signatures/technologies/opencart.ts
+++ b/src/signatures/technologies/opencart.ts
@@ -1,0 +1,19 @@
+import type { Signature } from "../_types.js";
+import { phpSignature } from "./php.js";
+import { mysqlSignature } from "./mysql.js";
+
+export const opencartSignature: Signature = {
+  name: "OpenCart",
+  description: "OpenCart is a free and open-source ecommerce platform used for creating and managing online stores. It is written in PHP and uses a MySQL database to store information.",
+  cpe: "cpe:/a:opencart:opencart",
+  rule: {
+    confidence: "high",
+    cookies: {
+      "OCSESSID": "",
+    },
+    bodies: [
+      "href[^>]+catalog\\/view\\/theme\\/rgen\\-opencart\\/",
+    ],
+  },
+  impliedSoftwares: [phpSignature.name, mysqlSignature.name],
+};

--- a/src/signatures/technologies/outlook_web_app.ts
+++ b/src/signatures/technologies/outlook_web_app.ts
@@ -1,0 +1,24 @@
+import type { Signature } from "../_types.js";
+import { microsoftAspSignature } from "./microsoft_asp.js";
+
+export const outlookWebAppSignature: Signature = {
+  name: "Outlook Web App",
+  description: "Outlook on the web is an information manager web app. It includes a web-based email client, a calendar tool, a contact manager, and a task manager.",
+  cpe: "cpe:/a:microsoft:outlook_web_access",
+  rule: {
+    confidence: "high",
+    headers: {
+      "X-OWA-Version": "([\\d\\.]+)?",
+    },
+    bodies: [
+      "<link[^>]+/owa/auth/([\\d\\.]+)/themes/resources",
+    ],
+    urls: [
+      "/owa/auth/log(?:on|off)\\.aspx",
+    ],
+    javascriptVariables: {
+      "IsOwaPremiumBrowser": "",
+    },
+  },
+  impliedSoftwares: [microsoftAspSignature.name],
+};

--- a/src/signatures/technologies/play.ts
+++ b/src/signatures/technologies/play.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+import { scalaSignature } from "./scala.js";
+
+export const playSignature: Signature = {
+  name: "Play",
+  cpe: "cpe:/a:playframework:play_framework",
+  rule: {
+    confidence: "high",
+    cookies: {
+      "PLAY_SESSION": "",
+    },
+  },
+  impliedSoftwares: [scalaSignature.name],
+};

--- a/src/signatures/technologies/pulse_secure.ts
+++ b/src/signatures/technologies/pulse_secure.ts
@@ -1,0 +1,16 @@
+import type { Signature } from "../_types.js";
+
+export const pulseSecureSignature: Signature = {
+  name: "Pulse Secure",
+  description: "Pulse Secure allows to deploy VPNs to securely to your internal resources.",
+  cpe: "cpe:/a:pulsesecure:pulse_connect_secure",
+  rule: {
+    confidence: "high",
+    cookies: {
+      "DSSIGNIN": "",
+    },
+    urls: [
+      "/dana-na/auth/",
+    ],
+  },
+};

--- a/src/signatures/technologies/pure_css.ts
+++ b/src/signatures/technologies/pure_css.ts
@@ -1,0 +1,13 @@
+import type { Signature } from "../_types.js";
+
+export const pureCssSignature: Signature = {
+  name: "Pure CSS",
+  description: "Pure CSS is a set of small, responsive CSS modules that can be used in web projects.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<link[^>]+(?:([\\d.])+/)?pure(?:-min)?\\.css",
+      "<div[^>]+class=\"[^\"]*pure-u-(?:sm-|md-|lg-|xl-)?\\d-\\d",
+    ],
+  },
+};

--- a/src/signatures/technologies/redis.ts
+++ b/src/signatures/technologies/redis.ts
@@ -1,0 +1,7 @@
+import type { Signature } from "../_types.js";
+
+export const redisSignature: Signature = {
+  name: "Redis",
+  description: "Redis is an in-memory data structure project implementing a distributed, in-memory key–value database with optional durability. Redis supports different kinds of abstract data structures, such as strings, lists, maps, sets, sorted sets, HyperLogLogs, bitmaps, streams, and spatial indexes.",
+  cpe: "cpe:/a:redislabs:redis",
+};

--- a/src/signatures/technologies/remix.ts
+++ b/src/signatures/technologies/remix.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+import { reactSignature } from "./react.js";
+
+export const remixSignature: Signature = {
+  name: "Remix",
+  description: "Remix is a React framework used for server-side rendering (SSR).",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      "__remixContext": "",
+    },
+  },
+  impliedSoftwares: [reactSignature.name],
+};

--- a/src/signatures/technologies/salesforce_desk.ts
+++ b/src/signatures/technologies/salesforce_desk.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+
+export const salesforceDeskSignature: Signature = {
+  name: "Salesforce Desk",
+  description: "Salesforce Desk(Desk.com) is software as a service (SaaS) tool on the help desk.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "href[^>]+\\/s\\/sfsites\\/",
+    ],
+    urls: [
+      "^/s/sfsites/auraFW/",
+    ],
+  },
+};

--- a/src/signatures/technologies/salesforce_service_cloud.ts
+++ b/src/signatures/technologies/salesforce_service_cloud.ts
@@ -1,0 +1,17 @@
+import type { Signature } from "../_types.js";
+import { salesforceSignature } from "./salesforce.js";
+
+export const salesforceServiceCloudSignature: Signature = {
+  name: "Salesforce Service Cloud",
+  description: "Salesforce Service Cloud is a customer relationship management (CRM) platform for customer service and support.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "service\\.force\\.com",
+    ],
+    javascriptVariables: {
+      "embedded_svc": "",
+    },
+  },
+  impliedSoftwares: [salesforceSignature.name],
+};

--- a/src/signatures/technologies/scala.ts
+++ b/src/signatures/technologies/scala.ts
@@ -1,0 +1,6 @@
+import type { Signature } from "../_types.js";
+
+export const scalaSignature: Signature = {
+  name: "Scala",
+  description: "Scala is a general-purpose programming language providing support for both object-oriented programming and functional programming.",
+};

--- a/src/signatures/technologies/siteorigin_vantage.ts
+++ b/src/signatures/technologies/siteorigin_vantage.ts
@@ -1,0 +1,17 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const siteoriginVantageSignature: Signature = {
+  name: "SiteOrigin Vantage",
+  description: "SiteOrigin Vantage is a response, multi-purpose theme carefully developed with seamless integration into an array of amazing third-party plugins.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "vantage-style-css",
+    ],
+    urls: [
+      "/wp-content/themes/vantage/",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/sonarqubes.ts
+++ b/src/signatures/technologies/sonarqubes.ts
@@ -1,0 +1,23 @@
+import type { Signature } from "../_types.js";
+import { javaSignature } from "./java.js";
+
+export const sonarqubesSignature: Signature = {
+  name: "SonarQubes",
+  description: "SonarQube is an open-source platform for the continuous inspection of code quality to perform automatic reviews with static analysis of code to detect bugs, code smells, and security vulnerabilities on 20+ programming languages.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<link href=\"/css/sonar\\.css\\?v=([\\d.]+)",
+      "<title>SonarQube</title>",
+      "<meta[^>]+name=[\"']application-name[\"'][^>]+content=[\"']^SonarQubes$",
+    ],
+    urls: [
+      "^/js/bundles/sonar\\.js?v=([\\d.]+)$",
+    ],
+    javascriptVariables: {
+      "SonarMeasures": "",
+      "SonarRequest": "",
+    },
+  },
+  impliedSoftwares: [javaSignature.name],
+};

--- a/src/signatures/technologies/superpwa.ts
+++ b/src/signatures/technologies/superpwa.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+import { pwaSignature } from "./pwa.js";
+
+export const superpwaSignature: Signature = {
+  name: "SuperPWA",
+  description: "SuperPWA helps to easily convert your WordPress website into Progressive Web Apps instantly through our widely used PWA software without in coding.",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      "superpwa_sw": "",
+    },
+  },
+  impliedSoftwares: [wordpressSignature.name, pwaSignature.name],
+};

--- a/src/signatures/technologies/svelte.ts
+++ b/src/signatures/technologies/svelte.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const svelteSignature: Signature = {
+  name: "Svelte",
+  description: "Svelte is a free and open-source front end compiler created by Rich Harris and maintained by the Svelte core team members.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "class[^>]+svelte\\-",
+    ],
+  },
+};

--- a/src/signatures/technologies/svg_support.ts
+++ b/src/signatures/technologies/svg_support.ts
@@ -1,0 +1,17 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const svgSupportSignature: Signature = {
+  name: "SVG Support",
+  description: "SVG Support is a WordPress plugin which allows you to safely upload SVG files to your media library and use them like any other image.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "href[^>]+\\/wp\\-content\\/plugins\\/svg\\-support\\/",
+    ],
+    urls: [
+      "/wp-content/plugins/svg-support/",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/tengine.ts
+++ b/src/signatures/technologies/tengine.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const tengineSignature: Signature = {
+  name: "Tengine",
+  description: "Tengine is a web server which is based on the Nginx HTTP server.",
+  rule: {
+    confidence: "high",
+    headers: {
+      "Server": "Tengine",
+    },
+  },
+};

--- a/src/signatures/technologies/themegraphy_graphy.ts
+++ b/src/signatures/technologies/themegraphy_graphy.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const themegraphyGraphySignature: Signature = {
+  name: "Themegraphy Graphy",
+  description: "Themegraphy Graphy is now compatible with WordPress 5.0 and Gutenberg blog-oriented WordPress theme.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "/wp-content/themes/graphy(?:-pro)?/",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/twenty_sixteen.ts
+++ b/src/signatures/technologies/twenty_sixteen.ts
@@ -1,0 +1,17 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const twentySixteenSignature: Signature = {
+  name: "Twenty Sixteen",
+  description: "Twenty Sixteen is the default WordPress theme for 2016.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "twentysixteen-style-css",
+    ],
+    urls: [
+      "/wp-content/themes/twentysixteen/",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/twitter_typeahead_js.ts
+++ b/src/signatures/technologies/twitter_typeahead_js.ts
@@ -1,0 +1,16 @@
+import type { Signature } from "../_types.js";
+import { jquerySignature } from "./jquery.js";
+
+export const twitterTypeaheadSignature: Signature = {
+  name: "Twitter typeahead.js",
+  rule: {
+    confidence: "high",
+    urls: [
+      "(?:typeahead|bloodhound)\\.(?:jquery|bundle)?(?:\\.min)?\\.js",
+    ],
+    javascriptVariables: {
+      "typeahead": "",
+    },
+  },
+  impliedSoftwares: [jquerySignature.name],
+};

--- a/src/signatures/technologies/typepad.ts
+++ b/src/signatures/technologies/typepad.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+
+export const typepadSignature: Signature = {
+  name: "TypePad",
+  description: "Typepad is a blog hosting service.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<meta[^>]+name=[\"']generator[\"'][^>]+content=[\"']typepad",
+    ],
+    urls: [
+      "typepad\\.com",
+    ],
+  },
+};

--- a/src/signatures/technologies/wink.ts
+++ b/src/signatures/technologies/wink.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+
+export const winkSignature: Signature = {
+  name: "Wink",
+  description: "Wink Toolkit is a JavaScript toolkit used to build mobile web apps.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "(?:_base/js/base|wink).*\\.js",
+    ],
+    javascriptVariables: {
+      "wink.version": "^(.+)$",
+    },
+  },
+};

--- a/src/signatures/technologies/woocommerce_stripe_payment_gateway.ts
+++ b/src/signatures/technologies/woocommerce_stripe_payment_gateway.ts
@@ -1,0 +1,18 @@
+import type { Signature } from "../_types.js";
+import { stripeSignature } from "./stripe.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const woocommerceStripePaymentGatewaySignature: Signature = {
+  name: "WooCommerce Stripe Payment Gateway",
+  description: "WooCommerce Stripe Payment Gateway plugin extends WooCommerce allowing you to take payments directly on your store via Stripe’s API.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "href[^>]+\\/wp\\-content\\/plugins\\/woocommerce\\-gateway\\-stripe\\/",
+    ],
+    urls: [
+      "/wp-content/plugins/woocommerce-gateway-stripe/",
+    ],
+  },
+  impliedSoftwares: [stripeSignature.name, wordpressSignature.name],
+};

--- a/src/signatures/technologies/yii.ts
+++ b/src/signatures/technologies/yii.ts
@@ -1,0 +1,23 @@
+import type { Signature } from "../_types.js";
+import { phpSignature } from "./php.js";
+
+export const yiiSignature: Signature = {
+  name: "Yii",
+  description: "Yii is an open-source, object-oriented, component-based MVC PHP web application framework.",
+  rule: {
+    confidence: "high",
+    cookies: {
+      "YII_CSRF_TOKEN": "",
+    },
+    bodies: [
+      "Powered by <a href=\"http://www\\.yiiframework\\.com/\" rel=\"external\">Yii Framework</a>",
+      "<input type=\"hidden\" value=\"[a-zA-Z0-9]{40}\" name=\"YII_CSRF_TOKEN\" \\/>",
+      "<!\\[CDATA\\[YII-BLOCK-(?:HEAD|BODY-BEGIN|BODY-END)\\]",
+    ],
+    urls: [
+      "/assets/[a-zA-Z0-9]{8}\\/yii\\.js$",
+      "/yii\\.(?:validation|activeForm)\\.js",
+    ],
+  },
+  impliedSoftwares: [phpSignature.name],
+};


### PR DESCRIPTION
## Summary
- add signatures for requested frameworks, plugins, servers, and platforms (Yii, OpenCart, AEM, etc.)
- include WordPress plugin/theme detections and related framework implications
- register all new signatures in the index

## Testing
- not run