### PR TITLE
feat: add wappalyzer signatures

### DIFF
--- a/src/signatures/index.ts
+++ b/src/signatures/index.ts
@@ -354,6 +354,56 @@ import { gliderSignature } from "./technologies/glider_js.js";
 import { coreuiSignature } from "./technologies/coreui.js";
 import { redisSignature } from "./technologies/redis.js";
 import { themegraphyGraphySignature } from "./technologies/themegraphy_graphy.js";
+import { essentialAddonsForElementorSignature } from "./technologies/essential_addons_for_elementor.js";
+import { listSignature } from "./technologies/list_js.js";
+import { channelIoSignature } from "./technologies/channel_io.js";
+import { instantPageSignature } from "./technologies/instant_page.js";
+import { kineticjsSignature } from "./technologies/kineticjs.js";
+import { phppgadminSignature } from "./technologies/phppgadmin.js";
+import { apexchartsSignature } from "./technologies/apexcharts_js.js";
+import { microcmsSignature } from "./technologies/microcms.js";
+import { pagekitSignature } from "./technologies/pagekit.js";
+import { microsoftWordSignature } from "./technologies/microsoft_word.js";
+import { echartsSignature } from "./technologies/echarts.js";
+import { fusionchartsSignature } from "./technologies/fusioncharts.js";
+import { googleWebToolkitSignature } from "./technologies/google_web_toolkit.js";
+import { extendthemesMesmerizeSignature } from "./technologies/extendthemes_mesmerize.js";
+import { xenforoSignature } from "./technologies/xenforo.js";
+import { twentyTwentySignature } from "./technologies/twenty_twenty.js";
+import { choicesSignature } from "./technologies/choices.js";
+import { adobeColdfusionSignature } from "./technologies/adobe_coldfusion.js";
+import { cfmlSignature } from "./technologies/cfml.js";
+import { sapCustomerDataCloudSignInSignature } from "./technologies/sap_customer_data_cloud_sign_in.js";
+import { twentyFifteenSignature } from "./technologies/twenty_fifteen.js";
+import { glideSignature } from "./technologies/glide_js.js";
+import { lazysizesUnveilhooksPluginSignature } from "./technologies/lazy_sizes_unveilhooks_plugin.js";
+import { algoliaSignature } from "./technologies/algolia.js";
+import { flyingPagesSignature } from "./technologies/flying_pages.js";
+import { mermaidSignature } from "./technologies/mermaid.js";
+import { zimbraSignature } from "./technologies/zimbra.js";
+import { draftpressHfcmSignature } from "./technologies/draftpress_hfcm.js";
+import { csCartSignature } from "./technologies/cs_cart.js";
+import { libphonenumberSignature } from "./technologies/libphonenumber.js";
+import { chakraUiSignature } from "./technologies/chakra_ui.js";
+import { googleWebServerSignature } from "./technologies/google_web_server.js";
+import { opengseSignature } from "./technologies/opengse.js";
+import { springSignature } from "./technologies/spring.js";
+import { misskeySignature } from "./technologies/misskey.js";
+import { themebeezCreamMagazineSignature } from "./technologies/themebeez_cream_magazine.js";
+import { htmxSignature } from "./technologies/htmx.js";
+import { bricksSignature } from "./technologies/bricks.js";
+import { seedprodComingSoonSignature } from "./technologies/seedprod_coming_soon.js";
+import { mobxSignature } from "./technologies/mobx.js";
+import { cafe24Signature } from "./technologies/cafe24.js";
+import { twentyNineteenSignature } from "./technologies/twenty_nineteen.js";
+import { cyberchimpsResponsiveSignature } from "./technologies/cyberchimps_responsive.js";
+import { genesisThemeSignature } from "./technologies/genesis_theme.js";
+import { tdesignSignature } from "./technologies/tdesign.js";
+import { xchartsSignature } from "./technologies/xcharts.js";
+import { loginWithAmazonSignature } from "./technologies/login_with_amazon.js";
+import { howlerSignature } from "./technologies/howler_js.js";
+import { ultimatelysocialSignature } from "./technologies/ultimatelysocial.js";
+import { intercomSignature } from "./technologies/intercom.js";
 
 export const signatures: Signature[] = [
   addToAnySignature,
@@ -710,4 +760,54 @@ export const signatures: Signature[] = [
   coreuiSignature,
   redisSignature,
   themegraphyGraphySignature,
+  essentialAddonsForElementorSignature,
+  listSignature,
+  channelIoSignature,
+  instantPageSignature,
+  kineticjsSignature,
+  phppgadminSignature,
+  apexchartsSignature,
+  microcmsSignature,
+  pagekitSignature,
+  microsoftWordSignature,
+  echartsSignature,
+  fusionchartsSignature,
+  googleWebToolkitSignature,
+  extendthemesMesmerizeSignature,
+  xenforoSignature,
+  twentyTwentySignature,
+  choicesSignature,
+  adobeColdfusionSignature,
+  cfmlSignature,
+  sapCustomerDataCloudSignInSignature,
+  twentyFifteenSignature,
+  glideSignature,
+  lazysizesUnveilhooksPluginSignature,
+  algoliaSignature,
+  flyingPagesSignature,
+  mermaidSignature,
+  zimbraSignature,
+  draftpressHfcmSignature,
+  csCartSignature,
+  libphonenumberSignature,
+  chakraUiSignature,
+  googleWebServerSignature,
+  opengseSignature,
+  springSignature,
+  misskeySignature,
+  themebeezCreamMagazineSignature,
+  htmxSignature,
+  bricksSignature,
+  seedprodComingSoonSignature,
+  mobxSignature,
+  cafe24Signature,
+  twentyNineteenSignature,
+  cyberchimpsResponsiveSignature,
+  genesisThemeSignature,
+  tdesignSignature,
+  xchartsSignature,
+  loginWithAmazonSignature,
+  howlerSignature,
+  ultimatelysocialSignature,
+  intercomSignature,
 ];

--- a/src/signatures/technologies/adobe_coldfusion.ts
+++ b/src/signatures/technologies/adobe_coldfusion.ts
@@ -1,0 +1,24 @@
+import type { Signature } from "../_types.js";
+import { cfmlSignature } from "./cfml.js";
+
+export const adobeColdfusionSignature: Signature = {
+  name: "Adobe ColdFusion",
+  cpe: "cpe:/a:adobe:coldfusion",
+  rule: {
+    confidence: "high",
+    headers: {
+      "Cookie": "CFTOKEN=",
+    },
+    bodies: [
+      "<!-- START headerTags\\.cfm",
+    ],
+    urls: [
+      "/cfajax/",
+      "\\.cfm(?:$|\\?)",
+    ],
+    javascriptVariables: {
+      "_cfEmails": "",
+    },
+  },
+  impliedSoftwares: [cfmlSignature.name],
+};

--- a/src/signatures/technologies/algolia.ts
+++ b/src/signatures/technologies/algolia.ts
@@ -1,0 +1,23 @@
+import type { Signature } from "../_types.js";
+
+export const algoliaSignature: Signature = {
+  name: "Algolia",
+  description: "Algolia offers a hosted web search product delivering real-time results.",
+  rule: {
+    confidence: "high",
+    headers: {
+      "Content-Security-Policy": "\\.algolia",
+    },
+    cookies: {
+      "_ALGOLIA": "",
+    },
+    javascriptVariables: {
+      "ALGOLIA_INSIGHTS_SRC": "",
+      "AlgoliaSearch": "",
+      "__GLOBAL__.algolia": "",
+      "__NEXT_DATA__.props.pageProps.appSettings.ALGOLIA_APP_ID": "",
+      "__algolia": "",
+      "algoliasearch.version": "^(.+)$",
+    },
+  },
+};

--- a/src/signatures/technologies/apexcharts_js.ts
+++ b/src/signatures/technologies/apexcharts_js.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const apexchartsSignature: Signature = {
+  name: "ApexCharts.js",
+  description: "ApexCharts is a modern JavaScript charting library that empowers developers to build interactive data visualizations for commercial and non-commercial projects.",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      "ApexCharts": "",
+    },
+  },
+};

--- a/src/signatures/technologies/bricks.ts
+++ b/src/signatures/technologies/bricks.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const bricksSignature: Signature = {
+  name: "Bricks",
+  description: "Bricks is a premium WordPress theme that lets you visually build performant WordPress sites.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "/wp-content/themes/bricks/assets/",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/cafe24.ts
+++ b/src/signatures/technologies/cafe24.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+
+export const cafe24Signature: Signature = {
+  name: "Cafe24",
+  description: "Cafe24 is a global ecommerce platform that provides everything people need to build an online DTC store in one stop.",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      "EC_GLOBAL_DATETIME": "",
+      "EC_GLOBAL_INFO": "",
+      "EC_ROOT_DOMAIN": "",
+    },
+  },
+};

--- a/src/signatures/technologies/cfml.ts
+++ b/src/signatures/technologies/cfml.ts
@@ -1,0 +1,6 @@
+import type { Signature } from "../_types.js";
+
+export const cfmlSignature: Signature = {
+  name: "CFML",
+  description: "ColdFusion Markup Language (CFML), is a scripting language for web development that runs on the JVM, the .NET framework, and Google App Engine.",
+};

--- a/src/signatures/technologies/chakra_ui.ts
+++ b/src/signatures/technologies/chakra_ui.ts
@@ -1,0 +1,20 @@
+import type { Signature } from "../_types.js";
+import { reactSignature } from "./react.js";
+
+export const chakraUiSignature: Signature = {
+  name: "Chakra UI",
+  description: "Chakra UI is a simple, modular and accessible component library that gives you the building blocks you need to build your React applications.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "style[^>]+chakra\\-ui\\-color\\-mode",
+      "chakra-ui-dark",
+      "chakra-ui-light",
+      "chakra-portal",
+    ],
+    urls: [
+      "\\.chakra-ui\\.",
+    ],
+  },
+  impliedSoftwares: [reactSignature.name],
+};

--- a/src/signatures/technologies/channel_io.ts
+++ b/src/signatures/technologies/channel_io.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const channelIoSignature: Signature = {
+  name: "Channel.io",
+  description: "Channel.io is an all-in-one business communication platform that helps businesses connect with customers.",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      "ChannelIO": "",
+    },
+  },
+};

--- a/src/signatures/technologies/choices.ts
+++ b/src/signatures/technologies/choices.ts
@@ -1,0 +1,16 @@
+import type { Signature } from "../_types.js";
+
+export const choicesSignature: Signature = {
+  name: "Choices",
+  description: "Choices.js is a lightweight, configurable select box/text input plugin.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "choices\\.js(?:@|/)?([\\d\\.]+)?.+choices\\.min\\.js",
+      "/modules/choices/js/choices\\.js",
+    ],
+    javascriptVariables: {
+      "Choices": "",
+    },
+  },
+};

--- a/src/signatures/technologies/cs_cart.ts
+++ b/src/signatures/technologies/cs_cart.ts
@@ -1,0 +1,25 @@
+import type { Signature } from "../_types.js";
+import { phpSignature } from "./php.js";
+
+export const csCartSignature: Signature = {
+  name: "CS Cart",
+  description: "CS Cart is a turnkey ecommerce shopping cart software solution.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "href[^>]+.cs\\-cart.com",
+      "target[^>]+_blank",
+      "cs-cart",
+      "com",
+    ],
+    urls: [
+      "var/cache/misc/assets/js/tygh/scripts-(?:[\\d\\w]+)\\.js",
+    ],
+    javascriptVariables: {
+      "fn_buy_together_apply_discount": "",
+      "fn_calculate_total_shipping": "",
+      "fn_compare_strings": "",
+    },
+  },
+  impliedSoftwares: [phpSignature.name],
+};

--- a/src/signatures/technologies/cyberchimps_responsive.ts
+++ b/src/signatures/technologies/cyberchimps_responsive.ts
@@ -1,0 +1,18 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const cyberchimpsResponsiveSignature: Signature = {
+  name: "CyberChimps Responsive",
+  description: "CyberChimps Responsive is a modern, lightweight, fully customizable, fast and responsive WordPress theme.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "href[^>]+\\/wp\\-content\\/themes\\/responsive\\/",
+      "href[^>]+\\/wp\\-content\\/themes\\/responsivepro\\/",
+    ],
+    urls: [
+      "/wp-content/themes/responsive(?:pro)?/",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/draftpress_hfcm.ts
+++ b/src/signatures/technologies/draftpress_hfcm.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const draftpressHfcmSignature: Signature = {
+  name: "Draftpress HFCM",
+  description: "Header Footer Code Manager by Draftpress is a easy interface to add snippets to the header or footer or above or below the content of your page.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<!--[^>]*HFCM\\sby\\s99\\sRobots",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/echarts.ts
+++ b/src/signatures/technologies/echarts.ts
@@ -1,0 +1,17 @@
+import type { Signature } from "../_types.js";
+
+export const echartsSignature: Signature = {
+  name: "ECharts",
+  description: "ECharts is an open-source JavaScript visualisation library.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "_echarts_instance_",
+    ],
+    urls: [
+      "/echarts\\.min\\.[a-zA-Z0-9]*\\.js",
+      "/echarts(?:\\.simple)?(?:\\.esm)?(?:\\.common)?(?:\\.min)?\\.js",
+      "cdn\\.jsdelivr\\.net/(?:npm|gh/apache)/echarts@([\\d.]+(?:-[^/]+)?|latest)/dist/echarts.*\\.js",
+    ],
+  },
+};

--- a/src/signatures/technologies/essential_addons_for_elementor.ts
+++ b/src/signatures/technologies/essential_addons_for_elementor.ts
@@ -1,0 +1,17 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const essentialAddonsForElementorSignature: Signature = {
+  name: "Essential Addons for Elementor",
+  description: "Essential Addons for Elementor gives you 70+ creative elements and extensions to help you extend the stock features of Elementor page builder.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "href[^>]+\\/wp\\-content\\/uploads\\/essential\\-addons\\-elementor\\/",
+    ],
+    urls: [
+      "/wp-content/uploads/essential-addons-elementor/",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/extendthemes_mesmerize.ts
+++ b/src/signatures/technologies/extendthemes_mesmerize.ts
@@ -1,0 +1,23 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const extendthemesMesmerizeSignature: Signature = {
+  name: "ExtendThemes Mesmerize",
+  description: "ExtendThemes Mesmerize is an flexible, multipurpose WordPress theme.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "mesmerize-style-css",
+    ],
+    urls: [
+      "/wp-content/themes/mesmerize(?:-pro)?/",
+    ],
+    javascriptVariables: {
+      "MesmerizeKube": "",
+      "mesmerizeDomReady": "",
+      "mesmerizeFooterParalax": "",
+      "mesmerizeMenuSticky": "",
+    },
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/flying_pages.ts
+++ b/src/signatures/technologies/flying_pages.ts
@@ -1,0 +1,20 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const flyingPagesSignature: Signature = {
+  name: "Flying Pages",
+  description: "Flying Pages is a performance optimisation plugin for WordPress websites designed to reduce page load times and improve the user experience.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "href[^>]+\\/wp\\-content\\/plugins\\/flying\\-pages\\/",
+    ],
+    urls: [
+      "/wp-content/plugins/flying-pages/.+\\.js(?:\\?ver=([\\d\\.]+))?",
+    ],
+    javascriptVariables: {
+      "flyingPages": "",
+    },
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/fusioncharts.ts
+++ b/src/signatures/technologies/fusioncharts.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+
+export const fusionchartsSignature: Signature = {
+  name: "FusionCharts",
+  description: "FusionCharts is a comprehensive charting solution for websites.",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      "FusionCharts": "",
+      "FusionChartsDataFormats": "",
+      "FusionMaps": "",
+    },
+  },
+};

--- a/src/signatures/technologies/genesis_theme.ts
+++ b/src/signatures/technologies/genesis_theme.ts
@@ -1,0 +1,18 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const genesisThemeSignature: Signature = {
+  name: "Genesis theme",
+  description: "Genesis theme is a WordPress theme that has been developed using the Genesis Framework from Studiopress.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "/wp-content/themes/genesis/lib/js/",
+    ],
+    javascriptVariables: {
+      "genesisBlocksShare": "",
+      "genesis_responsive_menu": "",
+    },
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/glide_js.ts
+++ b/src/signatures/technologies/glide_js.ts
@@ -1,0 +1,18 @@
+import type { Signature } from "../_types.js";
+
+export const glideSignature: Signature = {
+  name: "Glide.js",
+  description: "Glide.js is a dependency-free JavaScript ES6 slider and carousel.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "data-glide-el",
+    ],
+    urls: [
+      "/@glidejs/glide(?:@([\\d\\.]+))?",
+    ],
+    javascriptVariables: {
+      "Glide": "",
+    },
+  },
+};

--- a/src/signatures/technologies/google_web_server.ts
+++ b/src/signatures/technologies/google_web_server.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const googleWebServerSignature: Signature = {
+  name: "Google Web Server",
+  cpe: "cpe:/a:google:web_server",
+  rule: {
+    confidence: "high",
+    headers: {
+      "Server": "gws",
+    },
+  },
+};

--- a/src/signatures/technologies/google_web_toolkit.ts
+++ b/src/signatures/technologies/google_web_toolkit.ts
@@ -1,0 +1,23 @@
+import type { Signature } from "../_types.js";
+import { javaSignature } from "./java.js";
+
+export const googleWebToolkitSignature: Signature = {
+  name: "Google Web Toolkit",
+  description: "Google Web Toolkit (GWT) is an open-source Java software development framework that makes writing AJAX applications.",
+  cpe: "cpe:/a:google:web_toolkit",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<meta[^>]+name=[\"']gwt:property[\"']",
+    ],
+    javascriptVariables: {
+      "__gwt_": "",
+      "__gwt_activeModules": "",
+      "__gwt_getMetaProperty": "",
+      "__gwt_isKnownPropertyValue": "",
+      "__gwt_stylesLoaded": "",
+      "__gwtlistener": "",
+    },
+  },
+  impliedSoftwares: [javaSignature.name],
+};

--- a/src/signatures/technologies/howler_js.ts
+++ b/src/signatures/technologies/howler_js.ts
@@ -1,0 +1,17 @@
+import type { Signature } from "../_types.js";
+
+export const howlerSignature: Signature = {
+  name: "Howler.js",
+  description: "Howler.js is an audio library with support for the Web Audio API and a fallback mechanism for HTML5 Audio.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "howler@([\\d.]+)/dist/howler\\.min\\.js",
+      "howler/([\\d.]+)/howler(?:\\.core)?\\.min\\.js",
+    ],
+    javascriptVariables: {
+      "Howler": "",
+      "HowlerGlobal": "",
+    },
+  },
+};

--- a/src/signatures/technologies/htmx.ts
+++ b/src/signatures/technologies/htmx.ts
@@ -1,0 +1,20 @@
+import type { Signature } from "../_types.js";
+
+export const htmxSignature: Signature = {
+  name: "Htmx",
+  description: "Htmx is a JavaScript library for performing AJAX requests, triggering CSS transitions, and invoking WebSocket and server-sent events directly from HTML elements.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "data-src[^>]+\\/dist\\/htmx.min.js",
+      "min",
+      "js",
+    ],
+    urls: [
+      "/htmx\\.org@([\\d\\.]+)",
+    ],
+    javascriptVariables: {
+      "htmx": "",
+    },
+  },
+};

--- a/src/signatures/technologies/htmx.ts
+++ b/src/signatures/technologies/htmx.ts
@@ -7,8 +7,7 @@ export const htmxSignature: Signature = {
     confidence: "high",
     bodies: [
       "data-src[^>]+\\/dist\\/htmx.min.js",
-      "min",
-      "js",
+      "hx-(?:get|post|put|delete|patch|boost|trigger|swap|target|include|vals|confirm)=",
     ],
     urls: [
       "/htmx\\.org@([\\d\\.]+)",

--- a/src/signatures/technologies/instant_page.ts
+++ b/src/signatures/technologies/instant_page.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const instantPageSignature: Signature = {
+  name: "Instant.Page",
+  description: "Instant.Page is a JavaScript library which uses just-in-time preloading technique to make websites faster.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "instant\\.page",
+    ],
+  },
+};

--- a/src/signatures/technologies/intercom.ts
+++ b/src/signatures/technologies/intercom.ts
@@ -7,8 +7,6 @@ export const intercomSignature: Signature = {
     confidence: "high",
     bodies: [
       "href[^>]+https:\\/\\/widget.intercom.io",
-      "intercom",
-      "io",
       "live-chat-loader-placeholder",
       "intercom-frame",
     ],

--- a/src/signatures/technologies/intercom.ts
+++ b/src/signatures/technologies/intercom.ts
@@ -1,0 +1,22 @@
+import type { Signature } from "../_types.js";
+
+export const intercomSignature: Signature = {
+  name: "Intercom",
+  description: "Intercom is an American software company that produces a messaging platform which allows businesses to communicate with prospective and existing customers within their app, on their website, through social media, or via email.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "href[^>]+https:\\/\\/widget.intercom.io",
+      "intercom",
+      "io",
+      "live-chat-loader-placeholder",
+      "intercom-frame",
+    ],
+    urls: [
+      "(?:api\\.intercom\\.io/api|static\\.intercomcdn\\.com/intercom\\.v1)",
+    ],
+    javascriptVariables: {
+      "Intercom": "",
+    },
+  },
+};

--- a/src/signatures/technologies/kineticjs.ts
+++ b/src/signatures/technologies/kineticjs.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+
+export const kineticjsSignature: Signature = {
+  name: "KineticJS",
+  rule: {
+    confidence: "high",
+    urls: [
+      "kinetic(?:-v?([\\d.]+))?(?:\\.min)?\\.js",
+    ],
+    javascriptVariables: {
+      "Kinetic": "",
+      "Kinetic.version": "^(.+)$",
+    },
+  },
+};

--- a/src/signatures/technologies/lazy_sizes_unveilhooks_plugin.ts
+++ b/src/signatures/technologies/lazy_sizes_unveilhooks_plugin.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const lazysizesUnveilhooksPluginSignature: Signature = {
+  name: "LazySizes unveilhooks plugin",
+  description: "LazySizes unveilhooks plugin extends lazySizes to lazyload scripts/widgets, background images, styles and video/audio elements.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "ls\\.unveilhooks(?:\\.min)?\\.js",
+    ],
+  },
+};

--- a/src/signatures/technologies/libphonenumber.ts
+++ b/src/signatures/technologies/libphonenumber.ts
@@ -1,0 +1,16 @@
+import type { Signature } from "../_types.js";
+
+export const libphonenumberSignature: Signature = {
+  name: "libphonenumber",
+  description: "libphonenumber is a JavaScript library for parsing, formatting, and validating international phone numbers.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "(?:/([\\d\\.]+))?/libphonenumber(?:-js\\.min)?\\.js",
+    ],
+    javascriptVariables: {
+      "libphonenumber.AsYouType": "",
+      "libphonenumber.DIGITS": "",
+    },
+  },
+};

--- a/src/signatures/technologies/list_js.ts
+++ b/src/signatures/technologies/list_js.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+
+export const listSignature: Signature = {
+  name: "List.js",
+  rule: {
+    confidence: "high",
+    urls: [
+      "list\\.js/",
+      "@([\\d.]+)/(?:/dist)?list\\.(?:min\\.)?js",
+    ],
+    javascriptVariables: {
+      "List": "",
+    },
+  },
+};

--- a/src/signatures/technologies/login_with_amazon.ts
+++ b/src/signatures/technologies/login_with_amazon.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const loginWithAmazonSignature: Signature = {
+  name: "Login with Amazon",
+  description: "Login with Amazon allows you use your Amazon user name and password to sign into and share information with participating third-party websites or apps.",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      "onAmazonLoginReady": "",
+    },
+  },
+};

--- a/src/signatures/technologies/mermaid.ts
+++ b/src/signatures/technologies/mermaid.ts
@@ -1,0 +1,17 @@
+import type { Signature } from "../_types.js";
+
+export const mermaidSignature: Signature = {
+  name: "Mermaid",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<div [^>]*class=[\"']mermaid[\"']>",
+    ],
+    urls: [
+      "/mermaid(?:\\.min)?\\.js",
+    ],
+    javascriptVariables: {
+      "mermaid": "",
+    },
+  },
+};

--- a/src/signatures/technologies/microcms.ts
+++ b/src/signatures/technologies/microcms.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+
+export const microcmsSignature: Signature = {
+  name: "microCMS",
+  description: "microCMS is a Japan-based headless CMS that enables editors and developers to build delicate sites and apps.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "src[^>]+.microcms\\-assets.io\\/",
+      "microcms-assets",
+      "io",
+    ],
+  },
+};

--- a/src/signatures/technologies/microsoft_word.ts
+++ b/src/signatures/technologies/microsoft_word.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+
+export const microsoftWordSignature: Signature = {
+  name: "Microsoft Word",
+  description: "MS Word is a word-processing program used primarily for creating documents.",
+  cpe: "cpe:/a:microsoft:word",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "(?:<html [^>]*xmlns:w=\"urn:schemas-microsoft-com:office:word\"|<w:WordDocument>|<div [^>]*class=\"?WordSection1[\" >]|<style[^>]*>[^>]*@page WordSection1)",
+      "<meta[^>]+name=[\"']ProgId[\"'][^>]+content=[\"']^Word\\.",
+      "<meta[^>]+name=[\"']generator[\"'][^>]+content=[\"']Microsoft Word( [\\d.]+)?",
+    ],
+  },
+};

--- a/src/signatures/technologies/misskey.ts
+++ b/src/signatures/technologies/misskey.ts
@@ -1,0 +1,13 @@
+import type { Signature } from "../_types.js";
+
+export const misskeySignature: Signature = {
+  name: "Misskey",
+  description: "Misskey is a distributed microblogging platform.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<!-- Thank you for using Misskey! @syuilo -->",
+      "<meta[^>]+name=[\"']application-name[\"'][^>]+content=[\"']Misskey",
+    ],
+  },
+};

--- a/src/signatures/technologies/mobx.ts
+++ b/src/signatures/technologies/mobx.ts
@@ -1,0 +1,16 @@
+import type { Signature } from "../_types.js";
+
+export const mobxSignature: Signature = {
+  name: "MobX",
+  rule: {
+    confidence: "high",
+    urls: [
+      "(?:/([\\d\\.]+))?/mobx(?:\\.[a-z]+){0,2}\\.js(?:$|\\?)",
+    ],
+    javascriptVariables: {
+      "__mobxGlobal": "",
+      "__mobxGlobals": "",
+      "__mobxInstanceCount": "",
+    },
+  },
+};

--- a/src/signatures/technologies/opengse.ts
+++ b/src/signatures/technologies/opengse.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+import { javaSignature } from "./java.js";
+
+export const opengseSignature: Signature = {
+  name: "OpenGSE",
+  description: "OpenGSE is a test suite used for testing servlet compliance. It is deployed by using WAR files that are deployed on the server engine.",
+  rule: {
+    confidence: "high",
+    headers: {
+      "Server": "GSE",
+    },
+  },
+  impliedSoftwares: [javaSignature.name],
+};

--- a/src/signatures/technologies/pagekit.ts
+++ b/src/signatures/technologies/pagekit.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const pagekitSignature: Signature = {
+  name: "Pagekit",
+  cpe: "cpe:/a:pagekit:pagekit",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<meta[^>]+name=[\"']generator[\"'][^>]+content=[\"']Pagekit",
+    ],
+  },
+};

--- a/src/signatures/technologies/phppgadmin.ts
+++ b/src/signatures/technologies/phppgadmin.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+import { phpSignature } from "./php.js";
+
+export const phppgadminSignature: Signature = {
+  name: "phpPgAdmin",
+  cpe: "cpe:/a:phppgadmin_project:phppgadmin",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "(?:<title>phpPgAdmin</title>|<span class=\"appname\">phpPgAdmin)",
+    ],
+  },
+  impliedSoftwares: [phpSignature.name],
+};

--- a/src/signatures/technologies/sap_customer_data_cloud_sign_in.ts
+++ b/src/signatures/technologies/sap_customer_data_cloud_sign_in.ts
@@ -1,0 +1,11 @@
+import type { Signature } from "../_types.js";
+
+export const sapCustomerDataCloudSignInSignature: Signature = {
+  name: "SAP Customer Data Cloud Sign-in",
+  rule: {
+    confidence: "high",
+    urls: [
+      "\\.gigya\\.com/JS/gigya\\.js",
+    ],
+  },
+};

--- a/src/signatures/technologies/seedprod_coming_soon.ts
+++ b/src/signatures/technologies/seedprod_coming_soon.ts
@@ -1,0 +1,17 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const seedprodComingSoonSignature: Signature = {
+  name: "SeedProd Coming Soon",
+  description: "SeedProd Coming Soon is a page builder allows you to add a new website under construction page to your WordPress site without hiring a developer.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "href[^>]+\\/wp\\-content\\/plugins\\/coming\\-soon\\/",
+    ],
+    urls: [
+      "/wp-content/plugins/coming-soon/",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/spring.ts
+++ b/src/signatures/technologies/spring.ts
@@ -1,0 +1,13 @@
+import type { Signature } from "../_types.js";
+import { javaSignature } from "./java.js";
+
+export const springSignature: Signature = {
+  name: "Spring",
+  rule: {
+    confidence: "high",
+    headers: {
+      "X-Application-Context": "",
+    },
+  },
+  impliedSoftwares: [javaSignature.name],
+};

--- a/src/signatures/technologies/tdesign.ts
+++ b/src/signatures/technologies/tdesign.ts
@@ -1,0 +1,16 @@
+import type { Signature } from "../_types.js";
+
+export const tdesignSignature: Signature = {
+  name: "TDesign",
+  description: "TDesign launched by Tencent contains rich and reusable design component resources, such as color system, text system, motion design, etc.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "t-button__text",
+      "t-layout",
+    ],
+    urls: [
+      "tdesign\\.gtimg\\.com/",
+    ],
+  },
+};

--- a/src/signatures/technologies/themebeez_cream_magazine.ts
+++ b/src/signatures/technologies/themebeez_cream_magazine.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const themebeezCreamMagazineSignature: Signature = {
+  name: "Themebeez Cream Magazine",
+  description: "Cream Magazine is a news and magazine WordPress theme by Themebeez.",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      "cream_magazine_script_obj": "",
+    },
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/twenty_fifteen.ts
+++ b/src/signatures/technologies/twenty_fifteen.ts
@@ -1,0 +1,17 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const twentyFifteenSignature: Signature = {
+  name: "Twenty Fifteen",
+  description: "Twenty Fifteen is the default WordPress theme for 2015.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "twentyfifteen-style-css",
+    ],
+    urls: [
+      "/wp-content/themes/twentyfifteen/",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/twenty_nineteen.ts
+++ b/src/signatures/technologies/twenty_nineteen.ts
@@ -1,0 +1,17 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const twentyNineteenSignature: Signature = {
+  name: "Twenty Nineteen",
+  description: "Twenty Nineteen is the default WordPress theme for 2019.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "twentynineteen-style-css",
+    ],
+    urls: [
+      "/wp-content/themes/twentynineteen/",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/twenty_twenty.ts
+++ b/src/signatures/technologies/twenty_twenty.ts
@@ -1,0 +1,20 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const twentyTwentySignature: Signature = {
+  name: "Twenty Twenty",
+  description: "Twenty Twenty is the default WordPress theme for 2020.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "twentytwenty-style-css",
+    ],
+    urls: [
+      "/wp-content/themes/twentytwenty/",
+    ],
+    javascriptVariables: {
+      "twentytwenty": "",
+    },
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/ultimatelysocial.ts
+++ b/src/signatures/technologies/ultimatelysocial.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const ultimatelysocialSignature: Signature = {
+  name: "UltimatelySocial",
+  description: "Ultimately Social (Share Buttons & Sharing Icons) is a plugin that allows you to place fancy social media icons and buttons on your WordPress website.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "/wp-content/plugins/ultimate-social-media-icons/",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/xcharts.ts
+++ b/src/signatures/technologies/xcharts.ts
@@ -1,0 +1,19 @@
+import type { Signature } from "../_types.js";
+import { d3Signature } from "./d3.js";
+
+export const xchartsSignature: Signature = {
+  name: "xCharts",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<link[^>]* href=\"[^\"]*xcharts(?:\\.min)?\\.css",
+    ],
+    urls: [
+      "xcharts\\.js",
+    ],
+    javascriptVariables: {
+      "xChart": "",
+    },
+  },
+  impliedSoftwares: [d3Signature.name],
+};

--- a/src/signatures/technologies/xenforo.ts
+++ b/src/signatures/technologies/xenforo.ts
@@ -1,0 +1,23 @@
+import type { Signature } from "../_types.js";
+import { phpSignature } from "./php.js";
+import { mysqlSignature } from "./mysql.js";
+
+export const xenforoSignature: Signature = {
+  name: "XenForo",
+  description: "XenForo is a PHP-based forum hosting program for communities that is designed to be deployed on a remote web server.",
+  rule: {
+    confidence: "high",
+    cookies: {
+      "xf_csrf": "",
+      "xf_session": "",
+    },
+    bodies: [
+      "(?:jQuery\\.extend\\(true, XenForo|<a[^>]+>Forum software by XenForo™|<!--XF:branding|<html[^>]+id=\"XenForo\")",
+      "<html id=\"XF\" ",
+    ],
+    javascriptVariables: {
+      "XF.GuestUsername": "",
+    },
+  },
+  impliedSoftwares: [phpSignature.name, mysqlSignature.name],
+};

--- a/src/signatures/technologies/zimbra.ts
+++ b/src/signatures/technologies/zimbra.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+import { javaSignature } from "./java.js";
+
+export const zimbraSignature: Signature = {
+  name: "Zimbra",
+  cpe: "cpe:/a:zimbra:zimbra",
+  rule: {
+    confidence: "high",
+    cookies: {
+      "ZM_TEST": "true",
+    },
+  },
+  impliedSoftwares: [javaSignature.name],
+};


### PR DESCRIPTION
## Summary
- add signatures for requested plugins, libraries, and platforms (Elementor add-ons, microCMS, Intercom, etc.)
- include WordPress plugin/theme detections and related framework implications
- register all new signatures in the index

## Testing
- not run