### PR TITLE
fix: reduce htmx/intercom false positives

### DIFF
--- a/src/signatures/technologies/htmx.ts
+++ b/src/signatures/technologies/htmx.ts
@@ -7,8 +7,7 @@ export const htmxSignature: Signature = {
     confidence: "high",
     bodies: [
       "data-src[^>]+\\/dist\\/htmx.min.js",
-      "min",
-      "js",
+      "hx-(?:get|post|put|delete|patch|boost|trigger|swap|target|include|vals|confirm)=",
     ],
     urls: [
       "/htmx\\.org@([\\d\\.]+)",

--- a/src/signatures/technologies/intercom.ts
+++ b/src/signatures/technologies/intercom.ts
@@ -7,8 +7,6 @@ export const intercomSignature: Signature = {
     confidence: "high",
     bodies: [
       "href[^>]+https:\\/\\/widget.intercom.io",
-      "intercom",
-      "io",
       "live-chat-loader-placeholder",
       "intercom-frame",
     ],


### PR DESCRIPTION
## Summary
- remove generic body tokens from Htmx and Intercom signatures
- add specific htmx attribute pattern to avoid matching unrelated pages

## Testing
- not run