### PR TITLE
feat: add wappalyzer signatures

### DIFF
--- a/src/signatures/index.ts
+++ b/src/signatures/index.ts
@@ -404,6 +404,32 @@ import { loginWithAmazonSignature } from "./technologies/login_with_amazon.js";
 import { howlerSignature } from "./technologies/howler_js.js";
 import { ultimatelysocialSignature } from "./technologies/ultimatelysocial.js";
 import { intercomSignature } from "./technologies/intercom.js";
+import { wpRoyalAsheSignature } from "./technologies/wp_royal_ashe.js";
+import { webfactoryMaintenanceSignature } from "./technologies/webfactory_maintenance.js";
+import { colibriWpSignature } from "./technologies/colibri_wp.js";
+import { soundmanagerSignature } from "./technologies/soundmanager.js";
+import { bubbleSignature } from "./technologies/bubble.js";
+import { perfmattersSignature } from "./technologies/perfmatters.js";
+import { crocoblockJetelementsSignature } from "./technologies/crocoblock_jetelements.js";
+import { pixelyoursiteSignature } from "./technologies/pixelyoursite.js";
+import { xpressengineSignature } from "./technologies/xpressengine.js";
+import { helixUltimateSignature } from "./technologies/helix_ultimate.js";
+import { cmsMadeSimpleSignature } from "./technologies/cms_made_simple.js";
+import { formidableFormSignature } from "./technologies/formidable_form.js";
+import { phpdebugbarSignature } from "./technologies/php_debug_bar.js";
+import { boostCommerceSignature } from "./technologies/boost_commerce.js";
+import { goSignature } from "./technologies/go.js";
+import { macaronSignature } from "./technologies/macaron.js";
+import { mdbootstrapSignature } from "./technologies/mdbootstrap.js";
+import { ramdaSignature } from "./technologies/ramda.js";
+import { godaddyCoblocksSignature } from "./technologies/godaddy_coblocks.js";
+import { ampSignature } from "./technologies/amp.js";
+import { patternByEtsySignature } from "./technologies/pattern_by_etsy.js";
+import { boomerangSignature } from "./technologies/boomerang.js";
+import { moodleSignature } from "./technologies/moodle.js";
+import { ebisumartSignature } from "./technologies/ebisumart.js";
+import { onepressSocialLockerSignature } from "./technologies/onepress_social_locker.js";
+import { wpStatisticsSignature } from "./technologies/wp_statistics.js";
 
 export const signatures: Signature[] = [
   addToAnySignature,
@@ -810,4 +836,30 @@ export const signatures: Signature[] = [
   howlerSignature,
   ultimatelysocialSignature,
   intercomSignature,
+  wpRoyalAsheSignature,
+  webfactoryMaintenanceSignature,
+  colibriWpSignature,
+  soundmanagerSignature,
+  bubbleSignature,
+  perfmattersSignature,
+  crocoblockJetelementsSignature,
+  pixelyoursiteSignature,
+  xpressengineSignature,
+  helixUltimateSignature,
+  cmsMadeSimpleSignature,
+  formidableFormSignature,
+  phpdebugbarSignature,
+  boostCommerceSignature,
+  goSignature,
+  macaronSignature,
+  mdbootstrapSignature,
+  ramdaSignature,
+  godaddyCoblocksSignature,
+  ampSignature,
+  patternByEtsySignature,
+  boomerangSignature,
+  moodleSignature,
+  ebisumartSignature,
+  onepressSocialLockerSignature,
+  wpStatisticsSignature,
 ];

--- a/src/signatures/technologies/amp.ts
+++ b/src/signatures/technologies/amp.ts
@@ -1,0 +1,13 @@
+import type { Signature } from "../_types.js";
+
+export const ampSignature: Signature = {
+  name: "AMP",
+  description: "AMP, originally created by Google, is an open-source HTML framework developed by the AMP open-source Project. AMP is designed to help webpages load faster.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<html[^>]* (?:amp|⚡)[^-]",
+      "<link rel=\"amphtml\"",
+    ],
+  },
+};

--- a/src/signatures/technologies/boomerang.ts
+++ b/src/signatures/technologies/boomerang.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+
+export const boomerangSignature: Signature = {
+  name: "Boomerang",
+  description: "boomerang is a JavaScript library that measures the page load time experienced by real users, commonly called RUM (Real User Measurement).",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      "BOOMR": "",
+      "BOOMR_lstart": "",
+      "BOOMR_mq": "",
+    },
+  },
+};

--- a/src/signatures/technologies/boost_commerce.ts
+++ b/src/signatures/technologies/boost_commerce.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+import { shopifySignature } from "./shopify.js";
+
+export const boostCommerceSignature: Signature = {
+  name: "Boost Commerce",
+  description: "Boost Commerce provides beautiful and advanced product filter and smart site search for Shopify stores to boost sales.",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      "bcSfFilterConfig.api.filterUrl": "services\\.mybcapps\\.com/",
+      "boostPFSAppConfig.api.filterUrl": "services\\.mybcapps\\.com/",
+    },
+  },
+  impliedSoftwares: [shopifySignature.name],
+};

--- a/src/signatures/technologies/bubble.ts
+++ b/src/signatures/technologies/bubble.ts
@@ -1,0 +1,22 @@
+import type { Signature } from "../_types.js";
+import { nodeJsSignature } from "./node_js.js";
+
+export const bubbleSignature: Signature = {
+  name: "Bubble",
+  description: "Bubble is a no-code platform that lets anyone build web apps without writing any code.",
+  rule: {
+    confidence: "high",
+    headers: {
+      "x-bubble-capacity-limit": "",
+      "x-bubble-capacity-used": "",
+      "x-bubble-perf": "",
+    },
+    javascriptVariables: {
+      "_bubble_page_load_data": "",
+      "bubble_environment": "",
+      "bubble_hostname_modifier": "",
+      "bubble_version": "",
+    },
+  },
+  impliedSoftwares: [nodeJsSignature.name],
+};

--- a/src/signatures/technologies/cms_made_simple.ts
+++ b/src/signatures/technologies/cms_made_simple.ts
@@ -1,0 +1,17 @@
+import type { Signature } from "../_types.js";
+import { phpSignature } from "./php.js";
+
+export const cmsMadeSimpleSignature: Signature = {
+  name: "CMS Made Simple",
+  cpe: "cpe:/a:cmsmadesimple:cms_made_simple",
+  rule: {
+    confidence: "high",
+    cookies: {
+      "CMSSESSID": "",
+    },
+    bodies: [
+      "<meta[^>]+name=[\"']generator[\"'][^>]+content=[\"']CMS Made Simple",
+    ],
+  },
+  impliedSoftwares: [phpSignature.name],
+};

--- a/src/signatures/technologies/colibri_wp.ts
+++ b/src/signatures/technologies/colibri_wp.ts
@@ -1,0 +1,22 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const colibriWpSignature: Signature = {
+  name: "Colibri WP",
+  description: "Colibri WP is a drag-and-drop WordPress website builder.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "href[^>]+\\/wp\\-content\\/plugins\\/colibri\\-page\\-builder",
+    ],
+    urls: [
+      "/wp-content/plugins/colibri-page-builder.+\\.js(?:.+ver=([\\d\\.\\-\\w]+))?",
+    ],
+    javascriptVariables: {
+      "Colibri": "",
+      "colibriData": "",
+      "colibriFrontendData": "",
+    },
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/crocoblock_jetelements.ts
+++ b/src/signatures/technologies/crocoblock_jetelements.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+import { elementorSignature } from "./elementor.js";
+
+export const crocoblockJetelementsSignature: Signature = {
+  name: "Crocoblock JetElements",
+  description: "Crocoblock JetElements is an addon for Elementor that adds additional customisation options to the page builder.",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      "jetElements": "",
+    },
+  },
+  impliedSoftwares: [elementorSignature.name],
+};

--- a/src/signatures/technologies/ebisumart.ts
+++ b/src/signatures/technologies/ebisumart.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+
+export const ebisumartSignature: Signature = {
+  name: "ebisumart",
+  description: "ebisumart is a cloud-based storefront system for developing and renewing high-quality ecommerce websites.",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      "Ebisu.FontChanger": "",
+      "Ebisu.FontChanger.map.L": "",
+      "ebisu_conv": "",
+    },
+  },
+};

--- a/src/signatures/technologies/formidable_form.ts
+++ b/src/signatures/technologies/formidable_form.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const formidableFormSignature: Signature = {
+  name: "Formidable Form",
+  description: "Formidable Forms is a WordPress plugin that enables you to create quizzes, surveys, calculators, timesheets, multi-page application forms.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "href[^>]+\\/wp\\-content\\/plugins\\/formidable\\/",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/go.ts
+++ b/src/signatures/technologies/go.ts
@@ -1,0 +1,6 @@
+import type { Signature } from "../_types.js";
+
+export const goSignature: Signature = {
+  name: "Go",
+  cpe: "cpe:/a:golang:go",
+};

--- a/src/signatures/technologies/godaddy_coblocks.ts
+++ b/src/signatures/technologies/godaddy_coblocks.ts
@@ -1,0 +1,17 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const godaddyCoblocksSignature: Signature = {
+  name: "GoDaddy CoBlocks",
+  description: "GoDaddy CoBlocks is a suite of professional page building content blocks for the WordPress Gutenberg block editor.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "href[^>]+\\/wp\\-content\\/plugins\\/coblocks\\/",
+    ],
+    urls: [
+      "/wp-content/plugins/coblocks/",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/helix_ultimate.ts
+++ b/src/signatures/technologies/helix_ultimate.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+import { joomlaSignature } from "./joomla.js";
+
+export const helixUltimateSignature: Signature = {
+  name: "Helix Ultimate",
+  description: "Helix Ultimate a free template framework for Joomla.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "sp-header",
+      "helix-ultimate",
+    ],
+  },
+  impliedSoftwares: [joomlaSignature.name],
+};

--- a/src/signatures/technologies/macaron.ts
+++ b/src/signatures/technologies/macaron.ts
@@ -1,0 +1,8 @@
+import type { Signature } from "../_types.js";
+import { goSignature } from "./go.js";
+
+export const macaronSignature: Signature = {
+  name: "Macaron",
+  description: "Macaron is a high productive and modular web framework in Go.",
+  impliedSoftwares: [goSignature.name],
+};

--- a/src/signatures/technologies/mdbootstrap.ts
+++ b/src/signatures/technologies/mdbootstrap.ts
@@ -1,0 +1,17 @@
+import type { Signature } from "../_types.js";
+import { bootstrapSignature } from "./bootstrap.js";
+
+export const mdbootstrapSignature: Signature = {
+  name: "MDBootstrap",
+  description: "MDBootstrap (Material Design for Bootstrap) is a complete UI package that can be integrated with other frameworks such as Angular, React, Vue, etc. It is used to design a fully responsive and mobile-friendly layout using various components, plugins, animation.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "(?:/mdbootstrap/([\\d\\.]+)/)?js/mdb\\.min\\.js",
+    ],
+    javascriptVariables: {
+      "mdb.ScrollSpy": "",
+    },
+  },
+  impliedSoftwares: [bootstrapSignature.name],
+};

--- a/src/signatures/technologies/moodle.ts
+++ b/src/signatures/technologies/moodle.ts
@@ -1,0 +1,24 @@
+import type { Signature } from "../_types.js";
+import { phpSignature } from "./php.js";
+
+export const moodleSignature: Signature = {
+  name: "Moodle",
+  description: "Moodle is a free and open-source Learning Management System (LMS) written in PHP and distributed under the GNU General Public License.",
+  cpe: "cpe:/a:moodle:moodle",
+  rule: {
+    confidence: "high",
+    cookies: {
+      "MOODLEID_": "",
+      "MoodleSession": "",
+    },
+    bodies: [
+      "<img[^>]+moodlelogo",
+      "<meta[^>]+name=[\"']keywords[\"'][^>]+content=[\"']^moodle",
+    ],
+    javascriptVariables: {
+      "M.core": "",
+      "Y.Moodle": "",
+    },
+  },
+  impliedSoftwares: [phpSignature.name],
+};

--- a/src/signatures/technologies/onepress_social_locker.ts
+++ b/src/signatures/technologies/onepress_social_locker.ts
@@ -1,0 +1,18 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const onepressSocialLockerSignature: Signature = {
+  name: "OnePress Social Locker",
+  description: "Social Locker locks your most valuable site content behind a set of social buttons until the visitor likes, shares, +1s or tweets your page.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "/wp-content/plugins/social-?locker(?:-next-premium)?/bizpanda/assets/",
+    ],
+    javascriptVariables: {
+      "__pandalockers": "",
+      "bizpanda": "",
+    },
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/pattern_by_etsy.ts
+++ b/src/signatures/technologies/pattern_by_etsy.ts
@@ -1,0 +1,12 @@
+import type { Signature } from "../_types.js";
+
+export const patternByEtsySignature: Signature = {
+  name: "Pattern by Etsy",
+  description: "Pattern is an offering by Etsy to set up a website for Etsy sellers, in addition to Etsy shop.",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      "Etsy": "",
+    },
+  },
+};

--- a/src/signatures/technologies/perfmatters.ts
+++ b/src/signatures/technologies/perfmatters.ts
@@ -1,0 +1,14 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const perfmattersSignature: Signature = {
+  name: "Perfmatters",
+  description: "Perfmatters is a performance optimisation plugin for WordPress websites.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "/wp-content/(?:plugins|cache|uploads)/perfmatters/",
+    ],
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/php_debug_bar.ts
+++ b/src/signatures/technologies/php_debug_bar.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+
+export const phpdebugbarSignature: Signature = {
+  name: "PHPDebugBar",
+  rule: {
+    confidence: "high",
+    urls: [
+      "debugbar.*\\.js",
+    ],
+    javascriptVariables: {
+      "PhpDebugBar": "",
+      "phpdebugbar": "",
+    },
+  },
+};

--- a/src/signatures/technologies/pixelyoursite.ts
+++ b/src/signatures/technologies/pixelyoursite.ts
@@ -1,0 +1,19 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const pixelyoursiteSignature: Signature = {
+  name: "PixelYourSite",
+  description: "PixelyourSite is now probably the most complex tracking tool for WordPress, managing the Facebook Pixel, Google Analytics, Google Ads Remarketing, Pinterest Tag, Bing Tag, and virtually any other script.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "/wp-content/plugins/pixelyoursite/",
+    ],
+    javascriptVariables: {
+      "pys.Facebook": "",
+      "pysOptions": "",
+      "pys_generate_token": "",
+    },
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/ramda.ts
+++ b/src/signatures/technologies/ramda.ts
@@ -1,0 +1,11 @@
+import type { Signature } from "../_types.js";
+
+export const ramdaSignature: Signature = {
+  name: "Ramda",
+  rule: {
+    confidence: "high",
+    urls: [
+      "ramda.*\\.js",
+    ],
+  },
+};

--- a/src/signatures/technologies/soundmanager.ts
+++ b/src/signatures/technologies/soundmanager.ts
@@ -1,0 +1,13 @@
+import type { Signature } from "../_types.js";
+
+export const soundmanagerSignature: Signature = {
+  name: "SoundManager",
+  rule: {
+    confidence: "high",
+    javascriptVariables: {
+      "BaconPlayer": "",
+      "SoundManager": "",
+      "soundManager.version": "V(.+) ",
+    },
+  },
+};

--- a/src/signatures/technologies/webfactory_maintenance.ts
+++ b/src/signatures/technologies/webfactory_maintenance.ts
@@ -1,0 +1,17 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const webfactoryMaintenanceSignature: Signature = {
+  name: "WebFactory Maintenance",
+  description: "WebFactory Maintenance is a WordPress plugin which allows you to create an maintenance page.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "href[^>]+\\/wp\\-content\\/plugins\\/maintenance\\/",
+    ],
+    javascriptVariables: {
+      "mtnc_front_options": "",
+    },
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/wp_royal_ashe.ts
+++ b/src/signatures/technologies/wp_royal_ashe.ts
@@ -1,0 +1,21 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const wpRoyalAsheSignature: Signature = {
+  name: "WP-Royal Ashe",
+  description: "WP-Royal Ashe is a personal and multi-author WordPress blog theme.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "ashe-style-css",
+    ],
+    urls: [
+      "/wp-content/themes/ashe(?:-pro-premium)?/",
+    ],
+    javascriptVariables: {
+      "ashePreloader": "",
+      "asheStickySidebar": "",
+    },
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/wp_statistics.ts
+++ b/src/signatures/technologies/wp_statistics.ts
@@ -1,0 +1,19 @@
+import type { Signature } from "../_types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+export const wpStatisticsSignature: Signature = {
+  name: "WP-Statistics",
+  description: "WP-Statistics is a WordPress plugin which allows you to know your website statistics.",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<!-- Analytics by WP-Statistics v([\\d\\.]+)",
+      "href[^>]+\\/wp\\-content\\/plugins\\/wp\\-statistics\\/",
+    ],
+    javascriptVariables: {
+      "WP_Statistics_http": "",
+      "wps_statistics_object": "",
+    },
+  },
+  impliedSoftwares: [wordpressSignature.name],
+};

--- a/src/signatures/technologies/xpressengine.ts
+++ b/src/signatures/technologies/xpressengine.ts
@@ -1,0 +1,11 @@
+import type { Signature } from "../_types.js";
+
+export const xpressengineSignature: Signature = {
+  name: "XpressEngine",
+  rule: {
+    confidence: "high",
+    bodies: [
+      "<meta[^>]+name=[\"']generator[\"'][^>]+content=[\"']XpressEngine",
+    ],
+  },
+};


### PR DESCRIPTION
## Summary
- add signatures for requested WordPress plugins/themes and related libraries (Perfmatters, WP-Royal Ashe, etc.)
- include ecommerce/hosting platforms and JavaScript libraries
- register all new signatures in the index

## Testing
- not run