### PR TITLE
fix: resolve build errors in signature files

### DIFF
--- a/src/commands/detect_types.ts
+++ b/src/commands/detect_types.ts
@@ -3,7 +3,7 @@ import type { Confidence } from "../signatures/_types.js";
 
 export type DetectedSoftware = {
   name: string;
-  description: string;
+  description?: string;
   versions?: string[];
   cpes?: string[];
   confidence: Confidence;

--- a/src/commands/detect_utils.ts
+++ b/src/commands/detect_utils.ts
@@ -28,11 +28,13 @@ export function makeDetectCommandOutput(
     )!;
     const detectedSoftware: DetectedSoftware = {
       name: detection.name,
-      description: signature.description,
       confidence: maxConfidence(
         detection.evidences?.map((e) => e.confidence) || [],
       ),
     };
+    if (signature.description) {
+      detectedSoftware.description = signature.description;
+    }
     const evidences = detection.evidences;
     if (evidences && evidences.length > 0) {
       detectedSoftware.evidences = evidences;
@@ -79,10 +81,12 @@ export function makeDetectCommandOutput(
 
       const impliedSoftware: DetectedSoftware = {
         name: impliedSignature.name,
-        description: impliedSignature.description,
         confidence: detectedSoftware.confidence,
         impliedBy: detectedSoftware.name,
       };
+      if (impliedSignature.description) {
+        impliedSoftware.description = impliedSignature.description;
+      }
       return [impliedSoftware];
     });
   });

--- a/src/signatures/_types.ts
+++ b/src/signatures/_types.ts
@@ -13,7 +13,7 @@ export type Rule = {
 
 export type Signature = {
   name: string;
-  description: string;
+  description?: string;
   cpe?: string;
   rule?: Rule;
   impliedSoftwares?: string[];

--- a/src/signatures/index.ts
+++ b/src/signatures/index.ts
@@ -430,6 +430,8 @@ import { moodleSignature } from "./technologies/moodle.js";
 import { ebisumartSignature } from "./technologies/ebisumart.js";
 import { onepressSocialLockerSignature } from "./technologies/onepress_social_locker.js";
 import { wpStatisticsSignature } from "./technologies/wp_statistics.js";
+import { pwaSignature } from "./technologies/pwa.js";
+import { stripeSignature } from "./technologies/stripe.js";
 
 export const signatures: Signature[] = [
   addToAnySignature,
@@ -862,4 +864,6 @@ export const signatures: Signature[] = [
   ebisumartSignature,
   onepressSocialLockerSignature,
   wpStatisticsSignature,
+  pwaSignature,
+  stripeSignature,
 ];

--- a/src/signatures/technologies/elementor_header_footer_builder.ts
+++ b/src/signatures/technologies/elementor_header_footer_builder.ts
@@ -1,7 +1,6 @@
 import type { Signature } from "../_types.js";
 import { elementorSignature } from "./elementor.js";
 import { wordpressSignature } from "./wordpress.js";
-import { elementorSignature } from "./elementor.js";
 
 export const elementorHeaderFooterBuilderSignature: Signature = {
   name: "Elementor Header & Footer Builder",
@@ -12,5 +11,5 @@ export const elementorHeaderFooterBuilderSignature: Signature = {
       "href[^>]+\\/wp\\-content\\/plugins\\/header\\-footer\\-elementor\\/",
     ],
   },
-  impliedSoftwares: [elementorSignature.name, wordpressSignature.name, elementorSignature.name],
+  impliedSoftwares: [elementorSignature.name, wordpressSignature.name],
 };

--- a/src/signatures/technologies/jsrender.ts
+++ b/src/signatures/technologies/jsrender.ts
@@ -1,5 +1,5 @@
 import type { Signature } from "../_types.js";
-import { jsViewsSignature } from "./jsviews.js";
+import { jsviewsSignature } from "./jsviews.js";
 
 export const jsrenderSignature: Signature = {
   name: "JsRender",
@@ -10,5 +10,5 @@ export const jsrenderSignature: Signature = {
       "([\\d\\.]+)?/jsrender(?:\\.min)?\\.js",
     ],
   },
-  impliedSoftwares: [jsViewsSignature.name],
+  impliedSoftwares: [jsviewsSignature.name],
 };

--- a/src/signatures/technologies/jsviews.ts
+++ b/src/signatures/technologies/jsviews.ts
@@ -1,6 +1,5 @@
 import type { Signature } from "../_types.js";
-import { jsObservableSignature } from "./jsobservable.js";
-import { jsRenderSignature } from "./jsrender.js";
+import { jsobservableSignature } from "./jsobservable.js";
 
 export const jsviewsSignature: Signature = {
   name: "JsViews",
@@ -11,5 +10,5 @@ export const jsviewsSignature: Signature = {
       "([\\d\\.]+)?/jsviews(?:\\.min)?\\.js",
     ],
   },
-  impliedSoftwares: [jsObservableSignature.name, jsRenderSignature.name],
+  impliedSoftwares: [jsobservableSignature.name, "JsRender"],
 };

--- a/src/signatures/technologies/meteor.ts
+++ b/src/signatures/technologies/meteor.ts
@@ -1,5 +1,5 @@
 import type { Signature } from "../_types.js";
-import { mongoDbSignature } from "./mongodb.js";
+import { mongodbSignature } from "./mongodb.js";
 import { nodeJsSignature } from "./node_js.js";
 
 export const meteorSignature: Signature = {
@@ -14,5 +14,5 @@ export const meteorSignature: Signature = {
       "Meteor.release": "^METEOR@([\\d.]+)",
     },
   },
-  impliedSoftwares: [mongoDbSignature.name, nodeJsSignature.name],
+  impliedSoftwares: [mongodbSignature.name, nodeJsSignature.name],
 };

--- a/src/signatures/technologies/pwa.ts
+++ b/src/signatures/technologies/pwa.ts
@@ -1,0 +1,6 @@
+import type { Signature } from "../_types.js";
+
+export const pwaSignature: Signature = {
+  name: "PWA",
+  description: "Progressive Web App (PWA) is a type of application software delivered through the web, built using common web technologies including HTML, CSS, JavaScript, and WebAssembly.",
+};

--- a/src/signatures/technologies/stripe.ts
+++ b/src/signatures/technologies/stripe.ts
@@ -1,0 +1,15 @@
+import type { Signature } from "../_types.js";
+
+export const stripeSignature: Signature = {
+  name: "Stripe",
+  description: "Stripe is a suite of APIs powering online payment processing and commerce solutions for internet businesses of all sizes.",
+  rule: {
+    confidence: "high",
+    urls: [
+      "js\\.stripe\\.com",
+    ],
+    javascriptVariables: {
+      Stripe: "",
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- `Signature` 型の `description` フィールドをオプショナルに変更
- `elementor_header_footer_builder.ts` の重複インポートを削除
- `jsrender.ts` と `jsviews.ts` の循環依存を解消
- `meteor.ts` のインポート名のタイポを修正 (`mongoDbSignature` -> `mongodbSignature`)
- 不足していた `pwa.ts` と `stripe.ts` シグネチャファイルを追加
- `DetectedSoftware` 型を更新してオプショナルな `description` に対応

## Test plan
- [ ] `npm run build` が成功することを確認

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)