### PR TITLE
test: add browser and signature validation tests (phase 2)

### DIFF
--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -82,22 +82,22 @@
 
 ## 進捗管理
 
-- [ ] `src/browser/index.test.ts` - Playwrightモック化が複雑なため保留
+- [x] `src/browser/index.test.ts` - 完了 (11テスト) Playwrightモック化
 - [x] `src/commands/detect_utils.test.ts` - 完了 (23テスト)
 - [x] `src/logger/index.test.ts` - 完了 (12テスト)
 - [x] `src/logger/utils.test.ts` - 完了 (2テスト)
-- [ ] `src/commands/detect.test.ts` - Playwrightモック化が複雑なため保留
+- [ ] `src/commands/detect.test.ts` - 保留（Playwrightモック化が複雑）
 - [x] `src/signatures/utils.test.ts` - 完了 (6テスト)
 - [x] `src/cli.test.ts` - 完了 (4テスト)
 - [x] `src/commands/banner.test.ts` - 完了 (4テスト)
 - [x] `src/commands/version.test.ts` - 完了 (3テスト)
 - [x] `src/browser/utils.test.ts` - 完了 (3テスト)
-- [ ] 署名バリデーションテスト
+- [x] `src/signatures/signatures.test.ts` - 完了 (12テスト) 署名バリデーション
 - [ ] E2Eテスト
 
 ### 現在のテスト状況
-- **合計テスト数**: 89個 (32個 → 89個)
-- **カバレッジ**: 98%以上
+- **合計テスト数**: 112個 (32個 → 89個 → 112個)
+- **カバレッジ**: 80%
 
 ## メモ
 

--- a/src/browser/index.test.ts
+++ b/src/browser/index.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { openPage } from "./index.js";
+
+// Mock playwright
+vi.mock("playwright", () => {
+  const mockPage = {
+    on: vi.fn(),
+    goto: vi.fn(),
+    context: vi.fn(),
+    evaluate: vi.fn(),
+    close: vi.fn(),
+  };
+
+  const mockBrowserContext = {
+    newPage: vi.fn(() => Promise.resolve(mockPage)),
+    cookies: vi.fn(() => Promise.resolve([])),
+  };
+
+  const mockBrowser = {
+    newContext: vi.fn(() => Promise.resolve(mockBrowserContext)),
+    close: vi.fn(),
+  };
+
+  return {
+    chromium: {
+      launch: vi.fn(() => Promise.resolve(mockBrowser)),
+    },
+  };
+});
+
+// Mock logger
+vi.mock("../logger/index.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Mock sleep to be instant in tests
+vi.mock("./utils.js", () => ({
+  sleep: vi.fn(() => Promise.resolve()),
+}));
+
+import { chromium } from "playwright";
+import { logger } from "../logger/index.js";
+import { sleep } from "./utils.js";
+
+describe("openPage", () => {
+  let mockPage: {
+    on: ReturnType<typeof vi.fn>;
+    goto: ReturnType<typeof vi.fn>;
+    context: ReturnType<typeof vi.fn>;
+    evaluate: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+  };
+  let mockBrowserContext: {
+    newPage: ReturnType<typeof vi.fn>;
+    cookies: ReturnType<typeof vi.fn>;
+  };
+  let mockBrowser: {
+    newContext: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Get references to mocked objects
+    mockPage = {
+      on: vi.fn(),
+      goto: vi.fn(() => Promise.resolve()),
+      context: vi.fn(),
+      evaluate: vi.fn(() => Promise.resolve({})),
+      close: vi.fn(),
+    };
+
+    mockBrowserContext = {
+      newPage: vi.fn(() => Promise.resolve(mockPage)),
+      cookies: vi.fn(() => Promise.resolve([])),
+    };
+
+    mockBrowser = {
+      newContext: vi.fn(() => Promise.resolve(mockBrowserContext)),
+      close: vi.fn(),
+    };
+
+    mockPage.context.mockReturnValue(mockBrowserContext);
+
+    vi.mocked(chromium.launch).mockResolvedValue(mockBrowser as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("successful page load", () => {
+    it("should launch browser with headless mode", async () => {
+      await openPage("https://example.com", 10000, []);
+
+      expect(chromium.launch).toHaveBeenCalledWith({ headless: true });
+    });
+
+    it("should create browser context with ignoreHTTPSErrors", async () => {
+      await openPage("https://example.com", 10000, []);
+
+      expect(mockBrowser.newContext).toHaveBeenCalledWith({
+        ignoreHTTPSErrors: true,
+      });
+    });
+
+    it("should navigate to the specified URL", async () => {
+      await openPage("https://example.com", 10000, []);
+
+      expect(mockPage.goto).toHaveBeenCalledWith("https://example.com", {
+        waitUntil: "networkidle",
+      });
+    });
+
+    it("should log success message on successful load", async () => {
+      mockPage.goto.mockResolvedValue(undefined);
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      await openPage("https://example.com", 10000, []);
+
+      expect(logger.info).toHaveBeenCalledWith("Page loaded successfully");
+    });
+
+    it("should return context with expected properties", async () => {
+      mockPage.goto.mockResolvedValue(undefined);
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      const result = await openPage("https://example.com", 5000, []);
+
+      expect(result).toHaveProperty("browser");
+      expect(result).toHaveProperty("page");
+      expect(result).toHaveProperty("responses");
+      expect(result).toHaveProperty("javascriptVariables");
+      expect(result).toHaveProperty("cookies");
+      expect(result).toHaveProperty("timeoutMs", 5000);
+      expect(result).toHaveProperty("timeoutOccurred", false);
+    });
+  });
+
+  describe("timeout handling", () => {
+    it("should set timeoutOccurred to true when timeout occurs", async () => {
+      // Make goto never resolve, and sleep resolve immediately
+      mockPage.goto.mockImplementation(
+        () => new Promise(() => {}), // Never resolves
+      );
+      vi.mocked(sleep).mockResolvedValue(undefined);
+
+      const result = await openPage("https://example.com", 1000, []);
+
+      expect(result.timeoutOccurred).toBe(true);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Timeout"),
+      );
+    });
+  });
+
+  describe("error handling", () => {
+    it("should log error when page load fails", async () => {
+      mockPage.goto.mockRejectedValue(new Error("Connection refused"));
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      await openPage("https://example.com", 10000, []);
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("Connection refused"),
+      );
+    });
+
+    it("should handle cookie/JS extraction failure gracefully", async () => {
+      mockPage.goto.mockResolvedValue(undefined);
+      mockBrowserContext.cookies.mockRejectedValue(
+        new Error("Context destroyed"),
+      );
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      const result = await openPage("https://example.com", 10000, []);
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to extract cookies"),
+      );
+      expect(result.cookies).toEqual([]);
+    });
+  });
+
+  describe("cookie extraction", () => {
+    it("should extract cookies from page context", async () => {
+      const mockCookies = [
+        {
+          name: "session",
+          value: "abc123",
+          domain: "example.com",
+          path: "/",
+          expires: -1,
+          httpOnly: true,
+          secure: true,
+          sameSite: "Lax" as const,
+        },
+      ];
+
+      mockPage.goto.mockResolvedValue(undefined);
+      mockBrowserContext.cookies.mockResolvedValue(mockCookies);
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      const result = await openPage("https://example.com", 10000, []);
+
+      expect(result.cookies).toEqual([
+        {
+          name: "session",
+          value: "abc123",
+          domain: "example.com",
+          path: "/",
+          expires: -1,
+          httpOnly: true,
+          secure: true,
+          sameSite: "Lax",
+        },
+      ]);
+    });
+  });
+
+  describe("javascript variable extraction", () => {
+    it("should evaluate javascript variables on page", async () => {
+      mockPage.goto.mockResolvedValue(undefined);
+      mockPage.evaluate.mockResolvedValue({ jQuery: "3.6.0" });
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      const result = await openPage("https://example.com", 10000, ["jQuery"]);
+
+      expect(mockPage.evaluate).toHaveBeenCalled();
+      expect(result.javascriptVariables).toEqual({ jQuery: "3.6.0" });
+    });
+  });
+
+  describe("response listener", () => {
+    it("should register response listener on page", async () => {
+      await openPage("https://example.com", 10000, []);
+
+      expect(mockPage.on).toHaveBeenCalledWith(
+        "response",
+        expect.any(Function),
+      );
+    });
+  });
+});

--- a/src/signatures/signatures.test.ts
+++ b/src/signatures/signatures.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import { signatures } from "./index.js";
+
+describe("signatures validation", () => {
+  describe("required fields", () => {
+    it("all signatures should have a non-empty name", () => {
+      for (const sig of signatures) {
+        expect(sig.name, `Signature missing name`).toBeDefined();
+        expect(sig.name.length, `Signature has empty name`).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe("uniqueness", () => {
+    it("all signature names should be unique", () => {
+      const names = signatures.map((s) => s.name);
+      const duplicates = names.filter(
+        (name, index) => names.indexOf(name) !== index,
+      );
+      expect(
+        duplicates,
+        `Duplicate signature names: ${duplicates.join(", ")}`,
+      ).toEqual([]);
+    });
+  });
+
+  describe("confidence values", () => {
+    it("all rules should have valid confidence values", () => {
+      const validConfidences = ["high", "medium", "low"];
+      for (const sig of signatures) {
+        if (sig.rule) {
+          expect(
+            validConfidences,
+            `Invalid confidence "${sig.rule.confidence}" in ${sig.name}`,
+          ).toContain(sig.rule.confidence);
+        }
+      }
+    });
+  });
+
+  describe("regex patterns", () => {
+    const testRegex = (pattern: string, sigName: string, field: string) => {
+      try {
+        new RegExp(pattern, "i");
+      } catch {
+        throw new Error(
+          `Invalid regex in ${sigName}.${field}: "${pattern}"`,
+        );
+      }
+    };
+
+    it("all header patterns should be valid regex", () => {
+      for (const sig of signatures) {
+        if (sig.rule?.headers) {
+          for (const [header, pattern] of Object.entries(sig.rule.headers)) {
+            testRegex(pattern, sig.name, `headers.${header}`);
+          }
+        }
+      }
+    });
+
+    it("all body patterns should be valid regex", () => {
+      for (const sig of signatures) {
+        if (sig.rule?.bodies) {
+          for (const pattern of sig.rule.bodies) {
+            testRegex(pattern, sig.name, "bodies");
+          }
+        }
+      }
+    });
+
+    it("all url patterns should be valid regex", () => {
+      for (const sig of signatures) {
+        if (sig.rule?.urls) {
+          for (const pattern of sig.rule.urls) {
+            testRegex(pattern, sig.name, "urls");
+          }
+        }
+      }
+    });
+
+    it("all cookie patterns should be valid regex", () => {
+      for (const sig of signatures) {
+        if (sig.rule?.cookies) {
+          for (const [cookie, pattern] of Object.entries(sig.rule.cookies)) {
+            testRegex(pattern, sig.name, `cookies.${cookie}`);
+          }
+        }
+      }
+    });
+
+    it("all javascriptVariables patterns should be valid regex", () => {
+      for (const sig of signatures) {
+        if (sig.rule?.javascriptVariables) {
+          for (const [varName, pattern] of Object.entries(
+            sig.rule.javascriptVariables,
+          )) {
+            testRegex(pattern, sig.name, `javascriptVariables.${varName}`);
+          }
+        }
+      }
+    });
+  });
+
+  describe("implied softwares", () => {
+    it("all implied software references should exist", () => {
+      const allNames = new Set(signatures.map((s) => s.name));
+      const missingRefs: string[] = [];
+
+      for (const sig of signatures) {
+        if (sig.impliedSoftwares) {
+          for (const implied of sig.impliedSoftwares) {
+            if (!allNames.has(implied)) {
+              missingRefs.push(`${sig.name} -> ${implied}`);
+            }
+          }
+        }
+      }
+
+      expect(
+        missingRefs,
+        `Missing implied software references: ${missingRefs.join(", ")}`,
+      ).toEqual([]);
+    });
+  });
+
+  describe("data integrity", () => {
+    it("should have a reasonable number of signatures", () => {
+      expect(signatures.length).toBeGreaterThan(100);
+    });
+
+    it("all signatures with rules should have at least one detection method", () => {
+      for (const sig of signatures) {
+        if (sig.rule) {
+          const hasDetectionMethod =
+            sig.rule.headers ||
+            sig.rule.bodies ||
+            sig.rule.urls ||
+            sig.rule.cookies ||
+            sig.rule.javascriptVariables;
+
+          expect(
+            hasDetectionMethod,
+            `${sig.name} has a rule but no detection method`,
+          ).toBeTruthy();
+        }
+      }
+    });
+  });
+
+  describe("cpe format", () => {
+    it("all cpe values should follow CPE format", () => {
+      const cpePattern = /^cpe:[/:]?[0-9.]*:?[a-z]:[\w\-_.]+:[\w\-_.]+/i;
+      for (const sig of signatures) {
+        if (sig.cpe) {
+          expect(
+            sig.cpe,
+            `Invalid CPE format in ${sig.name}: "${sig.cpe}"`,
+          ).toMatch(cpePattern);
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add Playwright mocking for browser module tests
- Add signature data validation tests
- Test count: 89 → 112 (+23 tests)
- Coverage: 71% → 80%

## New Test Files

| File | Tests | Coverage |
|------|-------|----------|
| `src/browser/index.test.ts` | 11 | Playwright mocking, page load, timeout, cookies, JS variables |
| `src/signatures/signatures.test.ts` | 12 | Schema validation, regex validity, implied software refs |

## Test plan

- [x] All 112 tests pass locally
- [x] Coverage at 80%
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)