### PR TITLE
refactor: use single version/cpe per software entry

### DIFF
--- a/src/commands/detect_types.ts
+++ b/src/commands/detect_types.ts
@@ -4,8 +4,8 @@ import type { Confidence } from "../signatures/_types.js";
 export type DetectedSoftware = {
   name: string;
   description?: string;
-  versions?: string[];
-  cpes?: string[];
+  version?: string;
+  cpe?: string;
   confidence: Confidence;
   evidences?: Evidence[];
   impliedBy?: string;

--- a/src/commands/detect_utils.test.ts
+++ b/src/commands/detect_utils.test.ts
@@ -59,7 +59,7 @@ describe("makeDetectCommandOutput", () => {
       expect(result.detectedSoftwares[0]!.name).toBe("nginx");
       expect(result.detectedSoftwares[0]!.description).toBe("Web server");
       expect(result.detectedSoftwares[0]!.confidence).toBe("high");
-      expect(result.detectedSoftwares[0]!.versions).toEqual(["1.20.0"]);
+      expect(result.detectedSoftwares[0]!.version).toBe("1.20.0");
     });
 
     it("should generate CPEs when signature has cpe", () => {
@@ -79,9 +79,9 @@ describe("makeDetectCommandOutput", () => {
 
       const result = makeDetectCommandOutput(detections, baseSignatures);
 
-      expect(result.detectedSoftwares[0]!.cpes).toEqual([
+      expect(result.detectedSoftwares[0]!.cpe).toBe(
         "cpe:2.3:a:nginx:nginx:1.20.0",
-      ]);
+      );
     });
 
     it("should not include cpes when signature has no cpe", () => {
@@ -101,20 +101,20 @@ describe("makeDetectCommandOutput", () => {
 
       const result = makeDetectCommandOutput(detections, baseSignatures);
 
-      expect(result.detectedSoftwares[0]!.cpes).toBeUndefined();
+      expect(result.detectedSoftwares[0]!.cpe).toBeUndefined();
     });
   });
 
   describe("confidence calculation", () => {
-    it("should use highest confidence from evidences", () => {
+    it("should use highest confidence from evidences with same version", () => {
       const detections: Detection[] = [
         {
           name: "nginx",
           evidences: [
             {
               type: "header",
-              value: "nginx",
-              version: undefined,
+              value: "nginx/1.20.0",
+              version: "1.20.0",
               confidence: "low",
             },
             {
@@ -129,7 +129,10 @@ describe("makeDetectCommandOutput", () => {
 
       const result = makeDetectCommandOutput(detections, baseSignatures);
 
-      expect(result.detectedSoftwares[0]!.confidence).toBe("high");
+      const nginx = result.detectedSoftwares.find(
+        (s) => s.version === "1.20.0",
+      );
+      expect(nginx!.confidence).toBe("high");
     });
   });
 
@@ -237,7 +240,7 @@ describe("makeDetectCommandOutput", () => {
 
       const result = makeDetectCommandOutput(detections, baseSignatures);
 
-      expect(result.detectedSoftwares[0]!.versions).toEqual(["1.20.0"]);
+      expect(result.detectedSoftwares[0]!.version).toBe("1.20.0");
     });
 
     it("should merge implied software from multiple sources", () => {
@@ -281,7 +284,7 @@ describe("makeDetectCommandOutput", () => {
       expect(js!.confidence).toBe("high"); // Should use highest confidence
     });
 
-    it("should merge versions and cpes when same software detected multiple ways", () => {
+    it("should create separate entries when same software has different versions", () => {
       const signatures: Signature[] = [
         { name: "nginx", cpe: "cpe:2.3:a:nginx:nginx" },
       ];
@@ -313,14 +316,22 @@ describe("makeDetectCommandOutput", () => {
 
       const result = makeDetectCommandOutput(detections, signatures);
 
-      const nginx = result.detectedSoftwares.find((s) => s.name === "nginx");
-      expect(nginx).toBeDefined();
-      expect(nginx!.versions).toContain("1.18.0");
-      expect(nginx!.versions).toContain("1.20.0");
-      expect(nginx!.cpes).toContain("cpe:2.3:a:nginx:nginx:1.18.0");
-      expect(nginx!.cpes).toContain("cpe:2.3:a:nginx:nginx:1.20.0");
-      expect(nginx!.confidence).toBe("high");
-      expect(nginx!.evidences).toHaveLength(2);
+      const nginxEntries = result.detectedSoftwares.filter(
+        (s) => s.name === "nginx",
+      );
+      expect(nginxEntries).toHaveLength(2);
+
+      const v1180 = nginxEntries.find((s) => s.version === "1.18.0");
+      expect(v1180).toBeDefined();
+      expect(v1180!.cpe).toBe("cpe:2.3:a:nginx:nginx:1.18.0");
+      expect(v1180!.confidence).toBe("medium");
+      expect(v1180!.evidences).toHaveLength(1);
+
+      const v1200 = nginxEntries.find((s) => s.version === "1.20.0");
+      expect(v1200).toBeDefined();
+      expect(v1200!.cpe).toBe("cpe:2.3:a:nginx:nginx:1.20.0");
+      expect(v1200!.confidence).toBe("high");
+      expect(v1200!.evidences).toHaveLength(1);
     });
 
     it("should merge description from existing or new software", () => {
@@ -386,11 +397,12 @@ describe("printDetectCommandOutputAsText", () => {
     expect(allOutput).toContain("nginx");
   });
 
-  it("should print versions when available", () => {
+  it("should print version when available", () => {
     const output = {
       detectedSoftwares: [
         {
           name: "nginx",
+          version: "1.20.0",
           confidence: "high" as const,
           evidences: [
             {
@@ -538,7 +550,7 @@ describe("printDetectCommandOutputAsJSON", () => {
         {
           name: "nginx",
           description: "Web server",
-          versions: ["1.20.0"],
+          version: "1.20.0",
           confidence: "high" as const,
         },
       ],
@@ -549,6 +561,6 @@ describe("printDetectCommandOutputAsJSON", () => {
     const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
     expect(jsonOutput.detectedSoftwares[0].name).toBe("nginx");
     expect(jsonOutput.detectedSoftwares[0].description).toBe("Web server");
-    expect(jsonOutput.detectedSoftwares[0].versions).toEqual(["1.20.0"]);
+    expect(jsonOutput.detectedSoftwares[0].version).toBe("1.20.0");
   });
 });

--- a/src/commands/detect_utils.ts
+++ b/src/commands/detect_utils.ts
@@ -21,48 +21,54 @@ export function makeDetectCommandOutput(
   detections: Detection[],
   signatures: Signature[],
 ): DetectCommandOutput {
-  // Handle directly detected softwares
-  const detectedSoftwares = detections.map((detection) => {
+  // Handle directly detected softwares (one entry per version)
+  const detectedSoftwares = detections.flatMap((detection) => {
     const signature = signatures.find(
       (signature) => signature.name === detection.name,
     )!;
-    const detectedSoftware: DetectedSoftware = {
-      name: detection.name,
-      confidence: maxConfidence(
-        detection.evidences?.map((e) => e.confidence) || [],
-      ),
-    };
-    if (signature.description) {
-      detectedSoftware.description = signature.description;
+    const evidences = detection.evidences || [];
+
+    // Group evidences by version
+    const versionGroups = new Map<string | undefined, typeof evidences>();
+    for (const evidence of evidences) {
+      const key = evidence.version;
+      if (!versionGroups.has(key)) {
+        versionGroups.set(key, []);
+      }
+      versionGroups.get(key)!.push(evidence);
     }
-    const evidences = detection.evidences;
-    if (evidences && evidences.length > 0) {
-      detectedSoftware.evidences = evidences;
+
+    // If no evidences, create a single entry
+    if (versionGroups.size === 0) {
+      const ds: DetectedSoftware = {
+        name: detection.name,
+        confidence: maxConfidence([]),
+      };
+      if (signature.description) {
+        ds.description = signature.description;
+      }
+      return [ds];
     }
-    const versions = [
-      ...new Set(
-        evidences
-          ?.map((evidence) => evidence.version)
-          .filter((v): v is string => v !== undefined),
-      ),
-    ];
-    if (versions && versions.length > 0) {
-      detectedSoftware.versions = versions;
-    }
-    const cpes = signature.cpe
-      ? [
-          ...new Set(
-            evidences
-              ?.map((evidence) => evidence.version)
-              .filter((v): v is string => v !== undefined)
-              .map((version) => signature.cpe + ":" + version),
-          ),
-        ]
-      : undefined;
-    if (cpes && cpes.length > 0) {
-      detectedSoftware.cpes = cpes;
-    }
-    return detectedSoftware;
+
+    return [...versionGroups.entries()].map(([version, versionEvidences]) => {
+      const ds: DetectedSoftware = {
+        name: detection.name,
+        confidence: maxConfidence(versionEvidences.map((e) => e.confidence)),
+      };
+      if (signature.description) {
+        ds.description = signature.description;
+      }
+      if (versionEvidences.length > 0) {
+        ds.evidences = versionEvidences;
+      }
+      if (version) {
+        ds.version = version;
+        if (signature.cpe) {
+          ds.cpe = signature.cpe + ":" + version;
+        }
+      }
+      return ds;
+    });
   });
 
   // Handle implied softwares
@@ -91,13 +97,14 @@ export function makeDetectCommandOutput(
     });
   });
 
-  const mergedByName = new Map<string, DetectedSoftware>();
+  const mergedByKey = new Map<string, DetectedSoftware>();
   const allSoftwares = [...detectedSoftwares, ...impliedSoftwares];
 
   for (const software of allSoftwares) {
-    const existing = mergedByName.get(software.name);
+    const key = software.name + "|" + (software.version || "");
+    const existing = mergedByKey.get(key);
     if (!existing) {
-      mergedByName.set(software.name, software);
+      mergedByKey.set(key, software);
       continue;
     }
 
@@ -117,18 +124,11 @@ export function makeDetectCommandOutput(
       merged.description = description;
     }
 
-    const versions = [
-      ...new Set([...(existing.versions || []), ...(software.versions || [])]),
-    ];
-    if (versions.length > 0) {
-      merged.versions = versions;
+    if (existing.version) {
+      merged.version = existing.version;
     }
-
-    const cpes = [
-      ...new Set([...(existing.cpes || []), ...(software.cpes || [])]),
-    ];
-    if (cpes.length > 0) {
-      merged.cpes = cpes;
+    if (existing.cpe) {
+      merged.cpe = existing.cpe;
     }
 
     const evidences = [
@@ -143,11 +143,11 @@ export function makeDetectCommandOutput(
       merged.impliedBy = uniqueImpliedBy.join(", ");
     }
 
-    mergedByName.set(software.name, merged);
+    mergedByKey.set(key, merged);
   }
 
   return {
-    detectedSoftwares: [...mergedByName.values()],
+    detectedSoftwares: [...mergedByKey.values()],
   };
 }
 
@@ -158,11 +158,8 @@ export function printDetectCommandOutputAsText(
   console.log();
   for (const detection of output.detectedSoftwares) {
     let message = `* ${chalk.green(detection.name)}`;
-    const versions = [
-      ...new Set(detection.evidences?.map((e) => e.version).filter((v) => v)),
-    ];
-    if (versions.length > 0) {
-      message += ` ${versions.join(", ")}`;
+    if (detection.version) {
+      message += ` ${detection.version}`;
     }
     console.log(message);
 


### PR DESCRIPTION
## Summary
- Change `DetectedSoftware` fields from `versions: string[]` / `cpes: string[]` to `version: string` / `cpe: string`
- Each version of a software now produces a separate entry instead of merging into one
- Merge key changed from `name` to `name + version` so only same-name same-version entries are merged

## Test plan
- [x] All existing tests updated and passing (168 passed)
- [x] Build succeeds with no type errors 