### PR TITLE
feat: add --user-agent option to detect command

### DIFF
--- a/src/browser/index.test.ts
+++ b/src/browser/index.test.ts
@@ -114,6 +114,15 @@ describe("openPage", () => {
       });
     });
 
+    it("should pass custom userAgent to browser context", async () => {
+      await openPage("https://example.com", 10000, [], "MyCustomAgent/1.0");
+
+      expect(mockBrowser.newContext).toHaveBeenCalledWith({
+        ignoreHTTPSErrors: true,
+        userAgent: "MyCustomAgent/1.0",
+      });
+    });
+
     it("should navigate to the specified URL", async () => {
       await openPage("https://example.com", 10000, []);
 

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -35,6 +35,7 @@ export async function openPage(
   url: string,
   timeoutMs: number,
   javascriptVariableNames: string[],
+  userAgent?: string,
 ): Promise<Context> {
   const pageHost = getHostFromUrl(url);
   if (!pageHost) {
@@ -44,6 +45,7 @@ export async function openPage(
   const browser = await chromium.launch({ headless: true });
   const context = await browser.newContext({
     ignoreHTTPSErrors: true,
+    ...(userAgent ? { userAgent } : {}),
   });
   const page = await context.newPage();
 

--- a/src/commands/detect.test.ts
+++ b/src/commands/detect.test.ts
@@ -123,6 +123,13 @@ describe("detectCommand", () => {
       expect(jsonOpt).toBeDefined();
     });
 
+    it("should have user-agent option", () => {
+      const command = detectCommand();
+      const options = command.options;
+      const uaOpt = options.find((o) => o.long === "--user-agent");
+      expect(uaOpt).toBeDefined();
+    });
+
   });
 
   describe("action execution", () => {
@@ -133,6 +140,7 @@ describe("detectCommand", () => {
         "https://example.com",
         10000,
         expect.any(Array),
+        undefined,
       );
     });
 
@@ -143,6 +151,18 @@ describe("detectCommand", () => {
         "https://example.com",
         5000,
         expect.any(Array),
+        undefined,
+      );
+    });
+
+    it("should pass custom user-agent when provided", async () => {
+      await runCommand(["--user-agent", "MyAgent/1.0"]);
+
+      expect(openPage).toHaveBeenCalledWith(
+        "https://example.com",
+        10000,
+        expect.any(Array),
+        "MyAgent/1.0",
       );
     });
 

--- a/src/commands/detect.ts
+++ b/src/commands/detect.ts
@@ -25,6 +25,7 @@ export const detectCommand = (): Command => {
     .option("-d, --debug", "Enable debug logging", false)
     .option("-e, --evidence", "Show evidence for detections", false)
     .option("-j, --json", "Output results in JSON format", false)
+    .option("-u, --user-agent <string>", "Custom User-Agent string")
     .action(
       async (
         url: string,
@@ -33,6 +34,7 @@ export const detectCommand = (): Command => {
           debug: boolean;
           evidence: boolean;
           json: boolean;
+          userAgent?: string;
         },
       ) => {
         if (options.debug) {
@@ -51,6 +53,7 @@ export const detectCommand = (): Command => {
             url,
             options.timeout,
             getJavascriptVariableNames(signatures),
+            options.userAgent,
           );
           const detections = analyze(context, signatures);
           if (detections.length === 0) {


### PR DESCRIPTION
## Summary
- Add `-u, --user-agent <string>` option to the `detect` command, allowing users to specify a custom User-Agent string for browser requests
- Pass the custom User-Agent to Playwright's `browser.newContext()` via the `openPage` function

## Test plan
- [x] Unit tests added for `openPage` with custom userAgent
- [x] Unit tests added for `detectCommand` with `--user-agent` option
- [x] All 171 existing tests pass
