### PR TITLE
fix: detect only the final page's tech stack after redirects

### DIFF
--- a/src/browser/index.test.ts
+++ b/src/browser/index.test.ts
@@ -58,6 +58,8 @@ describe("openPage", () => {
     context: ReturnType<typeof vi.fn>;
     evaluate: ReturnType<typeof vi.fn>;
     close: ReturnType<typeof vi.fn>;
+    url: ReturnType<typeof vi.fn>;
+    mainFrame: ReturnType<typeof vi.fn>;
   };
   let mockBrowserContext: {
     newPage: ReturnType<typeof vi.fn>;
@@ -72,12 +74,15 @@ describe("openPage", () => {
     vi.clearAllMocks();
 
     // Get references to mocked objects
+    const mainFrame = {};
     mockPage = {
       on: vi.fn(),
       goto: vi.fn(() => Promise.resolve()),
       context: vi.fn(),
       evaluate: vi.fn(() => Promise.resolve({})),
       close: vi.fn(),
+      url: vi.fn(() => "https://example.com"),
+      mainFrame: vi.fn(() => mainFrame),
     };
 
     mockBrowserContext = {
@@ -303,23 +308,29 @@ describe("openPage", () => {
     });
 
     it("should capture responses with body", async () => {
-      let capturedCallback: (response: unknown) => Promise<void>;
+      let capturedResponseCallback: (response: unknown) => Promise<void>;
+      let capturedRequestCallback: (request: unknown) => void;
 
       mockPage.on.mockImplementation(
-        (event: string, callback: (response: unknown) => Promise<void>) => {
+        (event: string, callback: (...args: unknown[]) => void) => {
           if (event === "response") {
-            capturedCallback = callback;
+            capturedResponseCallback = callback as (response: unknown) => Promise<void>;
+          } else if (event === "request") {
+            capturedRequestCallback = callback as (request: unknown) => void;
           }
         },
       );
 
+      const mockRequest = {};
       mockPage.goto.mockImplementation(async () => {
-        // Simulate a response being received during page load
-        await capturedCallback({
+        // Simulate request then response during page load
+        capturedRequestCallback(mockRequest);
+        await capturedResponseCallback({
           url: () => "https://example.com/api/data",
           status: () => 200,
           headers: () => ({ "content-type": "application/json" }),
           text: () => Promise.resolve('{"data": "test"}'),
+          request: () => mockRequest,
         });
       });
 
@@ -346,22 +357,28 @@ describe("openPage", () => {
     });
 
     it("should capture responses without body when text() fails", async () => {
-      let capturedCallback: (response: unknown) => Promise<void>;
+      let capturedResponseCallback: (response: unknown) => Promise<void>;
+      let capturedRequestCallback: (request: unknown) => void;
 
       mockPage.on.mockImplementation(
-        (event: string, callback: (response: unknown) => Promise<void>) => {
+        (event: string, callback: (...args: unknown[]) => void) => {
           if (event === "response") {
-            capturedCallback = callback;
+            capturedResponseCallback = callback as (response: unknown) => Promise<void>;
+          } else if (event === "request") {
+            capturedRequestCallback = callback as (request: unknown) => void;
           }
         },
       );
 
+      const mockRequest = {};
       mockPage.goto.mockImplementation(async () => {
-        await capturedCallback({
+        capturedRequestCallback(mockRequest);
+        await capturedResponseCallback({
           url: () => "https://example.com/binary",
           status: () => 200,
           headers: () => ({ "content-type": "application/octet-stream" }),
           text: () => Promise.reject(new Error("Cannot read binary")),
+          request: () => mockRequest,
         });
       });
 
@@ -383,22 +400,28 @@ describe("openPage", () => {
     });
 
     it("should mark third-party responses as non first-party", async () => {
-      let capturedCallback: (response: unknown) => Promise<void>;
+      let capturedResponseCallback: (response: unknown) => Promise<void>;
+      let capturedRequestCallback: (request: unknown) => void;
 
       mockPage.on.mockImplementation(
-        (event: string, callback: (response: unknown) => Promise<void>) => {
+        (event: string, callback: (...args: unknown[]) => void) => {
           if (event === "response") {
-            capturedCallback = callback;
+            capturedResponseCallback = callback as (response: unknown) => Promise<void>;
+          } else if (event === "request") {
+            capturedRequestCallback = callback as (request: unknown) => void;
           }
         },
       );
 
+      const mockRequest = {};
       mockPage.goto.mockImplementation(async () => {
-        await capturedCallback({
+        capturedRequestCallback(mockRequest);
+        await capturedResponseCallback({
           url: () => "https://cdn.example.net/app.js",
           status: () => 200,
           headers: () => ({ "content-type": "text/javascript" }),
           text: () => Promise.resolve("console.log('ok')"),
+          request: () => mockRequest,
         });
       });
 

--- a/src/browser/index.test.ts
+++ b/src/browser/index.test.ts
@@ -69,12 +69,10 @@ describe("openPage", () => {
     newContext: ReturnType<typeof vi.fn>;
     close: ReturnType<typeof vi.fn>;
   };
+  const mainFrame = {};
 
   beforeEach(() => {
     vi.clearAllMocks();
-
-    // Get references to mocked objects
-    const mainFrame = {};
     mockPage = {
       on: vi.fn(),
       goto: vi.fn(() => Promise.resolve()),
@@ -435,6 +433,232 @@ describe("openPage", () => {
         host: "cdn.example.net",
         isFirstParty: false,
       });
+    });
+
+    it("should filter out 3xx redirect responses", async () => {
+      let capturedResponseCallback: (response: unknown) => Promise<void>;
+      let capturedRequestCallback: (request: unknown) => void;
+
+      mockPage.on.mockImplementation(
+        (event: string, callback: (...args: unknown[]) => void) => {
+          if (event === "response") {
+            capturedResponseCallback = callback as (response: unknown) => Promise<void>;
+          } else if (event === "request") {
+            capturedRequestCallback = callback as (request: unknown) => void;
+          }
+        },
+      );
+
+      const mockRequest1 = {};
+      const mockRequest2 = {};
+      mockPage.goto.mockImplementation(async () => {
+        capturedRequestCallback(mockRequest1);
+        await capturedResponseCallback({
+          url: () => "https://example.com/",
+          status: () => 301,
+          headers: () => ({ location: "https://example.com/new", server: "awselb/2.0" }),
+          text: () => Promise.resolve(""),
+          request: () => mockRequest1,
+        });
+        capturedRequestCallback(mockRequest2);
+        await capturedResponseCallback({
+          url: () => "https://example.com/new",
+          status: () => 200,
+          headers: () => ({ "content-type": "text/html" }),
+          text: () => Promise.resolve("<html></html>"),
+          request: () => mockRequest2,
+        });
+      });
+
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      const result = await openPage("https://example.com", 10000, []);
+
+      expect(result.responses).toHaveLength(1);
+      expect(result.responses[0]).toMatchObject({
+        url: "https://example.com/new",
+        status: 200,
+      });
+    });
+
+    it("should discard responses from previous navigation on JS redirect", async () => {
+      let capturedResponseCallback: (response: unknown) => Promise<void>;
+      let capturedRequestCallback: (request: unknown) => void;
+      let capturedFramenavigatedCallback: (frame: unknown) => void;
+
+      // mainFrame is defined at describe scope
+
+      mockPage.on.mockImplementation(
+        (event: string, callback: (...args: unknown[]) => void) => {
+          if (event === "response") {
+            capturedResponseCallback = callback as (response: unknown) => Promise<void>;
+          } else if (event === "request") {
+            capturedRequestCallback = callback as (request: unknown) => void;
+          } else if (event === "framenavigated") {
+            capturedFramenavigatedCallback = callback as (frame: unknown) => void;
+          }
+        },
+      );
+
+      const oldRequest = {};
+      const newRequest = {};
+      mockPage.goto.mockImplementation(async () => {
+        // First page loads a resource
+        capturedRequestCallback(oldRequest);
+        await capturedResponseCallback({
+          url: () => "https://example.com/old.js",
+          status: () => 200,
+          headers: () => ({ "content-type": "text/javascript" }),
+          text: () => Promise.resolve("old"),
+          request: () => oldRequest,
+        });
+        // JS redirect causes navigation
+        capturedFramenavigatedCallback(mainFrame);
+        // New page loads a resource
+        capturedRequestCallback(newRequest);
+        await capturedResponseCallback({
+          url: () => "https://redirected.test/new.js",
+          status: () => 200,
+          headers: () => ({ "content-type": "text/javascript" }),
+          text: () => Promise.resolve("new"),
+          request: () => newRequest,
+        });
+      });
+
+      mockPage.url.mockReturnValue("https://redirected.test");
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      const result = await openPage("https://example.com", 10000, []);
+
+      expect(result.responses).toHaveLength(1);
+      expect(result.responses[0]).toMatchObject({
+        url: "https://redirected.test/new.js",
+      });
+    });
+
+    it("should discard late responses from previous navigation generation", async () => {
+      let capturedResponseCallback: (response: unknown) => Promise<void>;
+      let capturedRequestCallback: (request: unknown) => void;
+      let capturedFramenavigatedCallback: (frame: unknown) => void;
+
+      // mainFrame is defined at describe scope
+
+      mockPage.on.mockImplementation(
+        (event: string, callback: (...args: unknown[]) => void) => {
+          if (event === "response") {
+            capturedResponseCallback = callback as (response: unknown) => Promise<void>;
+          } else if (event === "request") {
+            capturedRequestCallback = callback as (request: unknown) => void;
+          } else if (event === "framenavigated") {
+            capturedFramenavigatedCallback = callback as (frame: unknown) => void;
+          }
+        },
+      );
+
+      const oldRequest = {};
+      const newRequest = {};
+      mockPage.goto.mockImplementation(async () => {
+        // Request starts on old page
+        capturedRequestCallback(oldRequest);
+        // JS redirect causes navigation before response arrives
+        capturedFramenavigatedCallback(mainFrame);
+        // New page loads
+        capturedRequestCallback(newRequest);
+        await capturedResponseCallback({
+          url: () => "https://redirected.test/page",
+          status: () => 200,
+          headers: () => ({ "content-type": "text/html" }),
+          text: () => Promise.resolve("<html></html>"),
+          request: () => newRequest,
+        });
+        // Late response from old page arrives after navigation
+        await capturedResponseCallback({
+          url: () => "https://example.com/old.js",
+          status: () => 200,
+          headers: () => ({ "content-type": "text/javascript" }),
+          text: () => Promise.resolve("old"),
+          request: () => oldRequest,
+        });
+      });
+
+      mockPage.url.mockReturnValue("https://redirected.test");
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      const result = await openPage("https://example.com", 10000, []);
+
+      expect(result.responses).toHaveLength(1);
+      expect(result.responses[0]).toMatchObject({
+        url: "https://redirected.test/page",
+      });
+    });
+
+    it("should recalculate isFirstParty based on final host after redirect", async () => {
+      let capturedResponseCallback: (response: unknown) => Promise<void>;
+      let capturedRequestCallback: (request: unknown) => void;
+      let capturedFramenavigatedCallback: (frame: unknown) => void;
+
+      // mainFrame is defined at describe scope
+
+      mockPage.on.mockImplementation(
+        (event: string, callback: (...args: unknown[]) => void) => {
+          if (event === "response") {
+            capturedResponseCallback = callback as (response: unknown) => Promise<void>;
+          } else if (event === "request") {
+            capturedRequestCallback = callback as (request: unknown) => void;
+          } else if (event === "framenavigated") {
+            capturedFramenavigatedCallback = callback as (frame: unknown) => void;
+          }
+        },
+      );
+
+      const req1 = {};
+      const req2 = {};
+      mockPage.goto.mockImplementation(async () => {
+        capturedFramenavigatedCallback(mainFrame);
+        capturedRequestCallback(req1);
+        await capturedResponseCallback({
+          url: () => "https://redirected.test/page",
+          status: () => 200,
+          headers: () => ({ "content-type": "text/html" }),
+          text: () => Promise.resolve("<html></html>"),
+          request: () => req1,
+        });
+        capturedRequestCallback(req2);
+        await capturedResponseCallback({
+          url: () => "https://cdn.example.net/lib.js",
+          status: () => 200,
+          headers: () => ({ "content-type": "text/javascript" }),
+          text: () => Promise.resolve("lib"),
+          request: () => req2,
+        });
+      });
+
+      // Final URL is different from initial URL
+      mockPage.url.mockReturnValue("https://redirected.test");
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      const result = await openPage("https://example.com", 10000, []);
+
+      // redirected.test is first-party (final host), cdn.example.net is third-party
+      expect(result.responses[0]).toMatchObject({
+        host: "redirected.test",
+        isFirstParty: true,
+      });
+      expect(result.responses[1]).toMatchObject({
+        host: "cdn.example.net",
+        isFirstParty: false,
+      });
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining("Redirect detected"),
+      );
     });
   });
 });

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -1,4 +1,4 @@
-import { chromium } from "playwright";
+import { chromium, type Request as PlaywrightRequest } from "playwright";
 import chalk from "chalk";
 import type { Context, Response } from "./types.js";
 import {
@@ -50,7 +50,24 @@ export async function openPage(
   const page = await context.newPage();
 
   const responses: Response[] = [];
+  let navigationGeneration = 0;
+  const requestGenerations = new WeakMap<PlaywrightRequest, number>();
+
+  // Discard responses from previous navigations (JS/meta redirects)
+  page.on("framenavigated", (frame) => {
+    if (frame === page.mainFrame()) {
+      navigationGeneration++;
+      responses.length = 0;
+    }
+  });
+
+  // Record generation at request time (synchronous, no race condition)
+  page.on("request", (request) => {
+    requestGenerations.set(request, navigationGeneration);
+  });
+
   page.on("response", async (response) => {
+    const gen = requestGenerations.get(response.request()) ?? -1;
     const responseUrl = response.url();
     const responseHost = getHostFromUrl(responseUrl) ?? "";
     const statusCode = response.status();
@@ -60,9 +77,7 @@ export async function openPage(
     const res: Response = {
       url: responseUrl,
       host: responseHost,
-      isFirstParty: responseHost
-        ? isFirstPartyHost(pageHost, responseHost)
-        : false,
+      isFirstParty: false,
       status: statusCode,
       headers: response.headers(),
     };
@@ -72,6 +87,7 @@ export async function openPage(
       res.body = body;
     }
 
+    if (gen !== navigationGeneration) return;
     responses.push(res);
   });
 
@@ -92,6 +108,28 @@ export async function openPage(
     logger.error(`Error loading page ${url}: ${result.split("\n")[0]}`);
   }
 
+  // Use the final URL (after redirects) to determine first-party scope
+  const finalHost = getHostFromUrl(page.url()) ?? pageHost;
+  if (finalHost !== pageHost) {
+    logger.debug(
+      `Redirect detected: using final host ${chalk.cyan(finalHost)} for first-party scope`,
+    );
+  }
+
+  // Remove redirect responses (they have no content, only intermediate infrastructure headers)
+  const filtered = responses.filter(
+    (r) => r.status < 300 || r.status >= 400,
+  );
+  responses.length = 0;
+  responses.push(...filtered);
+
+  // Recalculate isFirstParty for all responses based on the final host
+  for (const res of responses) {
+    res.isFirstParty = res.host
+      ? isFirstPartyHost(finalHost, res.host)
+      : false;
+  }
+
   let cookies: Context["cookies"] = [];
   let javascriptVariables: Record<string, unknown> = {};
 
@@ -100,7 +138,7 @@ export async function openPage(
       const cookieHost = cookie.domain.replace(/^\./, "").toLowerCase();
       return {
         host: cookieHost,
-        isFirstParty: isFirstPartyHost(pageHost, cookieHost),
+        isFirstParty: isFirstPartyHost(finalHost, cookieHost),
         name: cookie.name,
         value: cookie.value,
         domain: cookie.domain,


### PR DESCRIPTION
## Summary
- Discard responses from intermediate JS/meta redirect pages using `framenavigated` event with a generation counter (`WeakMap` keyed by request, recorded synchronously to avoid race conditions with async body reading)
- Filter out HTTP 3xx redirect responses (they contain no content, only intermediate infrastructure headers)
- Recalculate `isFirstParty` for all responses and cookies based on the final URL after redirects

## Background
When redirects occur, tech stacks from intermediate pages were incorrectly detected:
- HTTP 3xx redirects: headers from the redirect response (e.g. load balancer `Server` header) appeared in results
- JS/meta redirects: libraries loaded by intermediate pages were included in results

## Test plan
- [ ] HTTP 3xx redirect site → intermediate infrastructure is excluded from results
- [ ] JS redirect page → intermediate page libraries are excluded
- [ ] Non-redirect pages → detection works as before
- [ ] `npm run build && npm test` passes
