### PR TITLE
fix: stabilize evidence ordering in detect output

### DIFF
--- a/src/commands/detect_utils.test.ts
+++ b/src/commands/detect_utils.test.ts
@@ -365,6 +365,104 @@ describe("makeDetectCommandOutput", () => {
       expect(result.detectedSoftwares[0]!.confidence).toBe("low");
     });
   });
+
+  describe("evidence ordering", () => {
+    it("should sort evidences by explicit key order", () => {
+      const detections: Detection[] = [
+        {
+          name: "nginx",
+          evidences: [
+            {
+              type: "header",
+              value: "B",
+              version: undefined,
+              confidence: "high",
+              host: "b.example.com",
+              sourceUrl: "https://b.example.com/app.js",
+            },
+            {
+              type: "body",
+              value: "Z",
+              version: undefined,
+              confidence: "high",
+              host: "z.example.com",
+              sourceUrl: "https://z.example.com/index.html",
+            },
+            {
+              type: "header",
+              value: "A",
+              version: undefined,
+              confidence: "high",
+              host: "a.example.com",
+              sourceUrl: "https://a.example.com/app.js",
+            },
+            {
+              type: "header",
+              value: "B",
+              version: undefined,
+              confidence: "low",
+              host: "a.example.com",
+              sourceUrl: "https://a.example.com/app.js",
+            },
+          ],
+        },
+      ];
+
+      const result = makeDetectCommandOutput(detections, baseSignatures);
+      const evidences = result.detectedSoftwares[0]!.evidences!;
+
+      expect(
+        evidences.map((e) => `${e.type}|${e.value}|${e.host}|${e.sourceUrl}|${e.confidence}`),
+      ).toEqual([
+        "body|Z|z.example.com|https://z.example.com/index.html|high",
+        "header|A|a.example.com|https://a.example.com/app.js|high",
+        "header|B|b.example.com|https://b.example.com/app.js|high",
+        "header|B|a.example.com|https://a.example.com/app.js|low",
+      ]);
+    });
+
+    it("should keep merged evidences in stable order", () => {
+      const detections: Detection[] = [
+        {
+          name: "nginx",
+          evidences: [
+            {
+              type: "header",
+              value: "Server: nginx/1.20.0",
+              version: "1.20.0",
+              confidence: "high",
+              host: "b.example.com",
+              sourceUrl: "https://b.example.com",
+            },
+          ],
+        },
+        {
+          name: "nginx",
+          evidences: [
+            {
+              type: "header",
+              value: "Server: nginx/1.20.0",
+              version: "1.20.0",
+              confidence: "high",
+              host: "a.example.com",
+              sourceUrl: "https://a.example.com",
+            },
+          ],
+        },
+      ];
+
+      const result = makeDetectCommandOutput(detections, baseSignatures);
+      const nginx = result.detectedSoftwares.find(
+        (s) => s.name === "nginx" && s.version === "1.20.0",
+      );
+
+      expect(nginx).toBeDefined();
+      expect(nginx!.evidences!.map((e) => e.host)).toEqual([
+        "a.example.com",
+        "b.example.com",
+      ]);
+    });
+  });
 });
 
 describe("printDetectCommandOutputAsText", () => {

--- a/src/commands/detect_utils.ts
+++ b/src/commands/detect_utils.ts
@@ -1,6 +1,6 @@
 import chalk from "chalk";
 import type { Confidence, Signature } from "../signatures/_types.js";
-import type { Detection } from "../analyzer/types.js";
+import type { Detection, Evidence } from "../analyzer/types.js";
 import type { DetectCommandOutput, DetectedSoftware } from "./detect_types.js";
 import { maxConfidence } from "../analyzer/utils.js";
 
@@ -17,6 +17,21 @@ export function colorizeConfidence(confidence: Confidence): string {
   }
 }
 
+function compareMaybeString(a?: string, b?: string): number {
+  return (a ?? "").localeCompare(b ?? "");
+}
+
+function compareEvidence(a: Evidence, b: Evidence): number {
+  return (
+    compareMaybeString(a.type, b.type) ||
+    compareMaybeString(a.value, b.value) ||
+    compareMaybeString(a.version, b.version) ||
+    compareMaybeString(a.confidence, b.confidence) ||
+    compareMaybeString(a.host, b.host) ||
+    compareMaybeString(a.sourceUrl, b.sourceUrl)
+  );
+}
+
 export function makeDetectCommandOutput(
   detections: Detection[],
   signatures: Signature[],
@@ -26,7 +41,7 @@ export function makeDetectCommandOutput(
     const signature = signatures.find(
       (signature) => signature.name === detection.name,
     )!;
-    const evidences = detection.evidences || [];
+    const evidences = [...(detection.evidences || [])].sort(compareEvidence);
 
     // Group evidences by version
     const versionGroups = new Map<string | undefined, typeof evidences>();
@@ -134,7 +149,7 @@ export function makeDetectCommandOutput(
     const evidences = [
       ...(existing.evidences || []),
       ...(software.evidences || []),
-    ];
+    ].sort(compareEvidence);
     if (evidences.length > 0) {
       merged.evidences = evidences;
     }


### PR DESCRIPTION
## Summary
- Fix unstable `evidences` ordering in `detect` output caused by timing-dependent collection order.
- Sort `evidences` in `makeDetectCommandOutput` using an explicit comparison order:
  `type -> value -> version -> confidence -> host -> sourceUrl`.
- Add tests to verify deterministic ordering for both direct and merged evidences.

## Test plan
- [x] `npm test -- src/commands/detect_utils.test.ts`
- [x] Verified evidence ordering is stable even when input order differs.
- [x] Verified merged evidences also keep a stable order.

## Notes
- The comparison order follows the `Evidence` field order for readability and maintainability.