### PR TITLE
feat: add --block-cross-domain-redirect flag to detect command

### DIFF
--- a/src/browser/index.test.ts
+++ b/src/browser/index.test.ts
@@ -227,6 +227,139 @@ describe("openPage", () => {
       );
     });
 
+    it("should always continue when policy is any", async () => {
+      let routeHandler: (route: unknown) => Promise<void> = async () => {};
+      mockPage.route.mockImplementation(
+        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+          routeHandler = handler;
+        },
+      );
+
+      await openPage("https://example.com", 10000, [], undefined, RedirectPolicy.Any);
+
+      const continueMock = vi.fn(() => Promise.resolve());
+      const abortMock = vi.fn(() => Promise.resolve());
+      await routeHandler({
+        request: () => ({
+          isNavigationRequest: () => true,
+          frame: () => mockMainFrame,
+          url: () => "https://example.net",
+        }),
+        continue: continueMock,
+        abort: abortMock,
+      });
+
+      expect(continueMock).toHaveBeenCalledTimes(1);
+      expect(abortMock).not.toHaveBeenCalled();
+    });
+
+    it("should continue for non-navigation requests", async () => {
+      let routeHandler: (route: unknown) => Promise<void> = async () => {};
+      mockPage.route.mockImplementation(
+        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+          routeHandler = handler;
+        },
+      );
+
+      await openPage(
+        "https://example.com",
+        10000,
+        [],
+        undefined,
+        RedirectPolicy.SameHost,
+      );
+
+      const continueMock = vi.fn(() => Promise.resolve());
+      const abortMock = vi.fn(() => Promise.resolve());
+      await routeHandler({
+        request: () => ({
+          isNavigationRequest: () => false,
+          frame: () => mockMainFrame,
+          url: () => "https://example.net/script.js",
+        }),
+        continue: continueMock,
+        abort: abortMock,
+      });
+
+      expect(continueMock).toHaveBeenCalledTimes(1);
+      expect(abortMock).not.toHaveBeenCalled();
+    });
+
+    it("should continue for non-main-frame navigation requests", async () => {
+      let routeHandler: (route: unknown) => Promise<void> = async () => {};
+      mockPage.route.mockImplementation(
+        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+          routeHandler = handler;
+        },
+      );
+
+      await openPage(
+        "https://example.com",
+        10000,
+        [],
+        undefined,
+        RedirectPolicy.SameHost,
+      );
+
+      const continueMock = vi.fn(() => Promise.resolve());
+      const abortMock = vi.fn(() => Promise.resolve());
+      await routeHandler({
+        request: () => ({
+          isNavigationRequest: () => true,
+          frame: () => ({ id: "iframe-1" }),
+          url: () => "https://example.net/embedded",
+        }),
+        continue: continueMock,
+        abort: abortMock,
+      });
+
+      expect(continueMock).toHaveBeenCalledTimes(1);
+      expect(abortMock).not.toHaveBeenCalled();
+    });
+
+    it("should continue when navigation target host cannot be parsed", async () => {
+      let routeHandler: (route: unknown) => Promise<void> = async () => {};
+      mockPage.route.mockImplementation(
+        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+          routeHandler = handler;
+        },
+      );
+
+      await openPage(
+        "https://example.com",
+        10000,
+        [],
+        undefined,
+        RedirectPolicy.SameHost,
+      );
+
+      const continueMock = vi.fn(() => Promise.resolve());
+      const abortMock = vi.fn(() => Promise.resolve());
+      // first top-level navigation
+      await routeHandler({
+        request: () => ({
+          isNavigationRequest: () => true,
+          frame: () => mockMainFrame,
+          url: () => "https://example.com",
+        }),
+        continue: continueMock,
+        abort: abortMock,
+      });
+      // second top-level navigation with invalid URL should still continue
+      await routeHandler({
+        request: () => ({
+          isNavigationRequest: () => true,
+          frame: () => mockMainFrame,
+          url: () => "not-a-url",
+        }),
+        continue: continueMock,
+        abort: abortMock,
+      });
+
+      expect(continueMock).toHaveBeenCalledTimes(2);
+      expect(abortMock).not.toHaveBeenCalled();
+    });
+
     it("should allow same-site redirect for subdomains", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(

--- a/src/browser/index.test.ts
+++ b/src/browser/index.test.ts
@@ -1,10 +1,13 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { openPage } from "./index.js";
+import { RedirectPolicy } from "./types.js";
 
 // Mock playwright
 vi.mock("playwright", () => {
   const mockPage = {
     on: vi.fn(),
+    route: vi.fn(),
+    mainFrame: vi.fn(),
     goto: vi.fn(),
     context: vi.fn(),
     evaluate: vi.fn(),
@@ -54,6 +57,8 @@ import { sleep } from "./utils.js";
 describe("openPage", () => {
   let mockPage: {
     on: ReturnType<typeof vi.fn>;
+    route: ReturnType<typeof vi.fn>;
+    mainFrame: ReturnType<typeof vi.fn>;
     goto: ReturnType<typeof vi.fn>;
     context: ReturnType<typeof vi.fn>;
     evaluate: ReturnType<typeof vi.fn>;
@@ -67,6 +72,7 @@ describe("openPage", () => {
     newContext: ReturnType<typeof vi.fn>;
     close: ReturnType<typeof vi.fn>;
   };
+  let mockMainFrame: { id: string };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -74,6 +80,8 @@ describe("openPage", () => {
     // Get references to mocked objects
     mockPage = {
       on: vi.fn(),
+      route: vi.fn(),
+      mainFrame: vi.fn(),
       goto: vi.fn(() => Promise.resolve()),
       context: vi.fn(),
       evaluate: vi.fn(() => Promise.resolve({})),
@@ -90,7 +98,9 @@ describe("openPage", () => {
       close: vi.fn(),
     };
 
+    mockMainFrame = { id: "main-frame" };
     mockPage.context.mockReturnValue(mockBrowserContext);
+    mockPage.mainFrame.mockReturnValue(mockMainFrame);
 
     vi.mocked(chromium.launch).mockResolvedValue(mockBrowser as never);
   });
@@ -157,6 +167,152 @@ describe("openPage", () => {
       expect(result).toHaveProperty("cookies");
       expect(result).toHaveProperty("timeoutMs", 5000);
       expect(result).toHaveProperty("timeoutOccurred", false);
+    });
+  });
+
+  describe("redirect policy", () => {
+    it("should register route handler for request interception", async () => {
+      await openPage("https://example.com", 10000, []);
+
+      expect(mockPage.route).toHaveBeenCalledWith("**/*", expect.any(Function));
+    });
+
+    it("should block cross-host redirect when policy is same-host", async () => {
+      let routeHandler: (route: unknown) => Promise<void> = async () => {};
+      mockPage.route.mockImplementation(
+        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+          routeHandler = handler;
+        },
+      );
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      await openPage(
+        "https://example.com",
+        10000,
+        [],
+        undefined,
+        RedirectPolicy.SameHost,
+      );
+
+      const continueMock = vi.fn(() => Promise.resolve());
+      const abortMock = vi.fn(() => Promise.resolve());
+      // Initial navigation should always be allowed
+      await routeHandler({
+        request: () => ({
+          isNavigationRequest: () => true,
+          frame: () => mockMainFrame,
+          url: () => "https://example.com",
+        }),
+        continue: continueMock,
+        abort: abortMock,
+      });
+
+      // JS-driven navigation to different host should be blocked
+      await routeHandler({
+        request: () => ({
+          isNavigationRequest: () => true,
+          frame: () => mockMainFrame,
+          url: () => "https://www.example.com",
+        }),
+        continue: continueMock,
+        abort: abortMock,
+      });
+
+      expect(abortMock).toHaveBeenCalledWith("blockedbyclient");
+      expect(continueMock).toHaveBeenCalledTimes(1);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Blocked redirect by policy same-host"),
+      );
+    });
+
+    it("should allow same-site redirect for subdomains", async () => {
+      let routeHandler: (route: unknown) => Promise<void> = async () => {};
+      mockPage.route.mockImplementation(
+        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+          routeHandler = handler;
+        },
+      );
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      await openPage(
+        "https://app.example.com",
+        10000,
+        [],
+        undefined,
+        RedirectPolicy.SameSite,
+      );
+
+      const continueMock = vi.fn(() => Promise.resolve());
+      const abortMock = vi.fn(() => Promise.resolve());
+      await routeHandler({
+        request: () => ({
+          isNavigationRequest: () => true,
+          frame: () => mockMainFrame,
+          url: () => "https://app.example.com",
+        }),
+        continue: continueMock,
+        abort: abortMock,
+      });
+      await routeHandler({
+        request: () => ({
+          isNavigationRequest: () => true,
+          frame: () => mockMainFrame,
+          url: () => "https://cdn.example.com",
+        }),
+        continue: continueMock,
+        abort: abortMock,
+      });
+
+      expect(continueMock).toHaveBeenCalledTimes(2);
+      expect(abortMock).not.toHaveBeenCalled();
+    });
+
+    it("should block cross-site redirect when policy is same-site", async () => {
+      let routeHandler: (route: unknown) => Promise<void> = async () => {};
+      mockPage.route.mockImplementation(
+        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+          routeHandler = handler;
+        },
+      );
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      await openPage(
+        "https://example.com",
+        10000,
+        [],
+        undefined,
+        RedirectPolicy.SameSite,
+      );
+
+      const continueMock = vi.fn(() => Promise.resolve());
+      const abortMock = vi.fn(() => Promise.resolve());
+      await routeHandler({
+        request: () => ({
+          isNavigationRequest: () => true,
+          frame: () => mockMainFrame,
+          url: () => "https://example.com",
+        }),
+        continue: continueMock,
+        abort: abortMock,
+      });
+      await routeHandler({
+        request: () => ({
+          isNavigationRequest: () => true,
+          frame: () => mockMainFrame,
+          url: () => "https://example.net",
+        }),
+        continue: continueMock,
+        abort: abortMock,
+      });
+
+      expect(abortMock).toHaveBeenCalledWith("blockedbyclient");
+      expect(continueMock).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/browser/index.test.ts
+++ b/src/browser/index.test.ts
@@ -177,7 +177,7 @@ describe("openPage", () => {
       expect(mockPage.route).toHaveBeenCalledWith("**/*", expect.any(Function));
     });
 
-    it("should block cross-host redirect when policy is same-host", async () => {
+    it("should block first cross-host navigation when policy is same-host", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
         async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
@@ -198,18 +198,8 @@ describe("openPage", () => {
 
       const continueMock = vi.fn(() => Promise.resolve());
       const abortMock = vi.fn(() => Promise.resolve());
-      // Initial navigation should always be allowed
-      await routeHandler({
-        request: () => ({
-          isNavigationRequest: () => true,
-          frame: () => mockMainFrame,
-          url: () => "https://example.com",
-        }),
-        continue: continueMock,
-        abort: abortMock,
-      });
-
-      // JS-driven navigation to different host should be blocked
+      const fetchMock = vi.fn();
+      const fulfillMock = vi.fn(() => Promise.resolve());
       await routeHandler({
         request: () => ({
           isNavigationRequest: () => true,
@@ -218,10 +208,13 @@ describe("openPage", () => {
         }),
         continue: continueMock,
         abort: abortMock,
+        fetch: fetchMock,
+        fulfill: fulfillMock,
       });
 
       expect(abortMock).toHaveBeenCalledWith("blockedbyclient");
-      expect(continueMock).toHaveBeenCalledTimes(1);
+      expect(continueMock).not.toHaveBeenCalled();
+      expect(fetchMock).not.toHaveBeenCalled();
       expect(logger.warn).toHaveBeenCalledWith(
         expect.stringContaining("Blocked redirect by policy same-host"),
       );
@@ -333,8 +326,11 @@ describe("openPage", () => {
         RedirectPolicy.SameHost,
       );
 
+      const mockResponse = { status: () => 200, headers: () => ({}) };
       const continueMock = vi.fn(() => Promise.resolve());
       const abortMock = vi.fn(() => Promise.resolve());
+      const fetchMock = vi.fn(() => Promise.resolve(mockResponse));
+      const fulfillMock = vi.fn(() => Promise.resolve());
       // first top-level navigation
       await routeHandler({
         request: () => ({
@@ -344,6 +340,8 @@ describe("openPage", () => {
         }),
         continue: continueMock,
         abort: abortMock,
+        fetch: fetchMock,
+        fulfill: fulfillMock,
       });
       // second top-level navigation with invalid URL should still continue
       await routeHandler({
@@ -354,9 +352,13 @@ describe("openPage", () => {
         }),
         continue: continueMock,
         abort: abortMock,
+        fetch: fetchMock,
+        fulfill: fulfillMock,
       });
 
-      expect(continueMock).toHaveBeenCalledTimes(2);
+      // First call uses fetch+fulfill (same host, allowed), second uses continue (unparseable URL)
+      expect(fulfillMock).toHaveBeenCalledTimes(1);
+      expect(continueMock).toHaveBeenCalledTimes(1);
       expect(abortMock).not.toHaveBeenCalled();
     });
 
@@ -379,8 +381,11 @@ describe("openPage", () => {
         RedirectPolicy.SameSite,
       );
 
+      const mockResponse = { status: () => 200, headers: () => ({}) };
       const continueMock = vi.fn(() => Promise.resolve());
       const abortMock = vi.fn(() => Promise.resolve());
+      const fetchMock = vi.fn(() => Promise.resolve(mockResponse));
+      const fulfillMock = vi.fn(() => Promise.resolve());
       await routeHandler({
         request: () => ({
           isNavigationRequest: () => true,
@@ -389,6 +394,8 @@ describe("openPage", () => {
         }),
         continue: continueMock,
         abort: abortMock,
+        fetch: fetchMock,
+        fulfill: fulfillMock,
       });
       await routeHandler({
         request: () => ({
@@ -398,13 +405,15 @@ describe("openPage", () => {
         }),
         continue: continueMock,
         abort: abortMock,
+        fetch: fetchMock,
+        fulfill: fulfillMock,
       });
 
-      expect(continueMock).toHaveBeenCalledTimes(2);
+      expect(fulfillMock).toHaveBeenCalledTimes(2);
       expect(abortMock).not.toHaveBeenCalled();
     });
 
-    it("should block cross-site redirect when policy is same-site", async () => {
+    it("should block first cross-site navigation when policy is same-site", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
         async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
@@ -425,15 +434,8 @@ describe("openPage", () => {
 
       const continueMock = vi.fn(() => Promise.resolve());
       const abortMock = vi.fn(() => Promise.resolve());
-      await routeHandler({
-        request: () => ({
-          isNavigationRequest: () => true,
-          frame: () => mockMainFrame,
-          url: () => "https://example.com",
-        }),
-        continue: continueMock,
-        abort: abortMock,
-      });
+      const fetchMock = vi.fn();
+      const fulfillMock = vi.fn(() => Promise.resolve());
       await routeHandler({
         request: () => ({
           isNavigationRequest: () => true,
@@ -442,10 +444,235 @@ describe("openPage", () => {
         }),
         continue: continueMock,
         abort: abortMock,
+        fetch: fetchMock,
+        fulfill: fulfillMock,
       });
 
       expect(abortMock).toHaveBeenCalledWith("blockedbyclient");
-      expect(continueMock).toHaveBeenCalledTimes(1);
+      expect(continueMock).not.toHaveBeenCalled();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("should block HTTP 301 redirect to cross-host when policy is same-host", async () => {
+      let routeHandler: (route: unknown) => Promise<void> = async () => {};
+      mockPage.route.mockImplementation(
+        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+          routeHandler = handler;
+        },
+      );
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      await openPage(
+        "https://www.example.com",
+        10000,
+        [],
+        undefined,
+        RedirectPolicy.SameHost,
+      );
+
+      const mockResponse = {
+        status: () => 301,
+        headers: () => ({ location: "https://example.com/" }),
+      };
+      const continueMock = vi.fn(() => Promise.resolve());
+      const abortMock = vi.fn(() => Promise.resolve());
+      const fetchMock = vi.fn(() => Promise.resolve(mockResponse));
+      const fulfillMock = vi.fn(() => Promise.resolve());
+      await routeHandler({
+        request: () => ({
+          isNavigationRequest: () => true,
+          frame: () => mockMainFrame,
+          url: () => "https://www.example.com",
+        }),
+        continue: continueMock,
+        abort: abortMock,
+        fetch: fetchMock,
+        fulfill: fulfillMock,
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith({ maxRedirects: 0 });
+      expect(abortMock).toHaveBeenCalledWith("blockedbyclient");
+      expect(fulfillMock).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Blocked redirect by policy same-host: https://example.com/"),
+      );
+    });
+
+    it("should allow HTTP 301 redirect to same host", async () => {
+      let routeHandler: (route: unknown) => Promise<void> = async () => {};
+      mockPage.route.mockImplementation(
+        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+          routeHandler = handler;
+        },
+      );
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      await openPage(
+        "https://example.com",
+        10000,
+        [],
+        undefined,
+        RedirectPolicy.SameHost,
+      );
+
+      const mockResponse = {
+        status: () => 301,
+        headers: () => ({ location: "https://example.com/top" }),
+      };
+      const continueMock = vi.fn(() => Promise.resolve());
+      const abortMock = vi.fn(() => Promise.resolve());
+      const fetchMock = vi.fn(() => Promise.resolve(mockResponse));
+      const fulfillMock = vi.fn(() => Promise.resolve());
+      await routeHandler({
+        request: () => ({
+          isNavigationRequest: () => true,
+          frame: () => mockMainFrame,
+          url: () => "https://example.com",
+        }),
+        continue: continueMock,
+        abort: abortMock,
+        fetch: fetchMock,
+        fulfill: fulfillMock,
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith({ maxRedirects: 0 });
+      expect(fulfillMock).toHaveBeenCalledWith({ response: mockResponse });
+      expect(abortMock).not.toHaveBeenCalled();
+    });
+
+    it("should fulfill response when Location header is malformed", async () => {
+      let routeHandler: (route: unknown) => Promise<void> = async () => {};
+      mockPage.route.mockImplementation(
+        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+          routeHandler = handler;
+        },
+      );
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      await openPage(
+        "https://example.com",
+        10000,
+        [],
+        undefined,
+        RedirectPolicy.SameHost,
+      );
+
+      const mockResponse = {
+        status: () => 301,
+        headers: () => ({ location: "://broken" }),
+      };
+      const continueMock = vi.fn(() => Promise.resolve());
+      const abortMock = vi.fn(() => Promise.resolve());
+      const fetchMock = vi.fn(() => Promise.resolve(mockResponse));
+      const fulfillMock = vi.fn(() => Promise.resolve());
+      await routeHandler({
+        request: () => ({
+          isNavigationRequest: () => true,
+          frame: () => mockMainFrame,
+          url: () => "https://example.com",
+        }),
+        continue: continueMock,
+        abort: abortMock,
+        fetch: fetchMock,
+        fulfill: fulfillMock,
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith({ maxRedirects: 0 });
+      expect(fulfillMock).toHaveBeenCalledWith({ response: mockResponse });
+      expect(abortMock).not.toHaveBeenCalled();
+    });
+
+    it("should block HTTP 302 redirect to cross-site when policy is same-site", async () => {
+      let routeHandler: (route: unknown) => Promise<void> = async () => {};
+      mockPage.route.mockImplementation(
+        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+          routeHandler = handler;
+        },
+      );
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      await openPage(
+        "https://example.com",
+        10000,
+        [],
+        undefined,
+        RedirectPolicy.SameSite,
+      );
+
+      const mockResponse = {
+        status: () => 302,
+        headers: () => ({ location: "https://other.example/login" }),
+      };
+      const continueMock = vi.fn(() => Promise.resolve());
+      const abortMock = vi.fn(() => Promise.resolve());
+      const fetchMock = vi.fn(() => Promise.resolve(mockResponse));
+      const fulfillMock = vi.fn(() => Promise.resolve());
+      await routeHandler({
+        request: () => ({
+          isNavigationRequest: () => true,
+          frame: () => mockMainFrame,
+          url: () => "https://example.com",
+        }),
+        continue: continueMock,
+        abort: abortMock,
+        fetch: fetchMock,
+        fulfill: fulfillMock,
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith({ maxRedirects: 0 });
+      expect(abortMock).toHaveBeenCalledWith("blockedbyclient");
+      expect(fulfillMock).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Blocked redirect by policy same-site"),
+      );
+    });
+
+    it("should abort when route.fetch() throws an error", async () => {
+      let routeHandler: (route: unknown) => Promise<void> = async () => {};
+      mockPage.route.mockImplementation(
+        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+          routeHandler = handler;
+        },
+      );
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      await openPage(
+        "https://example.com",
+        10000,
+        [],
+        undefined,
+        RedirectPolicy.SameHost,
+      );
+
+      const continueMock = vi.fn(() => Promise.resolve());
+      const abortMock = vi.fn(() => Promise.resolve());
+      const fetchMock = vi.fn(() => Promise.reject(new Error("net::ERR_CONNECTION_REFUSED")));
+      const fulfillMock = vi.fn(() => Promise.resolve());
+      await routeHandler({
+        request: () => ({
+          isNavigationRequest: () => true,
+          frame: () => mockMainFrame,
+          url: () => "https://example.com",
+        }),
+        continue: continueMock,
+        abort: abortMock,
+        fetch: fetchMock,
+        fulfill: fulfillMock,
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith({ maxRedirects: 0 });
+      expect(abortMock).toHaveBeenCalledWith("failed");
+      expect(fulfillMock).not.toHaveBeenCalled();
     });
   });
 
@@ -478,6 +705,43 @@ describe("openPage", () => {
       expect(logger.error).toHaveBeenCalledWith(
         expect.stringContaining("Connection refused"),
       );
+    });
+
+    it("should not log error when navigation is blocked by redirect policy", async () => {
+      let routeHandler: (route: unknown) => Promise<void> = async () => {};
+      mockPage.route.mockImplementation(
+        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+          routeHandler = handler;
+        },
+      );
+      mockPage.goto.mockImplementation(async () => {
+        // Simulate the route handler blocking a cross-host redirect
+        await routeHandler({
+          request: () => ({
+            isNavigationRequest: () => true,
+            frame: () => mockMainFrame,
+            url: () => "https://other.example",
+          }),
+          continue: vi.fn(() => Promise.resolve()),
+          abort: vi.fn(() => Promise.resolve()),
+          fetch: vi.fn(),
+          fulfill: vi.fn(() => Promise.resolve()),
+        });
+        throw new Error("page.goto: net::ERR_BLOCKED_BY_CLIENT");
+      });
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      await openPage(
+        "https://example.com",
+        10000,
+        [],
+        undefined,
+        RedirectPolicy.SameHost,
+      );
+
+      expect(logger.error).not.toHaveBeenCalled();
     });
 
     it("should handle cookie/JS extraction failure gracefully", async () => {

--- a/src/browser/index.test.ts
+++ b/src/browser/index.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { openPage } from "./index.js";
-import { RedirectPolicy } from "./types.js";
 
 // Mock playwright
 vi.mock("playwright", () => {
@@ -177,7 +176,7 @@ describe("openPage", () => {
       expect(mockPage.route).toHaveBeenCalledWith("**/*", expect.any(Function));
     });
 
-    it("should block first cross-host navigation when policy is same-host", async () => {
+    it("should block cross-domain navigation when blocking is enabled", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
         async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
@@ -193,7 +192,7 @@ describe("openPage", () => {
         10000,
         [],
         undefined,
-        RedirectPolicy.SameHost,
+        true,
       );
 
       const continueMock = vi.fn(() => Promise.resolve());
@@ -216,11 +215,11 @@ describe("openPage", () => {
       expect(continueMock).not.toHaveBeenCalled();
       expect(fetchMock).not.toHaveBeenCalled();
       expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining("Blocked redirect by policy same-host"),
+        expect.stringContaining("Blocked cross-domain redirect"),
       );
     });
 
-    it("should allow any redirect and use fetch/fulfill when policy is any", async () => {
+    it("should allow any redirect when blocking is disabled", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
         async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
@@ -228,7 +227,7 @@ describe("openPage", () => {
         },
       );
 
-      await openPage("https://example.com", 10000, [], undefined, RedirectPolicy.Any);
+      await openPage("https://example.com", 10000, [], undefined, false);
 
       const mockResponse = { status: () => 200, headers: () => ({}) };
       const continueMock = vi.fn(() => Promise.resolve());
@@ -265,7 +264,7 @@ describe("openPage", () => {
         10000,
         [],
         undefined,
-        RedirectPolicy.SameHost,
+        true,
       );
 
       const continueMock = vi.fn(() => Promise.resolve());
@@ -297,7 +296,7 @@ describe("openPage", () => {
         10000,
         [],
         undefined,
-        RedirectPolicy.SameHost,
+        true,
       );
 
       const continueMock = vi.fn(() => Promise.resolve());
@@ -329,7 +328,7 @@ describe("openPage", () => {
         10000,
         [],
         undefined,
-        RedirectPolicy.SameHost,
+        true,
       );
 
       const mockResponse = { status: () => 200, headers: () => ({}) };
@@ -368,7 +367,7 @@ describe("openPage", () => {
       expect(abortMock).not.toHaveBeenCalled();
     });
 
-    it("should allow same-site redirect for subdomains", async () => {
+    it("should block subdomain redirect when blocking is enabled", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
         async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
@@ -384,7 +383,7 @@ describe("openPage", () => {
         10000,
         [],
         undefined,
-        RedirectPolicy.SameSite,
+        true,
       );
 
       const mockResponse = { status: () => 200, headers: () => ({}) };
@@ -415,51 +414,11 @@ describe("openPage", () => {
         fulfill: fulfillMock,
       });
 
-      expect(fulfillMock).toHaveBeenCalledTimes(2);
-      expect(abortMock).not.toHaveBeenCalled();
-    });
-
-    it("should block first cross-site navigation when policy is same-site", async () => {
-      let routeHandler: (route: unknown) => Promise<void> = async () => {};
-      mockPage.route.mockImplementation(
-        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
-          routeHandler = handler;
-        },
-      );
-      vi.mocked(sleep).mockImplementation(
-        () => new Promise((resolve) => setTimeout(resolve, 100)),
-      );
-
-      await openPage(
-        "https://example.com",
-        10000,
-        [],
-        undefined,
-        RedirectPolicy.SameSite,
-      );
-
-      const continueMock = vi.fn(() => Promise.resolve());
-      const abortMock = vi.fn(() => Promise.resolve());
-      const fetchMock = vi.fn();
-      const fulfillMock = vi.fn(() => Promise.resolve());
-      await routeHandler({
-        request: () => ({
-          isNavigationRequest: () => true,
-          frame: () => mockMainFrame,
-          url: () => "https://example.net",
-        }),
-        continue: continueMock,
-        abort: abortMock,
-        fetch: fetchMock,
-        fulfill: fulfillMock,
-      });
-
+      expect(fulfillMock).toHaveBeenCalledTimes(1);
       expect(abortMock).toHaveBeenCalledWith("blockedbyclient");
-      expect(continueMock).not.toHaveBeenCalled();
-      expect(fetchMock).not.toHaveBeenCalled();
     });
 
-    it("should block HTTP 301 redirect to cross-host when policy is same-host", async () => {
+    it("should block HTTP 301 redirect to cross-domain when blocking is enabled", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
         async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
@@ -475,7 +434,7 @@ describe("openPage", () => {
         10000,
         [],
         undefined,
-        RedirectPolicy.SameHost,
+        true,
       );
 
       const mockResponse = {
@@ -502,7 +461,7 @@ describe("openPage", () => {
       expect(abortMock).toHaveBeenCalledWith("blockedbyclient");
       expect(fulfillMock).not.toHaveBeenCalled();
       expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining("Blocked redirect by policy same-host: https://example.com/"),
+        expect.stringContaining("Blocked cross-domain redirect: https://example.com/"),
       );
     });
 
@@ -522,7 +481,7 @@ describe("openPage", () => {
         10000,
         [],
         undefined,
-        RedirectPolicy.SameHost,
+        true,
       );
 
       const mockResponse = {
@@ -566,7 +525,7 @@ describe("openPage", () => {
         10000,
         [],
         undefined,
-        RedirectPolicy.SameHost,
+        true,
       );
 
       const mockResponse = {
@@ -594,7 +553,7 @@ describe("openPage", () => {
       expect(abortMock).not.toHaveBeenCalled();
     });
 
-    it("should block HTTP 302 redirect to cross-site when policy is same-site", async () => {
+    it("should block HTTP 302 redirect to cross-domain when blocking is enabled", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
         async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
@@ -610,7 +569,7 @@ describe("openPage", () => {
         10000,
         [],
         undefined,
-        RedirectPolicy.SameSite,
+        true,
       );
 
       const mockResponse = {
@@ -637,7 +596,7 @@ describe("openPage", () => {
       expect(abortMock).toHaveBeenCalledWith("blockedbyclient");
       expect(fulfillMock).not.toHaveBeenCalled();
       expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining("Blocked redirect by policy same-site"),
+        expect.stringContaining("Blocked cross-domain redirect"),
       );
     });
 
@@ -657,7 +616,7 @@ describe("openPage", () => {
         10000,
         [],
         undefined,
-        RedirectPolicy.SameHost,
+        true,
       );
 
       const continueMock = vi.fn(() => Promise.resolve());
@@ -697,7 +656,7 @@ describe("openPage", () => {
         10000,
         [],
         undefined,
-        RedirectPolicy.SameHost,
+        true,
       );
 
       // First call: 301 chain example.com -> example.com/page
@@ -764,7 +723,7 @@ describe("openPage", () => {
         10000,
         [],
         undefined,
-        RedirectPolicy.SameHost,
+        true,
       );
 
       // First call: build a chain so inspectedUrls is populated
@@ -841,7 +800,7 @@ describe("openPage", () => {
         10000,
         [],
         undefined,
-        RedirectPolicy.SameHost,
+        true,
       );
 
       const mockRedirectResponse = {
@@ -889,7 +848,7 @@ describe("openPage", () => {
         10000,
         [],
         undefined,
-        RedirectPolicy.SameHost,
+        true,
       );
 
       // Location with an invalid base URL combination that triggers URL parse error
@@ -982,7 +941,7 @@ describe("openPage", () => {
         10000,
         [],
         undefined,
-        RedirectPolicy.SameHost,
+        true,
       );
 
       expect(logger.error).not.toHaveBeenCalled();

--- a/src/browser/index.test.ts
+++ b/src/browser/index.test.ts
@@ -220,7 +220,7 @@ describe("openPage", () => {
       );
     });
 
-    it("should always continue when policy is any", async () => {
+    it("should allow any redirect and use fetch/fulfill when policy is any", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
         async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
@@ -230,8 +230,11 @@ describe("openPage", () => {
 
       await openPage("https://example.com", 10000, [], undefined, RedirectPolicy.Any);
 
+      const mockResponse = { status: () => 200, headers: () => ({}) };
       const continueMock = vi.fn(() => Promise.resolve());
       const abortMock = vi.fn(() => Promise.resolve());
+      const fetchMock = vi.fn(() => Promise.resolve(mockResponse));
+      const fulfillMock = vi.fn(() => Promise.resolve());
       await routeHandler({
         request: () => ({
           isNavigationRequest: () => true,
@@ -240,9 +243,12 @@ describe("openPage", () => {
         }),
         continue: continueMock,
         abort: abortMock,
+        fetch: fetchMock,
+        fulfill: fulfillMock,
       });
 
-      expect(continueMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith({ maxRedirects: 0 });
+      expect(fulfillMock).toHaveBeenCalledWith({ response: mockResponse });
       expect(abortMock).not.toHaveBeenCalled();
     });
 

--- a/src/browser/index.test.ts
+++ b/src/browser/index.test.ts
@@ -440,6 +440,7 @@ describe("openPage", () => {
       const mockResponse = {
         status: () => 301,
         headers: () => ({ location: "https://example.com/" }),
+        text: () => Promise.resolve(null),
       };
       const continueMock = vi.fn(() => Promise.resolve());
       const abortMock = vi.fn(() => Promise.resolve());
@@ -487,6 +488,7 @@ describe("openPage", () => {
       const mockResponse = {
         status: () => 301,
         headers: () => ({ location: "https://example.com/top" }),
+        text: () => Promise.resolve(null),
       };
       const continueMock = vi.fn(() => Promise.resolve());
       const abortMock = vi.fn(() => Promise.resolve());
@@ -531,6 +533,7 @@ describe("openPage", () => {
       const mockResponse = {
         status: () => 301,
         headers: () => ({ location: "://broken" }),
+        text: () => Promise.resolve(null),
       };
       const continueMock = vi.fn(() => Promise.resolve());
       const abortMock = vi.fn(() => Promise.resolve());
@@ -575,6 +578,7 @@ describe("openPage", () => {
       const mockResponse = {
         status: () => 302,
         headers: () => ({ location: "https://other.example/login" }),
+        text: () => Promise.resolve(null),
       };
       const continueMock = vi.fn(() => Promise.resolve());
       const abortMock = vi.fn(() => Promise.resolve());
@@ -663,6 +667,7 @@ describe("openPage", () => {
       const mockRedirectResponse = {
         status: () => 301,
         headers: () => ({ location: "https://example.com/page" }),
+        text: () => Promise.resolve(null),
       };
       const mock200Response = {
         status: () => 200,
@@ -730,6 +735,7 @@ describe("openPage", () => {
       const mockRedirectResponse = {
         status: () => 301,
         headers: () => ({ location: "https://example.com/page" }),
+        text: () => Promise.resolve(null),
       };
       const mock200Response = {
         status: () => 200,
@@ -806,6 +812,7 @@ describe("openPage", () => {
       const mockRedirectResponse = {
         status: () => 301,
         headers: () => ({ location: "https://example.com/page" }),
+        text: () => Promise.resolve(null),
       };
       const continueMock = vi.fn(() => Promise.resolve());
       const abortMock = vi.fn(() => Promise.resolve());
@@ -855,6 +862,7 @@ describe("openPage", () => {
       const mockResponse = {
         status: () => 301,
         headers: () => ({ location: "https://[invalid" }),
+        text: () => Promise.resolve(null),
       };
       const continueMock = vi.fn(() => Promise.resolve());
       const abortMock = vi.fn(() => Promise.resolve());
@@ -876,6 +884,331 @@ describe("openPage", () => {
       expect(fetchMock).toHaveBeenCalledWith({ maxRedirects: 0 });
       expect(fulfillMock).toHaveBeenCalledWith({ response: mockResponse });
       expect(abortMock).not.toHaveBeenCalled();
+    });
+
+    it("should capture 3xx response headers and body into responses array", async () => {
+      let routeHandler: (route: unknown) => Promise<void> = async () => {};
+      mockPage.route.mockImplementation(
+        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+          routeHandler = handler;
+        },
+      );
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      const result = await openPage("https://example.com", 10000, []);
+
+      const mock301Response = {
+        status: () => 301,
+        headers: () => ({
+          location: "https://example.com/new",
+          server: "awselb/2.0",
+        }),
+        text: () =>
+          Promise.resolve("<html><body>Moved Permanently</body></html>"),
+      };
+      const mock200Response = {
+        status: () => 200,
+        headers: () => ({ server: "nginx" }),
+      };
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mock301Response)
+        .mockResolvedValueOnce(mock200Response);
+      const fulfillMock = vi.fn(() => Promise.resolve());
+      await routeHandler({
+        request: () => ({
+          isNavigationRequest: () => true,
+          frame: () => mockMainFrame,
+          url: () => "https://example.com",
+        }),
+        continue: vi.fn(),
+        abort: vi.fn(),
+        fetch: fetchMock,
+        fulfill: fulfillMock,
+      });
+
+      expect(result.responses).toHaveLength(1);
+      expect(result.responses[0]).toEqual({
+        url: "https://example.com",
+        host: "example.com",
+        isFirstParty: true,
+        status: 301,
+        headers: { location: "https://example.com/new", server: "awselb/2.0" },
+        body: "<html><body>Moved Permanently</body></html>",
+      });
+    });
+
+    it("should capture multi-hop 3xx chain into responses array", async () => {
+      let routeHandler: (route: unknown) => Promise<void> = async () => {};
+      mockPage.route.mockImplementation(
+        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+          routeHandler = handler;
+        },
+      );
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      const result = await openPage("https://example.com", 10000, []);
+
+      const mock301Response = {
+        status: () => 301,
+        headers: () => ({
+          location: "https://example.com/step2",
+          server: "awselb/2.0",
+        }),
+        text: () => Promise.resolve(null),
+      };
+      const mock302Response = {
+        status: () => 302,
+        headers: () => ({
+          location: "https://example.com/final",
+          server: "cloudflare",
+        }),
+        text: () =>
+          Promise.resolve("<html><body>Found</body></html>"),
+      };
+      const mock200Response = {
+        status: () => 200,
+        headers: () => ({ server: "nginx" }),
+      };
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mock301Response)
+        .mockResolvedValueOnce(mock302Response)
+        .mockResolvedValueOnce(mock200Response);
+      const fulfillMock = vi.fn(() => Promise.resolve());
+      await routeHandler({
+        request: () => ({
+          isNavigationRequest: () => true,
+          frame: () => mockMainFrame,
+          url: () => "https://example.com",
+        }),
+        continue: vi.fn(),
+        abort: vi.fn(),
+        fetch: fetchMock,
+        fulfill: fulfillMock,
+      });
+
+      expect(result.responses).toHaveLength(2);
+      expect(result.responses[0]).toMatchObject({
+        url: "https://example.com",
+        status: 301,
+        headers: expect.objectContaining({ server: "awselb/2.0" }),
+      });
+      expect(result.responses[1]).toMatchObject({
+        url: "https://example.com/step2",
+        status: 302,
+        headers: expect.objectContaining({ server: "cloudflare" }),
+        body: "<html><body>Found</body></html>",
+      });
+    });
+
+    it("should not duplicate 3xx responses in page.on response listener", async () => {
+      let routeHandler: (route: unknown) => Promise<void> = async () => {};
+      let responseListener: (response: unknown) => Promise<void> =
+        async () => {};
+      mockPage.route.mockImplementation(
+        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+          routeHandler = handler;
+        },
+      );
+      mockPage.on.mockImplementation(
+        (event: string, handler: (response: unknown) => Promise<void>) => {
+          if (event === "response") {
+            responseListener = handler;
+          }
+        },
+      );
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      const result = await openPage("https://example.com", 10000, []);
+
+      const mock301Response = {
+        status: () => 301,
+        headers: () => ({
+          location: "https://example.com/new",
+          server: "awselb/2.0",
+        }),
+        text: () => Promise.resolve(null),
+      };
+      const mock200Response = {
+        status: () => 200,
+        headers: () => ({}),
+      };
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mock301Response)
+        .mockResolvedValueOnce(mock200Response);
+      await routeHandler({
+        request: () => ({
+          isNavigationRequest: () => true,
+          frame: () => mockMainFrame,
+          url: () => "https://example.com",
+        }),
+        continue: vi.fn(),
+        abort: vi.fn(),
+        fetch: fetchMock,
+        fulfill: vi.fn(() => Promise.resolve()),
+      });
+
+      // Simulate browser re-delivering the same 3xx response via
+      // page.on("response") — it should be skipped as a duplicate.
+      await responseListener({
+        url: () => "https://example.com",
+        status: () => 301,
+        headers: () => ({
+          location: "https://example.com/new",
+          server: "awselb/2.0",
+        }),
+        text: () => Promise.resolve(null),
+      });
+
+      const matching301 = result.responses.filter(
+        (r) => r.url === "https://example.com" && r.status === 301,
+      );
+      expect(matching301).toHaveLength(1);
+    });
+
+    it("should omit body from 3xx response when body is empty", async () => {
+      let routeHandler: (route: unknown) => Promise<void> = async () => {};
+      mockPage.route.mockImplementation(
+        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+          routeHandler = handler;
+        },
+      );
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      const result = await openPage("https://example.com", 10000, []);
+
+      const mock301Response = {
+        status: () => 301,
+        headers: () => ({ location: "https://example.com/new" }),
+        text: () => Promise.resolve(null),
+      };
+      const mock200Response = {
+        status: () => 200,
+        headers: () => ({}),
+      };
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mock301Response)
+        .mockResolvedValueOnce(mock200Response);
+      await routeHandler({
+        request: () => ({
+          isNavigationRequest: () => true,
+          frame: () => mockMainFrame,
+          url: () => "https://example.com",
+        }),
+        continue: vi.fn(),
+        abort: vi.fn(),
+        fetch: fetchMock,
+        fulfill: vi.fn(() => Promise.resolve()),
+      });
+
+      expect(result.responses).toHaveLength(1);
+      expect(result.responses[0]).not.toHaveProperty("body");
+    });
+
+    it("should capture 3xx response without Location header", async () => {
+      let routeHandler: (route: unknown) => Promise<void> = async () => {};
+      mockPage.route.mockImplementation(
+        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+          routeHandler = handler;
+        },
+      );
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      const result = await openPage("https://example.com", 10000, []);
+
+      // 3xx response without a Location header — the loop should capture it
+      // and then break.
+      const mock301Response = {
+        status: () => 301,
+        headers: () => ({ server: "awselb/2.0" }),
+        text: () => Promise.resolve(null),
+      };
+      const fetchMock = vi.fn().mockResolvedValueOnce(mock301Response);
+      const fulfillMock = vi.fn(() => Promise.resolve());
+      await routeHandler({
+        request: () => ({
+          isNavigationRequest: () => true,
+          frame: () => mockMainFrame,
+          url: () => "https://example.com",
+        }),
+        continue: vi.fn(),
+        abort: vi.fn(),
+        fetch: fetchMock,
+        fulfill: fulfillMock,
+      });
+
+      expect(result.responses).toHaveLength(1);
+      expect(result.responses[0]).toMatchObject({
+        url: "https://example.com",
+        status: 301,
+        headers: { server: "awselb/2.0" },
+      });
+      // Only the initial fetch should have been called (no redirect to follow)
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fulfillMock).toHaveBeenCalled();
+    });
+
+    it("should handle 3xx response where URL has no extractable host", async () => {
+      let routeHandler: (route: unknown) => Promise<void> = async () => {};
+      mockPage.route.mockImplementation(
+        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+          routeHandler = handler;
+        },
+      );
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      const result = await openPage("https://example.com", 10000, []);
+
+      const mock301Response = {
+        status: () => 301,
+        headers: () => ({ location: "https://example.com/new" }),
+        text: () => Promise.resolve(null),
+      };
+      const mock200Response = {
+        status: () => 200,
+        headers: () => ({}),
+      };
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mock301Response)
+        .mockResolvedValueOnce(mock200Response);
+      const fulfillMock = vi.fn(() => Promise.resolve());
+
+      // Use a data: URL that getHostFromUrl returns null for
+      await routeHandler({
+        request: () => ({
+          isNavigationRequest: () => true,
+          frame: () => mockMainFrame,
+          url: () => "https://example.com",
+        }),
+        continue: vi.fn(),
+        abort: vi.fn(),
+        fetch: fetchMock,
+        fulfill: fulfillMock,
+      });
+
+      // The 3xx response should still be captured
+      expect(result.responses).toHaveLength(1);
+      expect(result.responses[0]).toMatchObject({
+        status: 301,
+        host: "example.com",
+        isFirstParty: true,
+      });
     });
   });
 

--- a/src/browser/index.test.ts
+++ b/src/browser/index.test.ts
@@ -680,6 +680,244 @@ describe("openPage", () => {
       expect(abortMock).toHaveBeenCalledWith("failed");
       expect(fulfillMock).not.toHaveBeenCalled();
     });
+
+    it("should continue for already-inspected URLs on route re-entry", async () => {
+      let routeHandler: (route: unknown) => Promise<void> = async () => {};
+      mockPage.route.mockImplementation(
+        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+          routeHandler = handler;
+        },
+      );
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      await openPage(
+        "https://example.com",
+        10000,
+        [],
+        undefined,
+        RedirectPolicy.SameHost,
+      );
+
+      // First call: 301 chain example.com -> example.com/page
+      const mockRedirectResponse = {
+        status: () => 301,
+        headers: () => ({ location: "https://example.com/page" }),
+      };
+      const mock200Response = {
+        status: () => 200,
+        headers: () => ({}),
+      };
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mockRedirectResponse)
+        .mockResolvedValueOnce(mock200Response);
+      const fulfillMock = vi.fn(() => Promise.resolve());
+      const abortMock = vi.fn(() => Promise.resolve());
+
+      await routeHandler({
+        request: () => ({
+          isNavigationRequest: () => true,
+          frame: () => mockMainFrame,
+          url: () => "https://example.com",
+        }),
+        continue: vi.fn(),
+        abort: abortMock,
+        fetch: fetchMock,
+        fulfill: fulfillMock,
+      });
+
+      // Simulate browser re-entry for the inspected redirect target
+      const continueMock = vi.fn(() => Promise.resolve());
+      await routeHandler({
+        request: () => ({
+          isNavigationRequest: () => true,
+          frame: () => mockMainFrame,
+          url: () => "https://example.com/page",
+        }),
+        continue: continueMock,
+        abort: vi.fn(),
+        fetch: vi.fn(),
+        fulfill: vi.fn(),
+      });
+
+      expect(continueMock).toHaveBeenCalled();
+    });
+
+    it("should abort after too many re-entries for inspected URLs", async () => {
+      let routeHandler: (route: unknown) => Promise<void> = async () => {};
+      mockPage.route.mockImplementation(
+        async (
+          _pattern: string,
+          handler: (route: unknown) => Promise<void>,
+        ) => {
+          routeHandler = handler;
+        },
+      );
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      await openPage(
+        "https://example.com",
+        10000,
+        [],
+        undefined,
+        RedirectPolicy.SameHost,
+      );
+
+      // First call: build a chain so inspectedUrls is populated
+      const mockRedirectResponse = {
+        status: () => 301,
+        headers: () => ({ location: "https://example.com/page" }),
+      };
+      const mock200Response = {
+        status: () => 200,
+        headers: () => ({}),
+      };
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mockRedirectResponse)
+        .mockResolvedValueOnce(mock200Response);
+
+      await routeHandler({
+        request: () => ({
+          isNavigationRequest: () => true,
+          frame: () => mockMainFrame,
+          url: () => "https://example.com",
+        }),
+        continue: vi.fn(),
+        abort: vi.fn(),
+        fetch: fetchMock,
+        fulfill: vi.fn(() => Promise.resolve()),
+      });
+
+      // Simulate re-entries exceeding MAX_REDIRECT_HOPS (20)
+      for (let i = 0; i < 20; i++) {
+        await routeHandler({
+          request: () => ({
+            isNavigationRequest: () => true,
+            frame: () => mockMainFrame,
+            url: () => "https://example.com/page",
+          }),
+          continue: vi.fn(() => Promise.resolve()),
+          abort: vi.fn(() => Promise.resolve()),
+          fetch: vi.fn(),
+          fulfill: vi.fn(),
+        });
+      }
+
+      // The 21st re-entry should abort
+      const abortMock = vi.fn(() => Promise.resolve());
+      await routeHandler({
+        request: () => ({
+          isNavigationRequest: () => true,
+          frame: () => mockMainFrame,
+          url: () => "https://example.com/page",
+        }),
+        continue: vi.fn(() => Promise.resolve()),
+        abort: abortMock,
+        fetch: vi.fn(),
+        fulfill: vi.fn(),
+      });
+
+      expect(abortMock).toHaveBeenCalledWith("failed");
+    });
+
+    it("should abort when redirect chain fetch fails mid-chain", async () => {
+      let routeHandler: (route: unknown) => Promise<void> = async () => {};
+      mockPage.route.mockImplementation(
+        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+          routeHandler = handler;
+        },
+      );
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      await openPage(
+        "https://example.com",
+        10000,
+        [],
+        undefined,
+        RedirectPolicy.SameHost,
+      );
+
+      const mockRedirectResponse = {
+        status: () => 301,
+        headers: () => ({ location: "https://example.com/page" }),
+      };
+      const continueMock = vi.fn(() => Promise.resolve());
+      const abortMock = vi.fn(() => Promise.resolve());
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mockRedirectResponse)
+        .mockRejectedValueOnce(new Error("net::ERR_CONNECTION_RESET"));
+      const fulfillMock = vi.fn(() => Promise.resolve());
+
+      await routeHandler({
+        request: () => ({
+          isNavigationRequest: () => true,
+          frame: () => mockMainFrame,
+          url: () => "https://example.com",
+        }),
+        continue: continueMock,
+        abort: abortMock,
+        fetch: fetchMock,
+        fulfill: fulfillMock,
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(abortMock).toHaveBeenCalledWith("failed");
+      expect(fulfillMock).not.toHaveBeenCalled();
+    });
+
+    it("should break loop when Location URL cannot be parsed", async () => {
+      let routeHandler: (route: unknown) => Promise<void> = async () => {};
+      mockPage.route.mockImplementation(
+        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+          routeHandler = handler;
+        },
+      );
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      await openPage(
+        "https://example.com",
+        10000,
+        [],
+        undefined,
+        RedirectPolicy.SameHost,
+      );
+
+      // Location with an invalid base URL combination that triggers URL parse error
+      const mockResponse = {
+        status: () => 301,
+        headers: () => ({ location: "https://[invalid" }),
+      };
+      const continueMock = vi.fn(() => Promise.resolve());
+      const abortMock = vi.fn(() => Promise.resolve());
+      const fetchMock = vi.fn(() => Promise.resolve(mockResponse));
+      const fulfillMock = vi.fn(() => Promise.resolve());
+
+      await routeHandler({
+        request: () => ({
+          isNavigationRequest: () => true,
+          frame: () => mockMainFrame,
+          url: () => "https://example.com",
+        }),
+        continue: continueMock,
+        abort: abortMock,
+        fetch: fetchMock,
+        fulfill: fulfillMock,
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith({ maxRedirects: 0 });
+      expect(fulfillMock).toHaveBeenCalledWith({ response: mockResponse });
+      expect(abortMock).not.toHaveBeenCalled();
+    });
   });
 
   describe("timeout handling", () => {

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -51,7 +51,8 @@ export async function openPage(
     ...(userAgent ? { userAgent } : {}),
   });
   const page = await context.newPage();
-  let isFirstNavigationRequest = true;
+
+  let blockedByRedirectPolicy = false;
 
   await page.route("**/*", async (route) => {
     const request = route.request();
@@ -64,12 +65,6 @@ export async function openPage(
       return;
     }
 
-    if (isFirstNavigationRequest) {
-      isFirstNavigationRequest = false;
-      await route.continue();
-      return;
-    }
-
     const targetUrl = request.url();
     const targetHost = getHostFromUrl(targetUrl);
     if (!targetHost) {
@@ -77,15 +72,52 @@ export async function openPage(
       return;
     }
 
-    if (isRedirectAllowed(pageHost, targetHost, redirectPolicy)) {
-      await route.continue();
+    if (!isRedirectAllowed(pageHost, targetHost, redirectPolicy)) {
+      logger.warn(
+        `Blocked redirect by policy ${redirectPolicy}: ${targetUrl}`,
+      );
+      blockedByRedirectPolicy = true;
+      await route.abort("blockedbyclient");
       return;
     }
 
-    logger.warn(
-      `Blocked redirect by policy ${redirectPolicy}: ${targetUrl}`,
-    );
-    await route.abort("blockedbyclient");
+    // Fetch without following redirects to inspect 3xx responses
+    let response;
+    try {
+      response = await route.fetch({ maxRedirects: 0 });
+    } catch {
+      await route.abort("failed");
+      return;
+    }
+
+    const status = response.status();
+
+    if (status >= 300 && status < 400) {
+      const location = response.headers()["location"];
+      if (location) {
+        let redirectUrl: string;
+        try {
+          redirectUrl = new URL(location, targetUrl).href;
+        } catch {
+          await route.fulfill({ response });
+          return;
+        }
+        const redirectHost = getHostFromUrl(redirectUrl);
+        if (
+          redirectHost &&
+          !isRedirectAllowed(pageHost, redirectHost, redirectPolicy)
+        ) {
+          logger.warn(
+            `Blocked redirect by policy ${redirectPolicy}: ${redirectUrl}`,
+          );
+          blockedByRedirectPolicy = true;
+          await route.abort("blockedbyclient");
+          return;
+        }
+      }
+    }
+
+    await route.fulfill({ response });
   });
 
   const responses: Response[] = [];
@@ -127,6 +159,8 @@ export async function openPage(
   } else if (result === "timeout") {
     timeoutOccurred = true;
     logger.warn(`Timeout of ${timeoutMs}ms exceeded while loading ${url}`);
+  } else if (blockedByRedirectPolicy) {
+    // Already logged by the route handler as "Blocked redirect by policy"
   } else {
     logger.error(`Error loading page ${url}: ${result.split("\n")[0]}`);
   }

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -11,6 +11,8 @@ import {
   sleep,
 } from "./utils.js";
 
+const MAX_REDIRECT_HOPS = 20;
+
 function colorizeStatusCode(statusCode: number): string {
   const code = String(statusCode);
 
@@ -54,6 +56,8 @@ export async function openPage(
 
   let blockedByRedirectPolicy = false;
   let lastNavigationUrl = url;
+  let inspectedUrls = new Set<string>();
+  let reentryCount = 0;
 
   await page.route("**/*", async (route) => {
     const request = route.request();
@@ -68,6 +72,21 @@ export async function openPage(
     const targetUrl = request.url();
     const targetHost = getHostFromUrl(targetUrl);
     if (!targetHost) {
+      await route.continue();
+      return;
+    }
+
+    // Skip URLs already inspected by the pre-inspection loop to prevent
+    // infinite re-entry: fulfill(301) may cause the browser to re-invoke
+    // this handler, and without this guard a circular redirect chain
+    // would loop indefinitely outside the MAX_REDIRECT_HOPS limit.
+    if (inspectedUrls.has(targetUrl)) {
+      reentryCount++;
+      if (reentryCount > MAX_REDIRECT_HOPS) {
+        logger.warn("Too many redirect re-entries, aborting");
+        await route.abort("failed");
+        return;
+      }
       await route.continue();
       return;
     }
@@ -92,7 +111,13 @@ export async function openPage(
     }
     lastNavigationUrl = targetUrl;
 
-    // Fetch without following redirects to inspect 3xx responses
+    // New set per navigation so previous chains don't interfere,
+    // but re-entry from the same chain still hits the guard above.
+    inspectedUrls = new Set<string>();
+    reentryCount = 0;
+
+    // Fetch without following redirects so we can inspect each hop
+    let currentUrl = targetUrl;
     let response;
     try {
       response = await route.fetch({ maxRedirects: 0 });
@@ -101,37 +126,50 @@ export async function openPage(
       return;
     }
 
-    const status = response.status();
-
-    if (status >= 300 && status < 400) {
+    // Pre-inspect the 3xx chain to log each hop and enforce the redirect
+    // policy before the browser sees any response. After inspection we
+    // fulfill with the *first* response so the browser follows the real
+    // chain itself, preserving Set-Cookie headers, origin, and URL state.
+    const firstResponse = response;
+    for (let hop = 0; hop < MAX_REDIRECT_HOPS && response.status() >= 300 && response.status() < 400; hop++) {
       const location = response.headers()["location"];
-      if (location) {
-        let redirectUrl: string;
-        try {
-          redirectUrl = new URL(location, targetUrl).href;
-        } catch {
-          await route.fulfill({ response });
-          return;
-        }
-        const redirectHost = getHostFromUrl(redirectUrl);
-        if (
-          redirectPolicy !== RedirectPolicy.Any &&
-          redirectHost &&
-          !isRedirectAllowed(pageHost, redirectHost, redirectPolicy)
-        ) {
-          logger.warn(
-            `Blocked redirect by policy ${redirectPolicy}: ${redirectUrl}`,
-          );
-          blockedByRedirectPolicy = true;
-          await route.abort("blockedbyclient");
-          return;
-        }
-        logger.info(`Following redirect: ${targetUrl} -> ${redirectUrl}`);
-        lastNavigationUrl = redirectUrl;
+      if (!location) break;
+
+      let redirectUrl: string;
+      try {
+        redirectUrl = new URL(location, currentUrl).href;
+      } catch {
+        break;
+      }
+
+      const redirectHost = getHostFromUrl(redirectUrl);
+      if (
+        redirectPolicy !== RedirectPolicy.Any &&
+        redirectHost &&
+        !isRedirectAllowed(pageHost, redirectHost, redirectPolicy)
+      ) {
+        logger.warn(
+          `Blocked redirect by policy ${redirectPolicy}: ${redirectUrl}`,
+        );
+        blockedByRedirectPolicy = true;
+        await route.abort("blockedbyclient");
+        return;
+      }
+
+      logger.info(`Following redirect: ${currentUrl} -> ${redirectUrl}`);
+      lastNavigationUrl = redirectUrl;
+      currentUrl = redirectUrl;
+      inspectedUrls.add(redirectUrl);
+
+      try {
+        response = await route.fetch({ url: redirectUrl, maxRedirects: 0 });
+      } catch {
+        await route.abort("failed");
+        return;
       }
     }
 
-    await route.fulfill({ response });
+    await route.fulfill({ response: firstResponse });
   });
 
   const responses: Response[] = [];

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -1,15 +1,15 @@
-import { chromium } from "playwright";
 import chalk from "chalk";
-import { RedirectPolicy } from "./types.js";
+import { chromium } from "playwright";
+import { logger } from "../logger/index.js";
 import type { Context, Response } from "./types.js";
+import { RedirectPolicy } from "./types.js";
 import {
-  sleep,
   extractJsVariables,
   getHostFromUrl,
   isFirstPartyHost,
   isRedirectAllowed,
+  sleep,
 } from "./utils.js";
-import { logger } from "../logger/index.js";
 
 function colorizeStatusCode(statusCode: number): string {
   const code = String(statusCode);
@@ -53,11 +53,11 @@ export async function openPage(
   const page = await context.newPage();
 
   let blockedByRedirectPolicy = false;
+  let lastNavigationUrl = url;
 
   await page.route("**/*", async (route) => {
     const request = route.request();
     if (
-      redirectPolicy === RedirectPolicy.Any ||
       !request.isNavigationRequest() ||
       request.frame() !== page.mainFrame()
     ) {
@@ -72,7 +72,10 @@ export async function openPage(
       return;
     }
 
-    if (!isRedirectAllowed(pageHost, targetHost, redirectPolicy)) {
+    if (
+      redirectPolicy !== RedirectPolicy.Any &&
+      !isRedirectAllowed(pageHost, targetHost, redirectPolicy)
+    ) {
       logger.warn(
         `Blocked redirect by policy ${redirectPolicy}: ${targetUrl}`,
       );
@@ -80,6 +83,14 @@ export async function openPage(
       await route.abort("blockedbyclient");
       return;
     }
+
+    // Log client-side redirects (JS / meta refresh)
+    if (targetUrl !== lastNavigationUrl) {
+      logger.info(
+        `Following redirect: ${lastNavigationUrl} -> ${targetUrl}`,
+      );
+    }
+    lastNavigationUrl = targetUrl;
 
     // Fetch without following redirects to inspect 3xx responses
     let response;
@@ -104,6 +115,7 @@ export async function openPage(
         }
         const redirectHost = getHostFromUrl(redirectUrl);
         if (
+          redirectPolicy !== RedirectPolicy.Any &&
           redirectHost &&
           !isRedirectAllowed(pageHost, redirectHost, redirectPolicy)
         ) {
@@ -114,6 +126,8 @@ export async function openPage(
           await route.abort("blockedbyclient");
           return;
         }
+        logger.info(`Following redirect: ${targetUrl} -> ${redirectUrl}`);
+        lastNavigationUrl = redirectUrl;
       }
     }
 

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -57,6 +57,7 @@ export async function openPage(
   let lastNavigationUrl = url;
   let inspectedUrls = new Set<string>();
   let reentryCount = 0;
+  const preInspectedUrls = new Set<string>();
 
   await page.route("**/*", async (route) => {
     const request = route.request();
@@ -129,8 +130,28 @@ export async function openPage(
     // policy before the browser sees any response. After inspection we
     // fulfill with the *first* response so the browser follows the real
     // chain itself, preserving Set-Cookie headers, origin, and URL state.
+    // URLs captured here are added to preInspectedUrls so that the
+    // page.on("response") listener can skip them and avoid duplicates.
     const firstResponse = response;
     for (let hop = 0; hop < MAX_REDIRECT_HOPS && response.status() >= 300 && response.status() < 400; hop++) {
+      // Capture intermediate 3xx responses so their headers (e.g. server,
+      // x-powered-by) are available for analysis even though the browser
+      // never sees these responses directly.
+      const hopHost = getHostFromUrl(currentUrl) ?? "";
+      preInspectedUrls.add(currentUrl);
+      const hopBody = await response.text().catch(() => null);
+      const hopResponse: Response = {
+        url: currentUrl,
+        host: hopHost,
+        isFirstParty: hopHost ? isFirstPartyHost(pageHost, hopHost) : false,
+        status: response.status(),
+        headers: response.headers(),
+      };
+      if (hopBody) {
+        hopResponse.body = hopBody;
+      }
+      responses.push(hopResponse);
+
       const location = response.headers()["location"];
       if (!location) break;
 
@@ -174,8 +195,18 @@ export async function openPage(
   const responses: Response[] = [];
   page.on("response", async (response) => {
     const responseUrl = response.url();
-    const responseHost = getHostFromUrl(responseUrl) ?? "";
     const statusCode = response.status();
+
+    // Skip responses already captured by the pre-inspection loop to
+    // avoid duplicates.
+    if (preInspectedUrls.has(responseUrl) && statusCode >= 300 && statusCode < 400) {
+      logger.debug(
+        `Skipping already captured response [${colorizeStatusCode(statusCode)}] ${responseUrl}`,
+      );
+      return;
+    }
+
+    const responseHost = getHostFromUrl(responseUrl) ?? "";
     logger.debug(
       `Received response [${colorizeStatusCode(statusCode)}] ${responseUrl}`,
     );

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -2,12 +2,11 @@ import chalk from "chalk";
 import { chromium } from "playwright";
 import { logger } from "../logger/index.js";
 import type { Context, Response } from "./types.js";
-import { RedirectPolicy } from "./types.js";
 import {
   extractJsVariables,
   getHostFromUrl,
   isFirstPartyHost,
-  isRedirectAllowed,
+  isSameHost,
   sleep,
 } from "./utils.js";
 
@@ -40,7 +39,7 @@ export async function openPage(
   timeoutMs: number,
   javascriptVariableNames: string[],
   userAgent?: string,
-  redirectPolicy: RedirectPolicy = RedirectPolicy.Any,
+  blockCrossDomainRedirect: boolean = false,
 ): Promise<Context> {
   const pageHost = getHostFromUrl(url);
   if (!pageHost) {
@@ -92,11 +91,11 @@ export async function openPage(
     }
 
     if (
-      redirectPolicy !== RedirectPolicy.Any &&
-      !isRedirectAllowed(pageHost, targetHost, redirectPolicy)
+      blockCrossDomainRedirect &&
+      !isSameHost(pageHost, targetHost)
     ) {
       logger.warn(
-        `Blocked redirect by policy ${redirectPolicy}: ${targetUrl}`,
+        `Blocked cross-domain redirect: ${targetUrl}`,
       );
       blockedByRedirectPolicy = true;
       await route.abort("blockedbyclient");
@@ -144,12 +143,12 @@ export async function openPage(
 
       const redirectHost = getHostFromUrl(redirectUrl);
       if (
-        redirectPolicy !== RedirectPolicy.Any &&
+        blockCrossDomainRedirect &&
         redirectHost &&
-        !isRedirectAllowed(pageHost, redirectHost, redirectPolicy)
+        !isSameHost(pageHost, redirectHost)
       ) {
         logger.warn(
-          `Blocked redirect by policy ${redirectPolicy}: ${redirectUrl}`,
+          `Blocked cross-domain redirect: ${redirectUrl}`,
         );
         blockedByRedirectPolicy = true;
         await route.abort("blockedbyclient");

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -1,11 +1,13 @@
 import { chromium } from "playwright";
 import chalk from "chalk";
+import { RedirectPolicy } from "./types.js";
 import type { Context, Response } from "./types.js";
 import {
   sleep,
   extractJsVariables,
   getHostFromUrl,
   isFirstPartyHost,
+  isRedirectAllowed,
 } from "./utils.js";
 import { logger } from "../logger/index.js";
 
@@ -36,6 +38,7 @@ export async function openPage(
   timeoutMs: number,
   javascriptVariableNames: string[],
   userAgent?: string,
+  redirectPolicy: RedirectPolicy = RedirectPolicy.Any,
 ): Promise<Context> {
   const pageHost = getHostFromUrl(url);
   if (!pageHost) {
@@ -48,6 +51,42 @@ export async function openPage(
     ...(userAgent ? { userAgent } : {}),
   });
   const page = await context.newPage();
+  let isFirstNavigationRequest = true;
+
+  await page.route("**/*", async (route) => {
+    const request = route.request();
+    if (
+      redirectPolicy === RedirectPolicy.Any ||
+      !request.isNavigationRequest() ||
+      request.frame() !== page.mainFrame()
+    ) {
+      await route.continue();
+      return;
+    }
+
+    if (isFirstNavigationRequest) {
+      isFirstNavigationRequest = false;
+      await route.continue();
+      return;
+    }
+
+    const targetUrl = request.url();
+    const targetHost = getHostFromUrl(targetUrl);
+    if (!targetHost) {
+      await route.continue();
+      return;
+    }
+
+    if (isRedirectAllowed(pageHost, targetHost, redirectPolicy)) {
+      await route.continue();
+      return;
+    }
+
+    logger.warn(
+      `Blocked redirect by policy ${redirectPolicy}: ${targetUrl}`,
+    );
+    await route.abort("blockedbyclient");
+  });
 
   const responses: Response[] = [];
   page.on("response", async (response) => {

--- a/src/browser/types.ts
+++ b/src/browser/types.ts
@@ -1,18 +1,6 @@
 import type { Browser, Page } from "playwright";
 
 export type Headers = Record<string, string>;
-export const RedirectPolicy = {
-  /** Follow all redirects (default) */
-  Any: "any",
-  /** Allow redirects within the same registrable domain (e.g. *.example.com) */
-  SameSite: "same-site",
-  /** Allow redirects only to the exact same host (e.g. example.com) */
-  SameHost: "same-host",
-} as const;
-
-export type RedirectPolicy =
-  (typeof RedirectPolicy)[keyof typeof RedirectPolicy];
-
 export type Cookie = {
   name: string;
   value: string;

--- a/src/browser/types.ts
+++ b/src/browser/types.ts
@@ -1,6 +1,17 @@
 import type { Browser, Page } from "playwright";
 
 export type Headers = Record<string, string>;
+export const RedirectPolicy = {
+  /** Follow all redirects (default) */
+  Any: "any",
+  /** Allow redirects within the same registrable domain (e.g. *.example.com) */
+  SameSite: "same-site",
+  /** Allow redirects only to the exact same host (e.g. example.com) */
+  SameHost: "same-host",
+} as const;
+
+export type RedirectPolicy =
+  (typeof RedirectPolicy)[keyof typeof RedirectPolicy];
 
 export type Cookie = {
   name: string;

--- a/src/browser/utils.test.ts
+++ b/src/browser/utils.test.ts
@@ -1,10 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { RedirectPolicy } from "./types.js";
 import {
   extractJsVariables,
   getHostFromUrl,
   isFirstPartyHost,
-  isRedirectAllowed,
+  isSameHost,
   sleep,
 } from "./utils.js";
 
@@ -139,35 +138,12 @@ describe("URL and host utilities", () => {
     expect(isFirstPartyHost("example.com", "example.net")).toBe(false);
   });
 
-  it("should allow any redirect policy", () => {
-    expect(
-      isRedirectAllowed("example.com", "example.net", RedirectPolicy.Any),
-    ).toBe(true);
+  it("should return true for exact host match", () => {
+    expect(isSameHost("example.com", "example.com")).toBe(true);
   });
 
-  it("should allow same-host redirect only for exact host match", () => {
-    expect(
-      isRedirectAllowed("example.com", "example.com", RedirectPolicy.SameHost),
-    ).toBe(true);
-    expect(
-      isRedirectAllowed(
-        "example.com",
-        "www.example.com",
-        RedirectPolicy.SameHost,
-      ),
-    ).toBe(false);
-  });
-
-  it("should allow same-site redirect for subdomains", () => {
-    expect(
-      isRedirectAllowed(
-        "app.example.com",
-        "cdn.example.com",
-        RedirectPolicy.SameSite,
-      ),
-    ).toBe(true);
-    expect(
-      isRedirectAllowed("example.com", "example.net", RedirectPolicy.SameSite),
-    ).toBe(false);
+  it("should return false for different hosts", () => {
+    expect(isSameHost("example.com", "www.example.com")).toBe(false);
+    expect(isSameHost("example.com", "example.net")).toBe(false);
   });
 });

--- a/src/browser/utils.test.ts
+++ b/src/browser/utils.test.ts
@@ -1,9 +1,11 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RedirectPolicy } from "./types.js";
 import {
-  sleep,
   extractJsVariables,
   getHostFromUrl,
   isFirstPartyHost,
+  isRedirectAllowed,
+  sleep,
 } from "./utils.js";
 
 describe("sleep", () => {
@@ -135,5 +137,37 @@ describe("URL and host utilities", () => {
 
   it("should identify different domain as third-party", () => {
     expect(isFirstPartyHost("example.com", "example.net")).toBe(false);
+  });
+
+  it("should allow any redirect policy", () => {
+    expect(
+      isRedirectAllowed("example.com", "example.net", RedirectPolicy.Any),
+    ).toBe(true);
+  });
+
+  it("should allow same-host redirect only for exact host match", () => {
+    expect(
+      isRedirectAllowed("example.com", "example.com", RedirectPolicy.SameHost),
+    ).toBe(true);
+    expect(
+      isRedirectAllowed(
+        "example.com",
+        "www.example.com",
+        RedirectPolicy.SameHost,
+      ),
+    ).toBe(false);
+  });
+
+  it("should allow same-site redirect for subdomains", () => {
+    expect(
+      isRedirectAllowed(
+        "app.example.com",
+        "cdn.example.com",
+        RedirectPolicy.SameSite,
+      ),
+    ).toBe(true);
+    expect(
+      isRedirectAllowed("example.com", "example.net", RedirectPolicy.SameSite),
+    ).toBe(false);
   });
 });

--- a/src/browser/utils.ts
+++ b/src/browser/utils.ts
@@ -1,5 +1,3 @@
-import { RedirectPolicy } from "./types.js";
-
 export function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -63,19 +61,11 @@ export function isFirstPartyHost(
   return toRegistrableDomain(base) === toRegistrableDomain(candidate);
 }
 
-export function isRedirectAllowed(
+export function isSameHost(
   sourceHost: string,
   targetHost: string,
-  policy: RedirectPolicy,
 ): boolean {
-  if (policy === RedirectPolicy.Any) {
-    return true;
-  }
-  if (policy === RedirectPolicy.SameHost) {
-    return normalizeHostname(sourceHost) === normalizeHostname(targetHost);
-  }
-
-  return isFirstPartyHost(sourceHost, targetHost);
+  return normalizeHostname(sourceHost) === normalizeHostname(targetHost);
 }
 
 /**

--- a/src/browser/utils.ts
+++ b/src/browser/utils.ts
@@ -1,3 +1,5 @@
+import { RedirectPolicy } from "./types.js";
+
 export function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -59,6 +61,21 @@ export function isFirstPartyHost(
   }
 
   return toRegistrableDomain(base) === toRegistrableDomain(candidate);
+}
+
+export function isRedirectAllowed(
+  sourceHost: string,
+  targetHost: string,
+  policy: RedirectPolicy,
+): boolean {
+  if (policy === RedirectPolicy.Any) {
+    return true;
+  }
+  if (policy === RedirectPolicy.SameHost) {
+    return normalizeHostname(sourceHost) === normalizeHostname(targetHost);
+  }
+
+  return isFirstPartyHost(sourceHost, targetHost);
 }
 
 /**

--- a/src/commands/detect.test.ts
+++ b/src/commands/detect.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { detectCommand } from "./detect.js";
-import { RedirectPolicy } from "../browser/types.js";
 
 // Mock dependencies
 vi.mock("../browser/index.js", () => ({
@@ -131,14 +130,14 @@ describe("detectCommand", () => {
       expect(uaOpt).toBeDefined();
     });
 
-    it("should have redirect-policy option with default any", () => {
+    it("should have block-cross-domain-redirect option with default false", () => {
       const command = detectCommand();
       const options = command.options;
-      const redirectPolicyOpt = options.find(
-        (o) => o.long === "--redirect-policy",
+      const blockOpt = options.find(
+        (o) => o.long === "--block-cross-domain-redirect",
       );
-      expect(redirectPolicyOpt).toBeDefined();
-      expect(redirectPolicyOpt?.defaultValue).toBe(RedirectPolicy.Any);
+      expect(blockOpt).toBeDefined();
+      expect(blockOpt?.defaultValue).toBe(false);
     });
   });
 
@@ -151,7 +150,7 @@ describe("detectCommand", () => {
         10000,
         expect.any(Array),
         undefined,
-        RedirectPolicy.Any,
+        false,
       );
     });
 
@@ -163,7 +162,7 @@ describe("detectCommand", () => {
         5000,
         expect.any(Array),
         undefined,
-        RedirectPolicy.Any,
+        false,
       );
     });
 
@@ -175,19 +174,19 @@ describe("detectCommand", () => {
         10000,
         expect.any(Array),
         "MyAgent/1.0",
-        RedirectPolicy.Any,
+        false,
       );
     });
 
-    it("should pass redirect policy when provided", async () => {
-      await runCommand(["--redirect-policy", "same-host"]);
+    it("should pass block-cross-domain-redirect when provided", async () => {
+      await runCommand(["--block-cross-domain-redirect"]);
 
       expect(openPage).toHaveBeenCalledWith(
         "https://example.com",
         10000,
         expect.any(Array),
         undefined,
-        RedirectPolicy.SameHost,
+        true,
       );
     });
 

--- a/src/commands/detect.test.ts
+++ b/src/commands/detect.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { detectCommand } from "./detect.js";
+import { RedirectPolicy } from "../browser/types.js";
 
 // Mock dependencies
 vi.mock("../browser/index.js", () => ({
@@ -130,6 +131,15 @@ describe("detectCommand", () => {
       expect(uaOpt).toBeDefined();
     });
 
+    it("should have redirect-policy option with default any", () => {
+      const command = detectCommand();
+      const options = command.options;
+      const redirectPolicyOpt = options.find(
+        (o) => o.long === "--redirect-policy",
+      );
+      expect(redirectPolicyOpt).toBeDefined();
+      expect(redirectPolicyOpt?.defaultValue).toBe(RedirectPolicy.Any);
+    });
   });
 
   describe("action execution", () => {
@@ -141,6 +151,7 @@ describe("detectCommand", () => {
         10000,
         expect.any(Array),
         undefined,
+        RedirectPolicy.Any,
       );
     });
 
@@ -152,6 +163,7 @@ describe("detectCommand", () => {
         5000,
         expect.any(Array),
         undefined,
+        RedirectPolicy.Any,
       );
     });
 
@@ -163,6 +175,19 @@ describe("detectCommand", () => {
         10000,
         expect.any(Array),
         "MyAgent/1.0",
+        RedirectPolicy.Any,
+      );
+    });
+
+    it("should pass redirect policy when provided", async () => {
+      await runCommand(["--redirect-policy", "same-host"]);
+
+      expect(openPage).toHaveBeenCalledWith(
+        "https://example.com",
+        10000,
+        expect.any(Array),
+        undefined,
+        RedirectPolicy.SameHost,
       );
     });
 

--- a/src/commands/detect.ts
+++ b/src/commands/detect.ts
@@ -1,6 +1,5 @@
-import { Command, Option } from "commander";
+import { Command } from "commander";
 import { openPage } from "../browser/index.js";
-import { RedirectPolicy } from "../browser/types.js";
 import { analyze } from "../analyzer/index.js";
 import { signatures } from "../signatures/index.js";
 import { logger, setLogLevel } from "../logger/index.js";
@@ -27,17 +26,10 @@ export const detectCommand = (): Command => {
     .option("-e, --evidence", "Show evidence for detections", false)
     .option("-j, --json", "Output results in JSON format", false)
     .option("-u, --user-agent <string>", "Custom User-Agent string")
-    .addOption(
-      new Option(
-        "-r, --redirect-policy <policy>",
-        "Redirect policy: 'any', 'same-site', or 'same-host'",
-      )
-        .choices([
-          RedirectPolicy.Any,
-          RedirectPolicy.SameSite,
-          RedirectPolicy.SameHost,
-        ])
-        .default(RedirectPolicy.Any),
+    .option(
+      "-b, --block-cross-domain-redirect",
+      "Block redirects to a different host",
+      false,
     )
     .action(
       async (
@@ -48,7 +40,7 @@ export const detectCommand = (): Command => {
           evidence: boolean;
           json: boolean;
           userAgent?: string;
-          redirectPolicy: RedirectPolicy;
+          blockCrossDomainRedirect: boolean;
         },
       ) => {
         if (options.debug) {
@@ -68,7 +60,7 @@ export const detectCommand = (): Command => {
             options.timeout,
             getJavascriptVariableNames(signatures),
             options.userAgent,
-            options.redirectPolicy,
+            options.blockCrossDomainRedirect,
           );
           const detections = analyze(context, signatures);
           if (detections.length === 0) {

--- a/src/commands/detect.ts
+++ b/src/commands/detect.ts
@@ -1,5 +1,6 @@
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { openPage } from "../browser/index.js";
+import { RedirectPolicy } from "../browser/types.js";
 import { analyze } from "../analyzer/index.js";
 import { signatures } from "../signatures/index.js";
 import { logger, setLogLevel } from "../logger/index.js";
@@ -26,6 +27,18 @@ export const detectCommand = (): Command => {
     .option("-e, --evidence", "Show evidence for detections", false)
     .option("-j, --json", "Output results in JSON format", false)
     .option("-u, --user-agent <string>", "Custom User-Agent string")
+    .addOption(
+      new Option(
+        "-r, --redirect-policy <policy>",
+        "Redirect policy: 'any', 'same-site', or 'same-host'",
+      )
+        .choices([
+          RedirectPolicy.Any,
+          RedirectPolicy.SameSite,
+          RedirectPolicy.SameHost,
+        ])
+        .default(RedirectPolicy.Any),
+    )
     .action(
       async (
         url: string,
@@ -35,6 +48,7 @@ export const detectCommand = (): Command => {
           evidence: boolean;
           json: boolean;
           userAgent?: string;
+          redirectPolicy: RedirectPolicy;
         },
       ) => {
         if (options.debug) {
@@ -54,6 +68,7 @@ export const detectCommand = (): Command => {
             options.timeout,
             getJavascriptVariableNames(signatures),
             options.userAgent,
+            options.redirectPolicy,
           );
           const detections = analyze(context, signatures);
           if (detections.length === 0) {

--- a/src/e2e/cli.e2e.test.ts
+++ b/src/e2e/cli.e2e.test.ts
@@ -40,6 +40,7 @@ describe("CLI E2E Tests", () => {
         expect(stdout).toContain("--json");
         expect(stdout).toContain("--evidence");
         expect(stdout).toContain("--debug");
+        expect(stdout).toContain("--redirect-policy");
       });
     });
 

--- a/src/e2e/cli.e2e.test.ts
+++ b/src/e2e/cli.e2e.test.ts
@@ -40,7 +40,7 @@ describe("CLI E2E Tests", () => {
         expect(stdout).toContain("--json");
         expect(stdout).toContain("--evidence");
         expect(stdout).toContain("--debug");
-        expect(stdout).toContain("--redirect-policy");
+        expect(stdout).toContain("--block-cross-domain-redirect");
       });
     });
 


### PR DESCRIPTION
## Summary

- Add `-b, --block-cross-domain-redirect` boolean flag to the `detect` command that blocks navigation redirects to a different host
- Pre-inspect the HTTP redirect chain (following 3xx hops) to detect and block cross-domain redirects before the browser processes them
- Log each redirect hop for navigation requests

## Details

When `--block-cross-domain-redirect` is enabled, the tool aborts any main-frame navigation redirect where the target host does not exactly match the original URL's host. This includes both client-side redirects (JS / meta refresh) and HTTP-level redirects (301, 302, etc.).

The redirect chain is pre-inspected by fetching each hop with `maxRedirects: 0`, so intermediate cross-domain hops are caught even if the final destination would return to the original host.

By default the flag is off, allowing all redirects.