### PR TITLE
feat: include navigation URL chain with status codes in JSON output

### DIFF
--- a/src/analyzer/apply.test.ts
+++ b/src/analyzer/apply.test.ts
@@ -12,6 +12,7 @@ function createMockContext(
   return {
     browser: {} as Context["browser"],
     page: {} as Context["page"],
+    urls: [],
     responses: [],
     cookies: [],
     javascriptVariables: {},

--- a/src/analyzer/index.test.ts
+++ b/src/analyzer/index.test.ts
@@ -11,6 +11,7 @@ function createMockContext(
   return {
     browser: {} as Context["browser"],
     page: {} as Context["page"],
+    urls: [],
     responses: [],
     cookies: [],
     javascriptVariables: {},

--- a/src/browser/index.test.ts
+++ b/src/browser/index.test.ts
@@ -644,6 +644,38 @@ describe("openPage", () => {
       expect(fulfillMock).not.toHaveBeenCalled();
     });
 
+    it("should record non-Error thrown by route.fetch() in urls", async () => {
+      let routeHandler: (route: unknown) => Promise<void> = async () => {};
+      mockPage.route.mockImplementation(
+        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+          routeHandler = handler;
+        },
+      );
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      const result = await openPage("https://example.com", 10000, []);
+
+      const abortMock = vi.fn(() => Promise.resolve());
+      const fetchMock = vi.fn(() => Promise.reject("string error"));
+      await routeHandler({
+        request: () => ({
+          isNavigationRequest: () => true,
+          frame: () => mockMainFrame,
+          url: () => "https://example.com",
+        }),
+        continue: vi.fn(() => Promise.resolve()),
+        abort: abortMock,
+        fetch: fetchMock,
+        fulfill: vi.fn(() => Promise.resolve()),
+      });
+
+      expect(result.urls).toEqual([
+        { url: "https://example.com", error: "string error" },
+      ]);
+    });
+
     it("should continue for already-inspected URLs on route re-entry", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
@@ -837,6 +869,48 @@ describe("openPage", () => {
       expect(fetchMock).toHaveBeenCalledTimes(2);
       expect(abortMock).toHaveBeenCalledWith("failed");
       expect(fulfillMock).not.toHaveBeenCalled();
+    });
+
+    it("should record non-Error thrown by redirect chain fetch in urls", async () => {
+      let routeHandler: (route: unknown) => Promise<void> = async () => {};
+      mockPage.route.mockImplementation(
+        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+          routeHandler = handler;
+        },
+      );
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      const result = await openPage("https://example.com", 10000, []);
+
+      const mockRedirectResponse = {
+        status: () => 301,
+        headers: () => ({ location: "https://example.com/page" }),
+        text: () => Promise.resolve(null),
+      };
+      const abortMock = vi.fn(() => Promise.resolve());
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mockRedirectResponse)
+        .mockRejectedValueOnce("string error");
+
+      await routeHandler({
+        request: () => ({
+          isNavigationRequest: () => true,
+          frame: () => mockMainFrame,
+          url: () => "https://example.com",
+        }),
+        continue: vi.fn(() => Promise.resolve()),
+        abort: abortMock,
+        fetch: fetchMock,
+        fulfill: vi.fn(() => Promise.resolve()),
+      });
+
+      expect(result.urls).toEqual([
+        { url: "https://example.com", status: 301 },
+        { url: "https://example.com/page", error: "string error" },
+      ]);
     });
 
     it("should break loop when Location URL cannot be parsed", async () => {
@@ -1241,6 +1315,39 @@ describe("openPage", () => {
       expect(logger.error).toHaveBeenCalledWith(
         expect.stringContaining("Connection refused"),
       );
+    });
+
+    it("should not duplicate error in urls when route handler already recorded entries", async () => {
+      let routeHandler: (route: unknown) => Promise<void> = async () => {};
+      mockPage.route.mockImplementation(
+        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+          routeHandler = handler;
+        },
+      );
+      mockPage.goto.mockImplementation(async () => {
+        // Route handler records a fetch error
+        await routeHandler({
+          request: () => ({
+            isNavigationRequest: () => true,
+            frame: () => mockMainFrame,
+            url: () => "https://example.com",
+          }),
+          continue: vi.fn(() => Promise.resolve()),
+          abort: vi.fn(() => Promise.resolve()),
+          fetch: vi.fn(() => Promise.reject(new Error("net::ERR_NAME_NOT_RESOLVED"))),
+          fulfill: vi.fn(() => Promise.resolve()),
+        });
+        throw new Error("page.goto: net::ERR_FAILED");
+      });
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      const result = await openPage("https://example.com", 10000, []);
+
+      // Only the route handler's error should be in urls, not the page.goto error
+      expect(result.urls).toHaveLength(1);
+      expect(result.urls[0]!.error).toContain("net::ERR_NAME_NOT_RESOLVED");
     });
 
     it("should not log error when navigation is blocked by redirect policy", async () => {

--- a/src/browser/index.test.ts
+++ b/src/browser/index.test.ts
@@ -1409,6 +1409,10 @@ describe("openPage", () => {
           status: () => 200,
           headers: () => ({ "content-type": "application/json" }),
           text: () => Promise.resolve('{"data": "test"}'),
+          request: () => ({
+            isNavigationRequest: () => false,
+            frame: () => null,
+          }),
         });
       });
 
@@ -1451,6 +1455,10 @@ describe("openPage", () => {
           status: () => 200,
           headers: () => ({ "content-type": "application/octet-stream" }),
           text: () => Promise.reject(new Error("Cannot read binary")),
+          request: () => ({
+            isNavigationRequest: () => false,
+            frame: () => null,
+          }),
         });
       });
 
@@ -1488,6 +1496,10 @@ describe("openPage", () => {
           status: () => 200,
           headers: () => ({ "content-type": "text/javascript" }),
           text: () => Promise.resolve("console.log('ok')"),
+          request: () => ({
+            isNavigationRequest: () => false,
+            frame: () => null,
+          }),
         });
       });
 
@@ -1501,6 +1513,77 @@ describe("openPage", () => {
         host: "cdn.example.net",
         isFirstParty: false,
       });
+    });
+
+    it("should record navigation response in urls", async () => {
+      const mockMainFrame = { id: "main" };
+      mockPage.mainFrame.mockReturnValue(mockMainFrame);
+
+      let capturedCallback: (response: unknown) => Promise<void>;
+
+      mockPage.on.mockImplementation(
+        (event: string, callback: (response: unknown) => Promise<void>) => {
+          if (event === "response") {
+            capturedCallback = callback;
+          }
+        },
+      );
+
+      mockPage.goto.mockImplementation(async () => {
+        await capturedCallback({
+          url: () => "https://example.com/",
+          status: () => 200,
+          headers: () => ({ "content-type": "text/html" }),
+          text: () => Promise.resolve("<html></html>"),
+          request: () => ({
+            isNavigationRequest: () => true,
+            frame: () => mockMainFrame,
+          }),
+        });
+      });
+
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      const result = await openPage("https://example.com", 10000, []);
+
+      expect(result.urls).toEqual([
+        { url: "https://example.com/", status: 200 },
+      ]);
+    });
+
+    it("should not record non-navigation response in urls", async () => {
+      let capturedCallback: (response: unknown) => Promise<void>;
+
+      mockPage.on.mockImplementation(
+        (event: string, callback: (response: unknown) => Promise<void>) => {
+          if (event === "response") {
+            capturedCallback = callback;
+          }
+        },
+      );
+
+      mockPage.goto.mockImplementation(async () => {
+        await capturedCallback({
+          url: () => "https://example.com/style.css",
+          status: () => 200,
+          headers: () => ({ "content-type": "text/css" }),
+          text: () => Promise.resolve("body {}"),
+          request: () => ({
+            isNavigationRequest: () => false,
+            frame: () => null,
+          }),
+        });
+      });
+
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      const result = await openPage("https://example.com", 10000, []);
+
+      expect(result.urls).toEqual([]);
     });
   });
 });

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import { chromium } from "playwright";
 import { logger } from "../logger/index.js";
-import type { Context, Response } from "./types.js";
+import type { Context, Response, UrlEntry } from "./types.js";
 import {
   extractJsVariables,
   getHostFromUrl,
@@ -99,6 +99,7 @@ export async function openPage(
         `Blocked cross-domain redirect: ${targetUrl}`,
       );
       blockedByRedirectPolicy = true;
+      urls.push({ url: targetUrl, error: "Blocked cross-domain redirect" });
       await route.abort("blockedbyclient");
       return;
     }
@@ -121,7 +122,9 @@ export async function openPage(
     let response;
     try {
       response = await route.fetch({ maxRedirects: 0 });
-    } catch {
+    } catch (e) {
+      const message = (e instanceof Error ? e.message : String(e)).split("\n")[0] ?? "";
+      urls.push({ url: targetUrl, error: message });
       await route.abort("failed");
       return;
     }
@@ -151,6 +154,7 @@ export async function openPage(
         hopResponse.body = hopBody;
       }
       responses.push(hopResponse);
+      urls.push({ url: currentUrl, status: response.status() });
 
       const location = response.headers()["location"];
       if (!location) break;
@@ -172,6 +176,7 @@ export async function openPage(
           `Blocked cross-domain redirect: ${redirectUrl}`,
         );
         blockedByRedirectPolicy = true;
+        urls.push({ url: redirectUrl, error: "Blocked cross-domain redirect" });
         await route.abort("blockedbyclient");
         return;
       }
@@ -183,7 +188,9 @@ export async function openPage(
 
       try {
         response = await route.fetch({ url: redirectUrl, maxRedirects: 0 });
-      } catch {
+      } catch (e) {
+        const message = (e instanceof Error ? e.message : String(e)).split("\n")[0] ?? "";
+        urls.push({ url: redirectUrl, error: message });
         await route.abort("failed");
         return;
       }
@@ -192,6 +199,7 @@ export async function openPage(
     await route.fulfill({ response: firstResponse });
   });
 
+  const urls: UrlEntry[] = [];
   const responses: Response[] = [];
   page.on("response", async (response) => {
     const responseUrl = response.url();
@@ -210,6 +218,11 @@ export async function openPage(
     logger.debug(
       `Received response [${colorizeStatusCode(statusCode)}] ${responseUrl}`,
     );
+    const request = response.request();
+    if (request.isNavigationRequest() && request.frame() === page.mainFrame()) {
+      urls.push({ url: responseUrl, status: statusCode });
+    }
+
     const res: Response = {
       url: responseUrl,
       host: responseHost,
@@ -244,7 +257,15 @@ export async function openPage(
   } else if (blockedByRedirectPolicy) {
     // Already logged by the route handler as "Blocked redirect by policy"
   } else {
-    logger.error(`Error loading page ${url}: ${result.split("\n")[0]}`);
+    const errorMessage = `Error loading page ${url}: ${result.split("\n")[0]}`;
+    logger.error(errorMessage);
+    // Fallback: record the error only when the route handler never ran
+    // (e.g. DNS failure on the initial URL). If the route handler already
+    // captured entries (e.g. a 302 hop followed by a fetch error), the
+    // error is already in urls via the route.fetch catch block.
+    if (urls.length === 0) {
+      urls.push({ url, error: errorMessage });
+    }
   }
 
   let cookies: Context["cookies"] = [];
@@ -287,6 +308,7 @@ export async function openPage(
   return {
     browser,
     page,
+    urls,
     responses,
     javascriptVariables,
     cookies,

--- a/src/browser/types.ts
+++ b/src/browser/types.ts
@@ -14,6 +14,12 @@ export type Cookie = {
   sameSite: "Strict" | "Lax" | "None";
 };
 
+export type UrlEntry = {
+  url: string;
+  status?: number;
+  error?: string;
+};
+
 export type Response = {
   url: string;
   host: string;
@@ -26,6 +32,7 @@ export type Response = {
 export type Context = {
   browser: Browser;
   page: Page;
+  urls: UrlEntry[];
   responses: Response[];
   javascriptVariables: Record<string, unknown>;
   cookies: Cookie[];

--- a/src/commands/detect.test.ts
+++ b/src/commands/detect.test.ts
@@ -39,6 +39,7 @@ describe("detectCommand", () => {
   let mockContext: {
     browser: { close: ReturnType<typeof vi.fn> };
     page: { close: ReturnType<typeof vi.fn> };
+    urls: never[];
     responses: never[];
     javascriptVariables: Record<string, unknown>;
     cookies: never[];
@@ -53,6 +54,7 @@ describe("detectCommand", () => {
     mockContext = {
       browser: { close: vi.fn() },
       page: { close: vi.fn() },
+      urls: [],
       responses: [],
       javascriptVariables: {},
       cookies: [],
@@ -245,6 +247,7 @@ describe("detectCommand", () => {
     it("should print text output by default", async () => {
       vi.mocked(analyze).mockReturnValue([{ name: "nginx" }]);
       vi.mocked(makeDetectCommandOutput).mockReturnValue({
+        urls: [],
         detectedSoftwares: [{ name: "nginx", confidence: "high" }],
       });
 
@@ -257,6 +260,7 @@ describe("detectCommand", () => {
     it("should print JSON output when --json flag is set", async () => {
       vi.mocked(analyze).mockReturnValue([{ name: "nginx" }]);
       vi.mocked(makeDetectCommandOutput).mockReturnValue({
+        urls: [],
         detectedSoftwares: [{ name: "nginx", confidence: "high" }],
       });
 
@@ -269,6 +273,7 @@ describe("detectCommand", () => {
     it("should pass evidence flag to text output", async () => {
       vi.mocked(analyze).mockReturnValue([{ name: "nginx" }]);
       vi.mocked(makeDetectCommandOutput).mockReturnValue({
+        urls: [],
         detectedSoftwares: [{ name: "nginx", confidence: "high" }],
       });
 

--- a/src/commands/detect.ts
+++ b/src/commands/detect.ts
@@ -63,15 +63,18 @@ export const detectCommand = (): Command => {
             options.blockCrossDomainRedirect,
           );
           const detections = analyze(context, signatures);
+          const output = makeDetectCommandOutput(
+            context.urls,
+            detections,
+            signatures,
+          );
           if (detections.length === 0) {
             logger.info("No technologies detected.");
-          } else {
-            const output = makeDetectCommandOutput(detections, signatures);
-            if (options.json) {
-              printDetectCommandOutputAsJSON(output);
-            } else {
-              printDetectCommandOutputAsText(output, options.evidence);
-            }
+          }
+          if (options.json) {
+            printDetectCommandOutputAsJSON(output);
+          } else if (detections.length > 0) {
+            printDetectCommandOutputAsText(output, options.evidence);
           }
         } catch (error) {
           const message =

--- a/src/commands/detect_types.ts
+++ b/src/commands/detect_types.ts
@@ -1,5 +1,6 @@
 import type { Evidence } from "../analyzer/types.js";
 import type { Confidence } from "../signatures/_types.js";
+import type { UrlEntry } from "../browser/types.js";
 
 export type DetectedSoftware = {
   name: string;
@@ -12,5 +13,6 @@ export type DetectedSoftware = {
 };
 
 export type DetectCommandOutput = {
+  urls: UrlEntry[];
   detectedSoftwares: DetectedSoftware[];
 };

--- a/src/commands/detect_utils.test.ts
+++ b/src/commands/detect_utils.test.ts
@@ -53,7 +53,7 @@ describe("makeDetectCommandOutput", () => {
         },
       ];
 
-      const result = makeDetectCommandOutput(detections, baseSignatures);
+      const result = makeDetectCommandOutput([], detections, baseSignatures);
 
       expect(result.detectedSoftwares).toHaveLength(1);
       expect(result.detectedSoftwares[0]!.name).toBe("nginx");
@@ -77,7 +77,7 @@ describe("makeDetectCommandOutput", () => {
         },
       ];
 
-      const result = makeDetectCommandOutput(detections, baseSignatures);
+      const result = makeDetectCommandOutput([], detections, baseSignatures);
 
       expect(result.detectedSoftwares[0]!.cpe).toBe(
         "cpe:2.3:a:nginx:nginx:1.20.0",
@@ -99,7 +99,7 @@ describe("makeDetectCommandOutput", () => {
         },
       ];
 
-      const result = makeDetectCommandOutput(detections, baseSignatures);
+      const result = makeDetectCommandOutput([], detections, baseSignatures);
 
       expect(result.detectedSoftwares[0]!.cpe).toBeUndefined();
     });
@@ -127,7 +127,7 @@ describe("makeDetectCommandOutput", () => {
         },
       ];
 
-      const result = makeDetectCommandOutput(detections, baseSignatures);
+      const result = makeDetectCommandOutput([], detections, baseSignatures);
 
       const nginx = result.detectedSoftwares.find(
         (s) => s.version === "1.20.0",
@@ -152,7 +152,7 @@ describe("makeDetectCommandOutput", () => {
         },
       ];
 
-      const result = makeDetectCommandOutput(detections, baseSignatures);
+      const result = makeDetectCommandOutput([], detections, baseSignatures);
 
       const names = result.detectedSoftwares.map((s) => s.name);
       expect(names).toContain("WordPress");
@@ -175,7 +175,7 @@ describe("makeDetectCommandOutput", () => {
         },
       ];
 
-      const result = makeDetectCommandOutput(detections, baseSignatures);
+      const result = makeDetectCommandOutput([], detections, baseSignatures);
 
       const php = result.detectedSoftwares.find((s) => s.name === "PHP");
       expect(php?.impliedBy).toBe("WordPress");
@@ -207,7 +207,7 @@ describe("makeDetectCommandOutput", () => {
         },
       ];
 
-      const result = makeDetectCommandOutput(detections, baseSignatures);
+      const result = makeDetectCommandOutput([], detections, baseSignatures);
 
       const phpInstances = result.detectedSoftwares.filter(
         (s) => s.name === "PHP",
@@ -238,7 +238,7 @@ describe("makeDetectCommandOutput", () => {
         },
       ];
 
-      const result = makeDetectCommandOutput(detections, baseSignatures);
+      const result = makeDetectCommandOutput([], detections, baseSignatures);
 
       expect(result.detectedSoftwares[0]!.version).toBe("1.20.0");
     });
@@ -275,7 +275,7 @@ describe("makeDetectCommandOutput", () => {
         },
       ];
 
-      const result = makeDetectCommandOutput(detections, signatures);
+      const result = makeDetectCommandOutput([], detections, signatures);
 
       const js = result.detectedSoftwares.find((s) => s.name === "JavaScript");
       expect(js).toBeDefined();
@@ -314,7 +314,7 @@ describe("makeDetectCommandOutput", () => {
         },
       ];
 
-      const result = makeDetectCommandOutput(detections, signatures);
+      const result = makeDetectCommandOutput([], detections, signatures);
 
       const nginxEntries = result.detectedSoftwares.filter(
         (s) => s.name === "nginx",
@@ -344,7 +344,7 @@ describe("makeDetectCommandOutput", () => {
         { name: "nginx" },
       ];
 
-      const result = makeDetectCommandOutput(detections, signatures);
+      const result = makeDetectCommandOutput([], detections, signatures);
 
       expect(result.detectedSoftwares).toHaveLength(1);
     });
@@ -352,14 +352,14 @@ describe("makeDetectCommandOutput", () => {
 
   describe("edge cases", () => {
     it("should handle empty detections", () => {
-      const result = makeDetectCommandOutput([], baseSignatures);
+      const result = makeDetectCommandOutput([], [], baseSignatures);
       expect(result.detectedSoftwares).toEqual([]);
     });
 
     it("should handle detections without evidences", () => {
       const detections: Detection[] = [{ name: "nginx" }];
 
-      const result = makeDetectCommandOutput(detections, baseSignatures);
+      const result = makeDetectCommandOutput([], detections, baseSignatures);
 
       expect(result.detectedSoftwares).toHaveLength(1);
       expect(result.detectedSoftwares[0]!.confidence).toBe("low");
@@ -408,7 +408,7 @@ describe("makeDetectCommandOutput", () => {
         },
       ];
 
-      const result = makeDetectCommandOutput(detections, baseSignatures);
+      const result = makeDetectCommandOutput([], detections, baseSignatures);
       const evidences = result.detectedSoftwares[0]!.evidences!;
 
       expect(
@@ -451,7 +451,7 @@ describe("makeDetectCommandOutput", () => {
         },
       ];
 
-      const result = makeDetectCommandOutput(detections, baseSignatures);
+      const result = makeDetectCommandOutput([], detections, baseSignatures);
       const nginx = result.detectedSoftwares.find(
         (s) => s.name === "nginx" && s.version === "1.20.0",
       );
@@ -478,6 +478,7 @@ describe("printDetectCommandOutputAsText", () => {
 
   it("should print software names", () => {
     const output = {
+      urls: [],
       detectedSoftwares: [
         {
           name: "nginx",
@@ -497,6 +498,7 @@ describe("printDetectCommandOutputAsText", () => {
 
   it("should print version when available", () => {
     const output = {
+      urls: [],
       detectedSoftwares: [
         {
           name: "nginx",
@@ -522,6 +524,7 @@ describe("printDetectCommandOutputAsText", () => {
 
   it("should print evidences when showEvidence is true", () => {
     const output = {
+      urls: [],
       detectedSoftwares: [
         {
           name: "nginx",
@@ -547,6 +550,7 @@ describe("printDetectCommandOutputAsText", () => {
 
   it("should print sourceUrl for body evidences", () => {
     const output = {
+      urls: [],
       detectedSoftwares: [
         {
           name: "WordPress",
@@ -573,6 +577,7 @@ describe("printDetectCommandOutputAsText", () => {
 
   it("should not print evidences when showEvidence is false", () => {
     const output = {
+      urls: [],
       detectedSoftwares: [
         {
           name: "nginx",
@@ -597,6 +602,7 @@ describe("printDetectCommandOutputAsText", () => {
 
   it("should print impliedBy when present", () => {
     const output = {
+      urls: [],
       detectedSoftwares: [
         {
           name: "PHP",
@@ -627,6 +633,7 @@ describe("printDetectCommandOutputAsJSON", () => {
 
   it("should print valid JSON", () => {
     const output = {
+      urls: [],
       detectedSoftwares: [
         {
           name: "nginx",
@@ -644,6 +651,7 @@ describe("printDetectCommandOutputAsJSON", () => {
 
   it("should include all fields in JSON output", () => {
     const output = {
+      urls: [],
       detectedSoftwares: [
         {
           name: "nginx",

--- a/src/commands/detect_utils.ts
+++ b/src/commands/detect_utils.ts
@@ -2,6 +2,7 @@ import chalk from "chalk";
 import type { Confidence, Signature } from "../signatures/_types.js";
 import type { Detection, Evidence } from "../analyzer/types.js";
 import type { DetectCommandOutput, DetectedSoftware } from "./detect_types.js";
+import type { UrlEntry } from "../browser/types.js";
 import { maxConfidence } from "../analyzer/utils.js";
 
 export function colorizeConfidence(confidence: Confidence): string {
@@ -33,6 +34,7 @@ function compareEvidence(a: Evidence, b: Evidence): number {
 }
 
 export function makeDetectCommandOutput(
+  urls: UrlEntry[],
   detections: Detection[],
   signatures: Signature[],
 ): DetectCommandOutput {
@@ -162,6 +164,7 @@ export function makeDetectCommandOutput(
   }
 
   return {
+    urls,
     detectedSoftwares: [...mergedByKey.values()],
   };
 }


### PR DESCRIPTION
## Summary
- Add a `urls` array to the JSON output that tracks the full navigation chain (redirects, final destination, errors)
- Each entry contains `url` and either `status` (HTTP status code) or `error` (failure reason)
- Covers all navigation scenarios: 3xx redirects, cross-domain blocks, fetch failures, and DNS resolution errors

## Example output

Redirect chain:
```json
{
  "urls": [
    { "url": "https://example.com/", "status": 302 },
    { "url": "https://example.com/login/", "status": 200 }
  ],
  "detectedSoftwares": [...]
}
```

Error case:
```json
{
  "urls": [
    { "url": "http://notfound.test/", "error": "Error loading page ..." }
  ],
  "detectedSoftwares": []
}
```

## Changes
- `src/browser/types.ts`: Add `UrlEntry` type and `urls` field to `Context`
- `src/browser/index.ts`: Track navigation URLs in route handler and response listener
- `src/commands/detect_types.ts`: Add `urls` to `DetectCommandOutput`
- `src/commands/detect_utils.ts`: Pass `urls` through `makeDetectCommandOutput`
- `src/commands/detect.ts`: Always build output (for JSON `urls`), text output only when detections > 0

## Test plan
- [x] Build passes
- [x] All 202 tests pass
- [x] Coverage verified for new code paths
- [x] Tested with real redirect chains (302 → 200, 302 → DNS failure)
