### PR TITLE
feat: add --locale and --header options to detect command

### DIFF
--- a/src/browser/index.test.ts
+++ b/src/browser/index.test.ts
@@ -124,11 +124,31 @@ describe("openPage", () => {
     });
 
     it("should pass custom userAgent to browser context", async () => {
-      await openPage("https://example.com", 10000, [], "MyCustomAgent/1.0");
+      await openPage("https://example.com", 10000, [], { userAgent: "MyCustomAgent/1.0" });
 
       expect(mockBrowser.newContext).toHaveBeenCalledWith({
         ignoreHTTPSErrors: true,
         userAgent: "MyCustomAgent/1.0",
+      });
+    });
+
+    it("should pass locale to browser context", async () => {
+      await openPage("https://example.com", 10000, [], { locale: "ja-JP" });
+
+      expect(mockBrowser.newContext).toHaveBeenCalledWith({
+        ignoreHTTPSErrors: true,
+        locale: "ja-JP",
+      });
+    });
+
+    it("should pass extraHTTPHeaders to browser context", async () => {
+      await openPage("https://example.com", 10000, [], {
+        extraHTTPHeaders: { "Accept-Language": "ja", "X-Custom": "value" },
+      });
+
+      expect(mockBrowser.newContext).toHaveBeenCalledWith({
+        ignoreHTTPSErrors: true,
+        extraHTTPHeaders: { "Accept-Language": "ja", "X-Custom": "value" },
       });
     });
 
@@ -187,13 +207,9 @@ describe("openPage", () => {
         () => new Promise((resolve) => setTimeout(resolve, 100)),
       );
 
-      await openPage(
-        "https://example.com",
-        10000,
-        [],
-        undefined,
-        true,
-      );
+      await openPage("https://example.com", 10000, [], {
+        blockCrossDomainRedirect: true,
+      });
 
       const continueMock = vi.fn(() => Promise.resolve());
       const abortMock = vi.fn(() => Promise.resolve());
@@ -227,7 +243,7 @@ describe("openPage", () => {
         },
       );
 
-      await openPage("https://example.com", 10000, [], undefined, false);
+      await openPage("https://example.com", 10000, [], { blockCrossDomainRedirect: false });
 
       const mockResponse = { status: () => 200, headers: () => ({}) };
       const continueMock = vi.fn(() => Promise.resolve());
@@ -259,13 +275,9 @@ describe("openPage", () => {
         },
       );
 
-      await openPage(
-        "https://example.com",
-        10000,
-        [],
-        undefined,
-        true,
-      );
+      await openPage("https://example.com", 10000, [], {
+        blockCrossDomainRedirect: true,
+      });
 
       const continueMock = vi.fn(() => Promise.resolve());
       const abortMock = vi.fn(() => Promise.resolve());
@@ -291,13 +303,9 @@ describe("openPage", () => {
         },
       );
 
-      await openPage(
-        "https://example.com",
-        10000,
-        [],
-        undefined,
-        true,
-      );
+      await openPage("https://example.com", 10000, [], {
+        blockCrossDomainRedirect: true,
+      });
 
       const continueMock = vi.fn(() => Promise.resolve());
       const abortMock = vi.fn(() => Promise.resolve());
@@ -323,13 +331,9 @@ describe("openPage", () => {
         },
       );
 
-      await openPage(
-        "https://example.com",
-        10000,
-        [],
-        undefined,
-        true,
-      );
+      await openPage("https://example.com", 10000, [], {
+        blockCrossDomainRedirect: true,
+      });
 
       const mockResponse = { status: () => 200, headers: () => ({}) };
       const continueMock = vi.fn(() => Promise.resolve());
@@ -378,13 +382,9 @@ describe("openPage", () => {
         () => new Promise((resolve) => setTimeout(resolve, 100)),
       );
 
-      await openPage(
-        "https://app.example.com",
-        10000,
-        [],
-        undefined,
-        true,
-      );
+      await openPage("https://app.example.com", 10000, [], {
+        blockCrossDomainRedirect: true,
+      });
 
       const mockResponse = { status: () => 200, headers: () => ({}) };
       const continueMock = vi.fn(() => Promise.resolve());
@@ -429,13 +429,9 @@ describe("openPage", () => {
         () => new Promise((resolve) => setTimeout(resolve, 100)),
       );
 
-      await openPage(
-        "https://www.example.com",
-        10000,
-        [],
-        undefined,
-        true,
-      );
+      await openPage("https://www.example.com", 10000, [], {
+        blockCrossDomainRedirect: true,
+      });
 
       const mockResponse = {
         status: () => 301,
@@ -477,13 +473,9 @@ describe("openPage", () => {
         () => new Promise((resolve) => setTimeout(resolve, 100)),
       );
 
-      await openPage(
-        "https://example.com",
-        10000,
-        [],
-        undefined,
-        true,
-      );
+      await openPage("https://example.com", 10000, [], {
+        blockCrossDomainRedirect: true,
+      });
 
       const mockResponse = {
         status: () => 301,
@@ -522,13 +514,9 @@ describe("openPage", () => {
         () => new Promise((resolve) => setTimeout(resolve, 100)),
       );
 
-      await openPage(
-        "https://example.com",
-        10000,
-        [],
-        undefined,
-        true,
-      );
+      await openPage("https://example.com", 10000, [], {
+        blockCrossDomainRedirect: true,
+      });
 
       const mockResponse = {
         status: () => 301,
@@ -567,13 +555,9 @@ describe("openPage", () => {
         () => new Promise((resolve) => setTimeout(resolve, 100)),
       );
 
-      await openPage(
-        "https://example.com",
-        10000,
-        [],
-        undefined,
-        true,
-      );
+      await openPage("https://example.com", 10000, [], {
+        blockCrossDomainRedirect: true,
+      });
 
       const mockResponse = {
         status: () => 302,
@@ -615,13 +599,9 @@ describe("openPage", () => {
         () => new Promise((resolve) => setTimeout(resolve, 100)),
       );
 
-      await openPage(
-        "https://example.com",
-        10000,
-        [],
-        undefined,
-        true,
-      );
+      await openPage("https://example.com", 10000, [], {
+        blockCrossDomainRedirect: true,
+      });
 
       const continueMock = vi.fn(() => Promise.resolve());
       const abortMock = vi.fn(() => Promise.resolve());
@@ -655,13 +635,9 @@ describe("openPage", () => {
         () => new Promise((resolve) => setTimeout(resolve, 100)),
       );
 
-      await openPage(
-        "https://example.com",
-        10000,
-        [],
-        undefined,
-        true,
-      );
+      await openPage("https://example.com", 10000, [], {
+        blockCrossDomainRedirect: true,
+      });
 
       // First call: 301 chain example.com -> example.com/page
       const mockRedirectResponse = {
@@ -723,13 +699,9 @@ describe("openPage", () => {
         () => new Promise((resolve) => setTimeout(resolve, 100)),
       );
 
-      await openPage(
-        "https://example.com",
-        10000,
-        [],
-        undefined,
-        true,
-      );
+      await openPage("https://example.com", 10000, [], {
+        blockCrossDomainRedirect: true,
+      });
 
       // First call: build a chain so inspectedUrls is populated
       const mockRedirectResponse = {
@@ -801,13 +773,9 @@ describe("openPage", () => {
         () => new Promise((resolve) => setTimeout(resolve, 100)),
       );
 
-      await openPage(
-        "https://example.com",
-        10000,
-        [],
-        undefined,
-        true,
-      );
+      await openPage("https://example.com", 10000, [], {
+        blockCrossDomainRedirect: true,
+      });
 
       const mockRedirectResponse = {
         status: () => 301,
@@ -850,13 +818,9 @@ describe("openPage", () => {
         () => new Promise((resolve) => setTimeout(resolve, 100)),
       );
 
-      await openPage(
-        "https://example.com",
-        10000,
-        [],
-        undefined,
-        true,
-      );
+      await openPage("https://example.com", 10000, [], {
+        blockCrossDomainRedirect: true,
+      });
 
       // Location with an invalid base URL combination that triggers URL parse error
       const mockResponse = {
@@ -1269,13 +1233,9 @@ describe("openPage", () => {
         () => new Promise((resolve) => setTimeout(resolve, 100)),
       );
 
-      await openPage(
-        "https://example.com",
-        10000,
-        [],
-        undefined,
-        true,
-      );
+      await openPage("https://example.com", 10000, [], {
+        blockCrossDomainRedirect: true,
+      });
 
       expect(logger.error).not.toHaveBeenCalled();
     });

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import { chromium } from "playwright";
 import { logger } from "../logger/index.js";
-import type { Context, Response } from "./types.js";
+import type { Context, OpenPageOptions, Response } from "./types.js";
 import {
   extractJsVariables,
   getHostFromUrl,
@@ -38,9 +38,15 @@ export async function openPage(
   url: string,
   timeoutMs: number,
   javascriptVariableNames: string[],
-  userAgent?: string,
-  blockCrossDomainRedirect: boolean = false,
+  options: OpenPageOptions = {},
 ): Promise<Context> {
+  const {
+    userAgent,
+    locale,
+    extraHTTPHeaders,
+    blockCrossDomainRedirect = false,
+  } = options;
+
   const pageHost = getHostFromUrl(url);
   if (!pageHost) {
     throw new Error(`Invalid URL: ${url}`);
@@ -50,6 +56,8 @@ export async function openPage(
   const context = await browser.newContext({
     ignoreHTTPSErrors: true,
     ...(userAgent ? { userAgent } : {}),
+    ...(locale ? { locale } : {}),
+    ...(extraHTTPHeaders ? { extraHTTPHeaders } : {}),
   });
   const page = await context.newPage();
 

--- a/src/browser/types.ts
+++ b/src/browser/types.ts
@@ -23,6 +23,13 @@ export type Response = {
   body?: string;
 };
 
+export type OpenPageOptions = {
+  userAgent?: string | undefined;
+  locale?: string | undefined;
+  extraHTTPHeaders?: Record<string, string> | undefined;
+  blockCrossDomainRedirect?: boolean | undefined;
+};
+
 export type Context = {
   browser: Browser;
   page: Page;

--- a/src/commands/detect.test.ts
+++ b/src/commands/detect.test.ts
@@ -249,6 +249,34 @@ describe("detectCommand", () => {
       );
     });
 
+    it("should warn on empty header name", async () => {
+      await runCommand(["-H", ": value"]);
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid header name"),
+      );
+      expect(openPage).toHaveBeenCalledWith(
+        "https://example.com",
+        10000,
+        expect.any(Array),
+        expect.objectContaining({ extraHTTPHeaders: undefined }),
+      );
+    });
+
+    it("should warn on header name with spaces", async () => {
+      await runCommand(["-H", "X Foo: bar"]);
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid header name"),
+      );
+      expect(openPage).toHaveBeenCalledWith(
+        "https://example.com",
+        10000,
+        expect.any(Array),
+        expect.objectContaining({ extraHTTPHeaders: undefined }),
+      );
+    });
+
     it("should enable debug logging when --debug flag is set", async () => {
       await runCommand(["--debug"]);
 

--- a/src/commands/detect.test.ts
+++ b/src/commands/detect.test.ts
@@ -149,8 +149,12 @@ describe("detectCommand", () => {
         "https://example.com",
         10000,
         expect.any(Array),
-        undefined,
-        false,
+        {
+          userAgent: undefined,
+          locale: undefined,
+          extraHTTPHeaders: undefined,
+          blockCrossDomainRedirect: false,
+        },
       );
     });
 
@@ -161,8 +165,7 @@ describe("detectCommand", () => {
         "https://example.com",
         5000,
         expect.any(Array),
-        undefined,
-        false,
+        expect.objectContaining({ blockCrossDomainRedirect: false }),
       );
     });
 
@@ -173,8 +176,7 @@ describe("detectCommand", () => {
         "https://example.com",
         10000,
         expect.any(Array),
-        "MyAgent/1.0",
-        false,
+        expect.objectContaining({ userAgent: "MyAgent/1.0" }),
       );
     });
 
@@ -185,8 +187,63 @@ describe("detectCommand", () => {
         "https://example.com",
         10000,
         expect.any(Array),
-        undefined,
-        true,
+        expect.objectContaining({ blockCrossDomainRedirect: true }),
+      );
+    });
+
+    it("should pass locale when provided", async () => {
+      await runCommand(["--locale", "ja-JP"]);
+
+      expect(openPage).toHaveBeenCalledWith(
+        "https://example.com",
+        10000,
+        expect.any(Array),
+        expect.objectContaining({ locale: "ja-JP" }),
+      );
+    });
+
+    it("should pass extra HTTP headers when provided", async () => {
+      await runCommand(["-H", "X-Custom: value", "-H", "Accept-Language: ja"]);
+
+      expect(openPage).toHaveBeenCalledWith(
+        "https://example.com",
+        10000,
+        expect.any(Array),
+        expect.objectContaining({
+          extraHTTPHeaders: {
+            "X-Custom": "value",
+            "Accept-Language": "ja",
+          },
+        }),
+      );
+    });
+
+    it("should handle header values containing colons", async () => {
+      await runCommand(["-H", "Authorization: Bearer token:with:colons"]);
+
+      expect(openPage).toHaveBeenCalledWith(
+        "https://example.com",
+        10000,
+        expect.any(Array),
+        expect.objectContaining({
+          extraHTTPHeaders: {
+            Authorization: "Bearer token:with:colons",
+          },
+        }),
+      );
+    });
+
+    it("should warn on invalid header format", async () => {
+      await runCommand(["-H", "InvalidHeader"]);
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid header"),
+      );
+      expect(openPage).toHaveBeenCalledWith(
+        "https://example.com",
+        10000,
+        expect.any(Array),
+        expect.objectContaining({ extraHTTPHeaders: undefined }),
       );
     });
 

--- a/src/commands/detect.ts
+++ b/src/commands/detect.ts
@@ -26,6 +26,13 @@ export const detectCommand = (): Command => {
     .option("-e, --evidence", "Show evidence for detections", false)
     .option("-j, --json", "Output results in JSON format", false)
     .option("-u, --user-agent <string>", "Custom User-Agent string")
+    .option("-l, --locale <locale>", "Browser locale (e.g. ja-JP, en-US)")
+    .option(
+      "-H, --header <header>",
+      "Extra HTTP header (e.g. -H \"X-Custom: value\"), can be specified multiple times",
+      (value: string, prev: string[]) => [...prev, value],
+      [] as string[],
+    )
     .option(
       "-b, --block-cross-domain-redirect",
       "Block redirects to a different host",
@@ -40,6 +47,8 @@ export const detectCommand = (): Command => {
           evidence: boolean;
           json: boolean;
           userAgent?: string;
+          locale?: string;
+          header: string[];
           blockCrossDomainRedirect: boolean;
         },
       ) => {
@@ -55,12 +64,28 @@ export const detectCommand = (): Command => {
 
         let context: Awaited<ReturnType<typeof openPage>> | null = null;
         try {
+          const extraHTTPHeaders: Record<string, string> = {};
+          for (const h of options.header) {
+            const idx = h.indexOf(":");
+            if (idx === -1) {
+              logger.warn(`Invalid header (missing ':'): ${h}`);
+              continue;
+            }
+            extraHTTPHeaders[h.slice(0, idx).trim()] = h.slice(idx + 1).trim();
+          }
+
           context = await openPage(
             url,
             options.timeout,
             getJavascriptVariableNames(signatures),
-            options.userAgent,
-            options.blockCrossDomainRedirect,
+            {
+              userAgent: options.userAgent,
+              locale: options.locale,
+              extraHTTPHeaders: Object.keys(extraHTTPHeaders).length > 0
+                ? extraHTTPHeaders
+                : undefined,
+              blockCrossDomainRedirect: options.blockCrossDomainRedirect,
+            },
           );
           const detections = analyze(context, signatures);
           if (detections.length === 0) {

--- a/src/commands/detect.ts
+++ b/src/commands/detect.ts
@@ -12,6 +12,8 @@ import {
   printDetectCommandOutputAsText,
 } from "./detect_utils.js";
 
+const HTTP_TOKEN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+
 export const detectCommand = (): Command => {
   return new Command("detect")
     .argument("<url>", "URL of the website to analyze")
@@ -71,7 +73,12 @@ export const detectCommand = (): Command => {
               logger.warn(`Invalid header (missing ':'): ${h}`);
               continue;
             }
-            extraHTTPHeaders[h.slice(0, idx).trim()] = h.slice(idx + 1).trim();
+            const name = h.slice(0, idx).trim();
+            if (!HTTP_TOKEN.test(name)) {
+              logger.warn(`Invalid header name: ${h}`);
+              continue;
+            }
+            extraHTTPHeaders[name] = h.slice(idx + 1).trim();
           }
 
           context = await openPage(


### PR DESCRIPTION
## Summary

- Add `--locale` (`-l`) option to set the browser locale (e.g. `ja-JP`, `en-US`), controlling the `Accept-Language` header sent by the browser
- Add `--header` (`-H`) option to set extra HTTP headers, can be specified multiple times (e.g. `-H "X-Custom: value" -H "Accept-Language: ja"`)
- Refactor `openPage` to accept an `OpenPageOptions` object instead of multiple positional arguments, improving readability and extensibility

## Motivation

Some websites redirect based on the browser's locale (e.g. `Accept-Language` header). Without a way to control this, users cannot analyze specific language versions of a site. The `--locale` option addresses this directly, and `--header` provides a general-purpose escape hatch for any additional HTTP headers.

## Test plan

- [x] Verify `--locale` passes the locale to Playwright's `browser.newContext()`
- [x] Verify `-H` parses and passes extra HTTP headers to `browser.newContext()`
- [x] Verify `-H` handles multiple headers, values containing colons, and invalid formats
- [x] Verify existing tests pass after `openPage` refactor
- [x] All 211 tests pass, coverage remains at 100% for `detect.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)