### PR TITLE
fix: prevent jQuery URL patterns from matching plugin versions

### DIFF
--- a/src/signatures/technologies/jquery.test.ts
+++ b/src/signatures/technologies/jquery.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { jquerySignature } from "./jquery.js";
+
+function createMockContext(
+  overrides: Partial<Pick<Context, "responses">> = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: {},
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("jquerySignature", () => {
+  describe("URL matching", () => {
+    it("should detect jQuery with version from CDN path", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://cdn.example.com/libs/jquery/3.6.0/jquery.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, jquerySignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "3.6.0")).toBe(true);
+    });
+
+    it("should detect jQuery with version from filename", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/js/jquery-3.6.0.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, jquerySignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.[0]?.version).toBe("3.6.0");
+    });
+
+    it("should detect jQuery without version", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/js/jquery.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, jquerySignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.[0]?.version).toBeUndefined();
+    });
+
+    it("should detect jQuery slim variant", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/js/jquery.slim.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, jquerySignature);
+      expect(result).toBeDefined();
+    });
+
+    it("should not detect jQuery from plugin URLs", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://cdn.example.com/libs/some-plugin/1.1.0/jquery.some-plugin.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, jquerySignature);
+      expect(result).toBeUndefined();
+    });
+
+    it("should not detect jQuery from jQuery plugin URL with dot notation", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/js/jquery.some-plugin.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, jquerySignature);
+      expect(result).toBeUndefined();
+    });
+
+    it("should not detect jQuery from jQuery plugin URL with hyphen notation", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/js/jquery-some-plugin-1.12.0.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, jquerySignature);
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/src/signatures/technologies/jquery.ts
+++ b/src/signatures/technologies/jquery.ts
@@ -8,9 +8,8 @@ export const jquerySignature: Signature = {
   rule: {
     confidence: "high",
     urls: [
-      "jquery",
-      "/jquery(?:-(\\d+\\.\\d+\\.\\d+))?[/.-]?",
-      "(\\d+\\.\\d+\\.\\d+)?/jquery[/.-]?",
+      "/jquery(?:-(\\d+\\.\\d+\\.\\d+))?(?:\\.slim)?(?:\\.min)?\\.js",
+      "(\\d+\\.\\d+\\.\\d+)/jquery(?:\\.slim)?(?:\\.min)?\\.js",
     ],
     javascriptVariables: {
       "$.fn.jquery": "(\\d+\\.\\d+\\.\\d+)",


### PR DESCRIPTION
## Summary
- Fix jQuery URL signature patterns that were too broad, causing plugin URLs to be incorrectly detected as jQuery with the plugin's version number
- Replace loose patterns (`[/.-]?` suffix) with strict patterns that only match jQuery core filenames (`jquery.js`, `jquery.min.js`, `jquery.slim.min.js`, `jquery-<version>.min.js`)
- Add dedicated test file for jQuery signature URL matching

## Test plan
- [x] Verify jQuery core URLs are correctly detected with version extraction
- [x] Verify jQuery plugin URLs (dot/hyphen notation) are not matched
- [x] Verify all existing tests pass (`npm test`)
