### PR TITLE
fix: fix Slick and Axios URL signature patterns

### DIFF
--- a/src/signatures/technologies/axios.test.ts
+++ b/src/signatures/technologies/axios.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { axiosSignature } from "./axios.js";
+
+function createMockContext(
+  overrides: Partial<Pick<Context, "responses">> = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: {},
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("axiosSignature", () => {
+  describe("URL matching", () => {
+    it("should detect Axios with version from @ notation", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://cdn.example.com/npm/axios@1.6.0/dist/axios.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, axiosSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.[0]?.version).toBe("1.6.0");
+    });
+
+    it("should detect Axios with version from slash notation", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://cdn.example.com/npm/axios/1.6.0/dist/axios.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, axiosSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.[0]?.version).toBe("1.6.0");
+    });
+
+});
+});

--- a/src/signatures/technologies/axios.ts
+++ b/src/signatures/technologies/axios.ts
@@ -6,7 +6,7 @@ export const axiosSignature: Signature = {
   rule: {
     confidence: "high",
     urls: [
-      "/axios(@|/)([\\d.]+)(?:/[a-z]+)?/axios(?:\\.min)?\\.js",
+      "/axios(?:@|/)([\\d.]+)(?:/[a-z]+)?/axios(?:\\.min)?\\.js",
     ],
     javascriptVariables: {
       "axios.get": "",

--- a/src/signatures/technologies/slick.test.ts
+++ b/src/signatures/technologies/slick.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { slickSignature } from "./slick.js";
+
+function createMockContext(
+  overrides: Partial<Pick<Context, "responses">> = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: {},
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("slickSignature", () => {
+  describe("URL matching", () => {
+    it("should detect Slick with version from path", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://cdn.example.com/libs/1.8.1/slick.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, slickSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "1.8.1")).toBe(true);
+    });
+
+    it("should detect Slick without version", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/js/slick.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, slickSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.[0]?.version).toBeUndefined();
+    });
+
+    it("should detect Slick from non-minified file", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/js/slick.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, slickSignature);
+      expect(result).toBeDefined();
+    });
+
+    it("should not detect Slick from plugin URLs", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://cdn.example.com/libs/some-plugin/1.0.0/slick-lightbox.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, slickSignature);
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/src/signatures/technologies/slick.ts
+++ b/src/signatures/technologies/slick.ts
@@ -7,7 +7,7 @@ export const slickSignature: Signature = {
     "Slick is a popular, fully responsive jQuery plugin used for creating versatile and customizable carousels and content sliders.",
   rule: {
     confidence: "high",
-    urls: ["(\\d+\\.\\d+\\.\\d+)?/slick[/.-]?"],
+    urls: ["(?:/(\\d+\\.\\d+\\.\\d+))?/slick(?:\\.min)?\\.js"],
     bodies: ["(\\d+\\.\\d+\\.\\d+)[\\s\\S]*?slick-theme\\.css"],
   },
   impliedSoftwares: [jquerySignature.name],


### PR DESCRIPTION
## Summary
- Slick: replace loose `[/.-]?` suffix with strict pattern that only matches `slick.js` and `slick.min.js`, preventing plugin filenames from being matched
- Axios: change `(@|/)` to non-capturing group `(?:@|/)` so that the version capture group is correctly returned as `match[1]`

## Test plan
- [x] Verify Slick URLs are correctly detected with version extraction
- [x] Verify Slick plugin URLs are not matched
- [x] Verify Axios version is correctly extracted from both `@` and `/` notation
- [x] Verify `@` or `/` is not captured as version
- [x] All existing tests pass (`npm test`)
