### PR TITLE
feat: add requiredJavascriptVariables to prevent false positives for Lodash and Underscore.js

### DIFF
--- a/src/analyzer/apply.test.ts
+++ b/src/analyzer/apply.test.ts
@@ -495,7 +495,7 @@ describe("applySignature", () => {
       expect(result).toBeUndefined();
     });
 
-    it("should keep URL evidences even when requiredJavascriptVariables are missing", () => {
+    it("should keep script evidences when non-script evidences exist even if requiredJavascriptVariables are missing", () => {
       const signature: Signature = {
         name: "Lodash",
         rule: {
@@ -522,8 +522,9 @@ describe("applySignature", () => {
       const result = applySignature(context, signature);
 
       expect(result).toBeDefined();
-      expect(result?.evidences).toHaveLength(1);
-      expect(result?.evidences?.[0]?.type).toBe("url");
+      expect(result?.evidences).toHaveLength(2);
+      expect(result?.evidences?.some((e) => e.type === "url")).toBe(true);
+      expect(result?.evidences?.some((e) => e.type === "script" && e.version === "4.17.21")).toBe(true);
     });
 
     it("should skip when JavaScript variable value does not match pattern", () => {

--- a/src/analyzer/apply.test.ts
+++ b/src/analyzer/apply.test.ts
@@ -447,6 +447,85 @@ describe("applySignature", () => {
       expect(result).toBeUndefined();
     });
 
+    it("should detect when all requiredJavascriptVariables are present", () => {
+      const signature: Signature = {
+        name: "Lodash",
+        rule: {
+          confidence: "high",
+          javascriptVariables: {
+            "_.VERSION": "(.+)",
+          },
+          requiredJavascriptVariables: ["_.differenceBy"],
+        },
+      };
+
+      const context = createMockContext({
+        javascriptVariables: {
+          "_.VERSION": "4.17.21",
+          "_.differenceBy": "function",
+        },
+      });
+
+      const result = applySignature(context, signature);
+
+      expect(result).toBeDefined();
+      expect(result?.name).toBe("Lodash");
+      expect(result?.evidences?.[0]?.version).toBe("4.17.21");
+    });
+
+    it("should discard script evidences when requiredJavascriptVariables are missing", () => {
+      const signature: Signature = {
+        name: "Lodash",
+        rule: {
+          confidence: "high",
+          javascriptVariables: {
+            "_.VERSION": "(.+)",
+          },
+          requiredJavascriptVariables: ["_.differenceBy"],
+        },
+      };
+
+      const context = createMockContext({
+        javascriptVariables: {
+          "_.VERSION": "4.17.21",
+        },
+      });
+
+      const result = applySignature(context, signature);
+      expect(result).toBeUndefined();
+    });
+
+    it("should keep URL evidences even when requiredJavascriptVariables are missing", () => {
+      const signature: Signature = {
+        name: "Lodash",
+        rule: {
+          confidence: "high",
+          urls: ["lodash.*\\.js"],
+          javascriptVariables: {
+            "_.VERSION": "(.+)",
+          },
+          requiredJavascriptVariables: ["_.differenceBy"],
+        },
+      };
+
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/lodash.min.js",
+          }),
+        ],
+        javascriptVariables: {
+          "_.VERSION": "4.17.21",
+        },
+      });
+
+      const result = applySignature(context, signature);
+
+      expect(result).toBeDefined();
+      expect(result?.evidences).toHaveLength(1);
+      expect(result?.evidences?.[0]?.type).toBe("url");
+    });
+
     it("should skip when JavaScript variable value does not match pattern", () => {
       const signature: Signature = {
         name: "CustomLib",

--- a/src/analyzer/apply.ts
+++ b/src/analyzer/apply.ts
@@ -65,7 +65,7 @@ export const applySignature = (
   context: Context,
   signature: Signature,
 ): Detection | undefined => {
-  const evidences: Evidence[] = [];
+  let evidences: Evidence[] = [];
   const rule = signature.rule;
   const runtime = resolveRuntime(signature);
   const allResponses = context.responses;
@@ -196,6 +196,16 @@ export const applySignature = (
         version: result.version,
         confidence: rule.confidence,
       });
+    }
+  }
+
+  if (rule?.requiredJavascriptVariables) {
+    const jsVars = context.javascriptVariables;
+    const allPresent = rule.requiredJavascriptVariables.every(
+      (name) => jsVars[name] !== undefined,
+    );
+    if (!allPresent) {
+      evidences = evidences.filter((e) => e.type !== "script");
     }
   }
 

--- a/src/analyzer/apply.ts
+++ b/src/analyzer/apply.ts
@@ -199,12 +199,15 @@ export const applySignature = (
     }
   }
 
+  // Discard script evidences when required JavaScript variables are missing,
+  // unless other evidence types (URL, header, etc.) already confirm the technology.
   if (rule?.requiredJavascriptVariables) {
     const jsVars = context.javascriptVariables;
     const allPresent = rule.requiredJavascriptVariables.every(
       (name) => jsVars[name] !== undefined,
     );
-    if (!allPresent) {
+    const hasNonScriptEvidence = evidences.some((e) => e.type !== "script");
+    if (!allPresent && !hasNonScriptEvidence) {
       evidences = evidences.filter((e) => e.type !== "script");
     }
   }

--- a/src/analyzer/apply.ts
+++ b/src/analyzer/apply.ts
@@ -199,8 +199,6 @@ export const applySignature = (
     }
   }
 
-  // Discard script evidences when required JavaScript variables are missing,
-  // unless other evidence types (URL, header, etc.) already confirm the technology.
   if (rule?.requiredJavascriptVariables) {
     const jsVars = context.javascriptVariables;
     const allPresent = rule.requiredJavascriptVariables.every(

--- a/src/signatures/_types.ts
+++ b/src/signatures/_types.ts
@@ -10,6 +10,8 @@ export type Rule = {
   urls?: Regex[];
   cookies?: Record<string, Regex>;
   javascriptVariables?: Record<string, Regex>;
+  // Variables that must all exist for script evidences to be kept.
+  // Skipped when non-script evidences already confirm the technology.
   requiredJavascriptVariables?: string[];
 };
 

--- a/src/signatures/_types.ts
+++ b/src/signatures/_types.ts
@@ -10,6 +10,7 @@ export type Rule = {
   urls?: Regex[];
   cookies?: Record<string, Regex>;
   javascriptVariables?: Record<string, Regex>;
+  requiredJavascriptVariables?: string[];
 };
 
 export type Signature = {

--- a/src/signatures/technologies/lodash.test.ts
+++ b/src/signatures/technologies/lodash.test.ts
@@ -88,6 +88,24 @@ describe("lodashSignature", () => {
       expect(result).toBeUndefined();
     });
 
+    it("should detect Lodash with version when URL matches and only _.VERSION is present", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/js/lodash.min.js",
+          }),
+        ],
+        javascriptVariables: {
+          "_.VERSION": "4.17.21",
+        },
+      });
+
+      const result = applySignature(context, lodashSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.type === "url")).toBe(true);
+      expect(result?.evidences?.some((e) => e.type === "script" && e.version === "4.17.21")).toBe(true);
+    });
+
     it("should detect Lodash from templateSettings path", () => {
       const context = createMockContext({
         javascriptVariables: {

--- a/src/signatures/technologies/lodash.test.ts
+++ b/src/signatures/technologies/lodash.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { lodashSignature } from "./lodash.js";
+
+function createMockContext(
+  overrides: Partial<
+    Pick<Context, "responses" | "javascriptVariables">
+  > = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: {},
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("lodashSignature", () => {
+  describe("URL matching", () => {
+    it("should detect Lodash from CDN URL", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://cdn.example.com/libs/lodash/4.17.21/lodash.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, lodashSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.[0]?.type).toBe("url");
+    });
+
+    it("should detect Lodash from filename", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/js/lodash.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, lodashSignature);
+      expect(result).toBeDefined();
+    });
+  });
+
+  describe("JavaScript variable matching", () => {
+    it("should detect Lodash when _.VERSION and _.differenceBy are present", () => {
+      const context = createMockContext({
+        javascriptVariables: {
+          "_.VERSION": "4.17.21",
+          "_.differenceBy": "function",
+        },
+      });
+
+      const result = applySignature(context, lodashSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "4.17.21")).toBe(true);
+    });
+
+    it("should not detect Lodash when only _.VERSION is present", () => {
+      const context = createMockContext({
+        javascriptVariables: {
+          "_.VERSION": "4.17.21",
+        },
+      });
+
+      const result = applySignature(context, lodashSignature);
+      expect(result).toBeUndefined();
+    });
+
+    it("should detect Lodash from templateSettings path", () => {
+      const context = createMockContext({
+        javascriptVariables: {
+          "_.templateSettings.imports._.templateSettings.imports._.VERSION":
+            "4.17.21",
+          "_.differenceBy": "function",
+        },
+      });
+
+      const result = applySignature(context, lodashSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "4.17.21")).toBe(true);
+    });
+  });
+});

--- a/src/signatures/technologies/lodash.ts
+++ b/src/signatures/technologies/lodash.ts
@@ -13,5 +13,6 @@ export const lodashSignature: Signature = {
       "_.differenceBy": "",
       "_.templateSettings.imports._.templateSettings.imports._.VERSION": "(.+)",
     },
+    requiredJavascriptVariables: ["_.differenceBy"],
   },
 };

--- a/src/signatures/technologies/underscore_js.test.ts
+++ b/src/signatures/technologies/underscore_js.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { underscoreJsSignature } from "./underscore_js.js";
+
+function createMockContext(
+  overrides: Partial<
+    Pick<Context, "responses" | "javascriptVariables">
+  > = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: {},
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("underscoreJsSignature", () => {
+  describe("URL matching", () => {
+    it("should detect Underscore.js from CDN URL", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://cdn.example.com/libs/underscore.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, underscoreJsSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.[0]?.type).toBe("url");
+    });
+
+    it("should detect Underscore.js with version from query parameter", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/js/underscore.min.js?ver=1.13.6",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, underscoreJsSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "1.13.6")).toBe(true);
+    });
+  });
+
+  describe("JavaScript variable matching", () => {
+    it("should detect Underscore.js when _.VERSION and _.restArguments are present", () => {
+      const context = createMockContext({
+        javascriptVariables: {
+          "_.VERSION": "1.13.6",
+          "_.restArguments": "function",
+        },
+      });
+
+      const result = applySignature(context, underscoreJsSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "1.13.6")).toBe(true);
+    });
+
+    it("should not detect Underscore.js when only _.VERSION is present", () => {
+      const context = createMockContext({
+        javascriptVariables: {
+          "_.VERSION": "1.13.6",
+        },
+      });
+
+      const result = applySignature(context, underscoreJsSignature);
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/src/signatures/technologies/underscore_js.test.ts
+++ b/src/signatures/technologies/underscore_js.test.ts
@@ -78,6 +78,24 @@ describe("underscoreJsSignature", () => {
       expect(result?.evidences?.some((e) => e.version === "1.13.6")).toBe(true);
     });
 
+    it("should detect Underscore.js with version when URL matches and only _.VERSION is present", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/js/underscore.min.js",
+          }),
+        ],
+        javascriptVariables: {
+          "_.VERSION": "1.13.6",
+        },
+      });
+
+      const result = applySignature(context, underscoreJsSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.type === "url")).toBe(true);
+      expect(result?.evidences?.some((e) => e.type === "script" && e.version === "1.13.6")).toBe(true);
+    });
+
     it("should not detect Underscore.js when only _.VERSION is present", () => {
       const context = createMockContext({
         javascriptVariables: {

--- a/src/signatures/technologies/underscore_js.ts
+++ b/src/signatures/technologies/underscore_js.ts
@@ -4,6 +4,7 @@ export const underscoreJsSignature: Signature = {
   name: "Underscore.js",
   description:
     "Underscore.js is a JavaScript library which provides utility functions for common programming tasks. It is comparable to features provided by Prototype.js and the Ruby language, but opts for a functional programming design instead of extending object prototypes.",
+  cpe: "cpe:/a:underscorejs:underscore",
   rule: {
     confidence: "high",
     urls: ["underscore.*\\.js(?:\\?ver=([\\d.]+))?"],

--- a/src/signatures/technologies/underscore_js.ts
+++ b/src/signatures/technologies/underscore_js.ts
@@ -11,5 +11,6 @@ export const underscoreJsSignature: Signature = {
       "_.VERSION": "^(.+)$",
       "_.restArguments": "",
     },
+    requiredJavascriptVariables: ["_.restArguments"],
   },
 };


### PR DESCRIPTION
## Summary
- Add `requiredJavascriptVariables` field to the `Rule` type, which acts as a gate that discards script evidences unless all specified variables exist in the browser context
- When non-script evidences (URL, header, etc.) already confirm the technology, skip the gate so script evidences (e.g. version from `_.VERSION`) are preserved
- Apply to Lodash (`_.differenceBy`) and Underscore.js (`_.restArguments`) signatures to prevent false detection when only `_.VERSION` is present, since both libraries share the `_` namespace
- Add CPE to Underscore.js signature

## Test plan
- [x] Run `npm run test` and verify all tests pass
- [x] Run `whopper detect` against a page using Lodash and confirm detection with version
- [x] Run `whopper detect` against a page using Underscore.js and confirm detection with version
- [x] Verify that a page with only `_.VERSION` does not falsely detect Lodash or Underscore.js