### PR TITLE
fix: replace networkidle with custom idle tracking for dynamic resources

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ export const exampleSignature: Signature = {
 - Version extraction regex: `(\\d+\\.\\d+\\.\\d+)`
 - Formatting: Prettier is the source of truth; run `npm run format` before PRs
 - Linting: ESLint with `@eslint/js` + `typescript-eslint` recommendations
+- Code comments (including inline comments, JSDoc, and TODO/FIXME) must be written in English, regardless of any global preference for Japanese. This project's source code is English-only; only chat with the user in Japanese.
 
 ## Testing
 

--- a/src/browser/index.test.ts
+++ b/src/browser/index.test.ts
@@ -156,7 +156,7 @@ describe("openPage", () => {
       await openPage("https://example.com", 10000, []);
 
       expect(mockPage.goto).toHaveBeenCalledWith("https://example.com", {
-        waitUntil: "networkidle",
+        waitUntil: "load",
       });
     });
 

--- a/src/browser/index.test.ts
+++ b/src/browser/index.test.ts
@@ -1267,6 +1267,157 @@ describe("openPage", () => {
     });
   });
 
+  describe("network idle tracking", () => {
+    it("should register request, requestfinished, and requestfailed listeners", async () => {
+      await openPage("https://example.com", 10000, []);
+
+      const registeredEvents = mockPage.on.mock.calls.map(
+        (call: unknown[]) => call[0],
+      );
+      expect(registeredEvents).toContain("request");
+      expect(registeredEvents).toContain("requestfinished");
+      expect(registeredEvents).toContain("requestfailed");
+      expect(registeredEvents).toContain("response");
+    });
+
+    it("should set timeoutOccurred when idle wait exhausts timeout budget", async () => {
+      mockPage.goto.mockResolvedValue(undefined);
+      // Use setTimeout(0) so sleep resolves via a macrotask (ensuring
+      // goto's microtask chain wins the race with "loaded"), while still
+      // being fast enough for the idle loop to spin through quickly.
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 0)),
+      );
+
+      // Very short timeout: the idle loop will exhaust the budget before
+      // the NETWORK_IDLE_THRESHOLD_MS (2000ms) quiet period is reached.
+      const result = await openPage("https://example.com", 10, []);
+
+      expect(result.timeoutOccurred).toBe(true);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("waiting for network idle after load"),
+      );
+    });
+
+    it("should wait for in-flight requests before declaring idle", async () => {
+      const listeners: Record<string, (...args: unknown[]) => void> = {};
+      mockPage.on.mockImplementation(
+        (event: string, callback: (...args: unknown[]) => void) => {
+          listeners[event] = callback;
+        },
+      );
+
+      // During goto, fire a request event but NOT requestfinished,
+      // so the request stays in-flight.
+      mockPage.goto.mockImplementation(async () => {
+        listeners["request"]?.();
+      });
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 0)),
+      );
+
+      // With an in-flight request (count=1), the idle condition
+      // (inFlightRequestCount === 0) is never met, so the loop can
+      // only exit via timeout budget exhaustion.
+      const result = await openPage("https://example.com", 10, []);
+
+      expect(result.timeoutOccurred).toBe(true);
+    });
+
+    it("should exit idle loop after requestfinished fires", async () => {
+      const listeners: Record<string, (...args: unknown[]) => void> = {};
+      mockPage.on.mockImplementation(
+        (event: string, callback: (...args: unknown[]) => void) => {
+          listeners[event] = callback;
+        },
+      );
+
+      mockPage.goto.mockImplementation(async () => {
+        listeners["request"]?.();
+        listeners["requestfinished"]?.();
+      });
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      const result = await openPage("https://example.com", 10000, []);
+
+      expect(result.timeoutOccurred).toBe(false);
+      expect(logger.info).toHaveBeenCalledWith("Page loaded successfully");
+    });
+
+    it("should exit idle loop after requestfailed fires", async () => {
+      const listeners: Record<string, (...args: unknown[]) => void> = {};
+      mockPage.on.mockImplementation(
+        (event: string, callback: (...args: unknown[]) => void) => {
+          listeners[event] = callback;
+        },
+      );
+
+      mockPage.goto.mockImplementation(async () => {
+        listeners["request"]?.();
+        listeners["requestfailed"]?.();
+      });
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+
+      const result = await openPage("https://example.com", 10000, []);
+
+      expect(result.timeoutOccurred).toBe(false);
+      expect(logger.info).toHaveBeenCalledWith("Page loaded successfully");
+    });
+
+    it("should await pending response handlers after idle loop exits", async () => {
+      const listeners: Record<string, (...args: unknown[]) => void> = {};
+      mockPage.on.mockImplementation(
+        (event: string, callback: (...args: unknown[]) => void) => {
+          listeners[event] = callback;
+        },
+      );
+
+      let resolveText!: (value: string) => void;
+      const textPromise = new Promise<string>((resolve) => {
+        resolveText = resolve;
+      });
+
+      // During goto, fire a response whose text() is intentionally slow.
+      mockPage.goto.mockImplementation(async () => {
+        listeners["response"]?.({
+          url: () => "https://example.com/slow.js",
+          status: () => 200,
+          headers: () => ({}),
+          text: () => textPromise,
+          request: () => ({
+            isNavigationRequest: () => false,
+            frame: () => null,
+          }),
+        });
+      });
+      vi.mocked(sleep).mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 0)),
+      );
+
+      // Short timeout: the idle loop exits via budget exhaustion while
+      // the response handler is still awaiting text().
+      const openPagePromise = openPage("https://example.com", 10, []);
+
+      // Resolve text() after the idle loop has exited but before
+      // Promise.allSettled gives up.
+      setTimeout(() => resolveText("slow content"), 50);
+
+      const result = await openPagePromise;
+
+      // The response should be captured because Promise.allSettled
+      // waited for the pending handler to finish.
+      const slowResponse = result.responses.find(
+        (r) => r.url === "https://example.com/slow.js",
+      );
+      expect(slowResponse).toBeDefined();
+      expect(slowResponse!.body).toBe("slow content");
+    });
+  });
+
   describe("error handling", () => {
     it("should log error when page load fails", async () => {
       mockPage.goto.mockRejectedValue(new Error("Connection refused"));

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -306,11 +306,19 @@ export async function openPage(
   // in-flight を条件に含めることで、「リクエスト発行後にレスポンスが
   // `NETWORK_IDLE_THRESHOLD_MS` 以上遅延する」ケースで途中で抜けてレスポンス
   // を取りこぼすことを防ぐ。
+  // idle ループが「アイドル成立」で抜けたか「タイムアウト予算を使い切って」
+  // 抜けたかを区別するためのフラグ。後者の場合は呼び出し元に
+  // `timeoutOccurred: true` を返す必要がある（呼び出し元は完全キャプチャと
+  // 途中終了を区別して扱うため）。
+  let idleWaitTimedOut = false;
   if (result === "loaded") {
     while (true) {
       const now = Date.now();
       const elapsed = now - navigationStartedAt;
-      if (elapsed >= timeoutMs) break;
+      if (elapsed >= timeoutMs) {
+        idleWaitTimedOut = true;
+        break;
+      }
       const idleFor = now - lastNetworkActivityAt;
       if (inFlightRequestCount === 0 && idleFor >= NETWORK_IDLE_THRESHOLD_MS) {
         break;
@@ -327,7 +335,14 @@ export async function openPage(
 
   logger.info(`${responses.length} responses captured`);
   if (result === "loaded") {
-    logger.info("Page loaded successfully");
+    if (idleWaitTimedOut) {
+      timeoutOccurred = true;
+      logger.warn(
+        `Timeout of ${timeoutMs}ms exceeded while waiting for network idle after load on ${url}`,
+      );
+    } else {
+      logger.info("Page loaded successfully");
+    }
   } else if (result === "timeout") {
     timeoutOccurred = true;
     logger.warn(`Timeout of ${timeoutMs}ms exceeded while loading ${url}`);

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -11,13 +11,14 @@ import {
 } from "./utils.js";
 
 const MAX_REDIRECT_HOPS = 20;
-// ネットワークアイドル判定に用いる静穏期間（ms）。
-// Playwright 組み込みの `networkidle` は 500ms 固定で短すぎ、
-// スクリプト経由で後から発火する二次リクエスト（例: eir_common.js が
-// 読み込む bootstrap_for_eir.css など）の前に成立してしまい検出漏れが
-// 発生するため、より長い閾値で自前判定する。
+// Quiet period (ms) used for the custom network-idle decision.
+// Playwright's built-in `networkidle` has a fixed 500ms threshold, which
+// is too short: it fires before script-driven secondary requests (e.g. a
+// CSS file loaded from within an async script) have a chance to start,
+// causing technology-detection evidence to be dropped. We use a longer
+// threshold evaluated by our own tracking.
 const NETWORK_IDLE_THRESHOLD_MS = 2000;
-// アイドル判定ループのポーリング間隔（ms）。
+// Polling interval (ms) for the idle-decision loop.
 const NETWORK_IDLE_POLL_INTERVAL_MS = 200;
 
 function colorizeStatusCode(statusCode: number): string {
@@ -217,16 +218,18 @@ export async function openPage(
 
   const urls: UrlEntry[] = [];
   const responses: Response[] = [];
-  // 最後にネットワーク活動（リクエスト送信／レスポンス受信）が観測された時刻。
-  // 後続の自前アイドル判定で利用する。
+  // Timestamp of the most recent network activity (request sent or
+  // response received). Used by the custom idle-decision loop below.
   let lastNetworkActivityAt = Date.now();
-  // 現在未完了のリクエスト数。レスポンス本体が返ってくるまで待つため、
-  // リクエスト発行後にレスポンスが遅延しても途中で idle と判定しないよう
-  // in-flight なリクエスト数も idle 条件に含める。
+  // Number of requests currently in flight. We include this in the idle
+  // condition so that a request whose response takes longer than the
+  // quiet-period threshold cannot cause the loop to exit before the
+  // response is captured.
   let inFlightRequestCount = 0;
-  // レスポンスハンドラの非同期処理（特に response.text()）をループ終了後に
-  // 待ち合わせるための Promise 集合。ハンドラが本文取得中にループを抜ける
-  // レースを防ぐ。
+  // Pending response-handler promises. The response handler awaits
+  // `response.text()`, which can still be in progress when the idle loop
+  // decides to break; awaiting this set after the loop prevents those
+  // in-progress body reads from being dropped.
   const pendingResponseWork = new Set<Promise<void>>();
 
   page.on("request", () => {
@@ -290,9 +293,10 @@ export async function openPage(
 
   let timeoutOccurred = false;
   const navigationStartedAt = Date.now();
-  // `networkidle` は 500ms 固定でフレーキーなため、ここでは `load` まで
-  // （onload 発火まで）で goto を解決し、その後に自前のアイドル判定で
-  // 遅延スクリプトが発火させる二次リクエストを待機する。
+  // Playwright's built-in `networkidle` is flaky (500ms fixed threshold),
+  // so resolve goto at the `load` event (onload fired) and wait for
+  // secondary requests triggered by deferred scripts using our own
+  // idle-decision loop below.
   const goto = page.goto(url, { waitUntil: "load" });
 
   const result = await Promise.race([
@@ -300,16 +304,17 @@ export async function openPage(
     sleep(timeoutMs).then(() => "timeout"),
   ]);
 
-  // onload 後に発火する遅延スクリプトの二次リクエストを取りこぼさないよう、
-  // 全 in-flight リクエストが完了し、かつ一定時間ネットワーク活動が途絶える
-  // （もしくは全体タイムアウトに達する）まで待機する。
-  // in-flight を条件に含めることで、「リクエスト発行後にレスポンスが
-  // `NETWORK_IDLE_THRESHOLD_MS` 以上遅延する」ケースで途中で抜けてレスポンス
-  // を取りこぼすことを防ぐ。
-  // idle ループが「アイドル成立」で抜けたか「タイムアウト予算を使い切って」
-  // 抜けたかを区別するためのフラグ。後者の場合は呼び出し元に
-  // `timeoutOccurred: true` を返す必要がある（呼び出し元は完全キャプチャと
-  // 途中終了を区別して扱うため）。
+  // After onload, wait until all in-flight requests have finished and a
+  // quiet period of `NETWORK_IDLE_THRESHOLD_MS` has elapsed (or the
+  // overall timeout is reached) so that secondary requests triggered by
+  // deferred scripts are captured. Including in-flight count in the
+  // condition prevents the loop from exiting while a slow response
+  // (> NETWORK_IDLE_THRESHOLD_MS) is still pending.
+  //
+  // Tracks whether the loop exited because the network actually went
+  // idle, or because the overall timeout budget was exhausted. In the
+  // latter case we must return `timeoutOccurred: true` so callers can
+  // distinguish a full capture from a partial one.
   let idleWaitTimedOut = false;
   if (result === "loaded") {
     while (true) {
@@ -326,8 +331,9 @@ export async function openPage(
       const remainingBudget = timeoutMs - elapsed;
       await sleep(Math.min(NETWORK_IDLE_POLL_INTERVAL_MS, remainingBudget));
     }
-    // ループ終了時点でまだ走っているレスポンスハンドラ（response.text() の
-    // 待機中など）が残っていれば、取りこぼしを防ぐために完了を待つ。
+    // If any response handlers are still running at loop exit (e.g.
+    // waiting on `response.text()`), wait for them to finish so their
+    // captures are not dropped.
     if (pendingResponseWork.size > 0) {
       await Promise.allSettled(Array.from(pendingResponseWork));
     }

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -11,6 +11,14 @@ import {
 } from "./utils.js";
 
 const MAX_REDIRECT_HOPS = 20;
+// ネットワークアイドル判定に用いる静穏期間（ms）。
+// Playwright 組み込みの `networkidle` は 500ms 固定で短すぎ、
+// スクリプト経由で後から発火する二次リクエスト（例: eir_common.js が
+// 読み込む bootstrap_for_eir.css など）の前に成立してしまい検出漏れが
+// 発生するため、より長い閾値で自前判定する。
+const NETWORK_IDLE_THRESHOLD_MS = 2000;
+// アイドル判定ループのポーリング間隔（ms）。
+const NETWORK_IDLE_POLL_INTERVAL_MS = 200;
 
 function colorizeStatusCode(statusCode: number): string {
   const code = String(statusCode);
@@ -209,7 +217,14 @@ export async function openPage(
 
   const urls: UrlEntry[] = [];
   const responses: Response[] = [];
+  // 最後にネットワーク活動（リクエスト送信／レスポンス受信）が観測された時刻。
+  // 後続の自前アイドル判定で利用する。
+  let lastNetworkActivityAt = Date.now();
+  page.on("request", () => {
+    lastNetworkActivityAt = Date.now();
+  });
   page.on("response", async (response) => {
+    lastNetworkActivityAt = Date.now();
     const responseUrl = response.url();
     const statusCode = response.status();
 
@@ -250,13 +265,36 @@ export async function openPage(
   });
 
   let timeoutOccurred = false;
-  const goto = page.goto(url, { waitUntil: "networkidle" });
+  const navigationStartedAt = Date.now();
+  // `networkidle` は 500ms 固定でフレーキーなため、ここでは `load` まで
+  // （onload 発火まで）で goto を解決し、その後に自前のアイドル判定で
+  // 遅延スクリプトが発火させる二次リクエストを待機する。
+  const goto = page.goto(url, { waitUntil: "load" });
 
   const result = await Promise.race([
     goto.then(() => "loaded").catch((e) => e.message),
     sleep(timeoutMs).then(() => "timeout"),
   ]);
 
+  // onload 後に発火する遅延スクリプトの二次リクエストを取りこぼさないよう、
+  // 一定時間ネットワーク活動が途絶えるか、全体タイムアウトに達するまで待機する。
+  if (result === "loaded") {
+    while (true) {
+      const now = Date.now();
+      const idleFor = now - lastNetworkActivityAt;
+      const elapsed = now - navigationStartedAt;
+      if (idleFor >= NETWORK_IDLE_THRESHOLD_MS) break;
+      if (elapsed >= timeoutMs) break;
+      const waitMs = Math.min(
+        NETWORK_IDLE_THRESHOLD_MS - idleFor,
+        timeoutMs - elapsed,
+        NETWORK_IDLE_POLL_INTERVAL_MS,
+      );
+      await sleep(waitMs);
+    }
+  }
+
+  logger.info(`${responses.length} responses captured`);
   if (result === "loaded") {
     logger.info("Page loaded successfully");
   } else if (result === "timeout") {

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -220,48 +220,72 @@ export async function openPage(
   // 最後にネットワーク活動（リクエスト送信／レスポンス受信）が観測された時刻。
   // 後続の自前アイドル判定で利用する。
   let lastNetworkActivityAt = Date.now();
+  // 現在未完了のリクエスト数。レスポンス本体が返ってくるまで待つため、
+  // リクエスト発行後にレスポンスが遅延しても途中で idle と判定しないよう
+  // in-flight なリクエスト数も idle 条件に含める。
+  let inFlightRequestCount = 0;
+  // レスポンスハンドラの非同期処理（特に response.text()）をループ終了後に
+  // 待ち合わせるための Promise 集合。ハンドラが本文取得中にループを抜ける
+  // レースを防ぐ。
+  const pendingResponseWork = new Set<Promise<void>>();
+
   page.on("request", () => {
+    inFlightRequestCount++;
     lastNetworkActivityAt = Date.now();
   });
-  page.on("response", async (response) => {
+  page.on("requestfinished", () => {
+    inFlightRequestCount = Math.max(0, inFlightRequestCount - 1);
     lastNetworkActivityAt = Date.now();
-    const responseUrl = response.url();
-    const statusCode = response.status();
+  });
+  page.on("requestfailed", () => {
+    inFlightRequestCount = Math.max(0, inFlightRequestCount - 1);
+    lastNetworkActivityAt = Date.now();
+  });
+  page.on("response", (response) => {
+    lastNetworkActivityAt = Date.now();
+    const work = (async () => {
+      const responseUrl = response.url();
+      const statusCode = response.status();
 
-    // Skip responses already captured by the pre-inspection loop to
-    // avoid duplicates.
-    if (preInspectedUrls.has(responseUrl) && statusCode >= 300 && statusCode < 400) {
+      // Skip responses already captured by the pre-inspection loop to
+      // avoid duplicates.
+      if (preInspectedUrls.has(responseUrl) && statusCode >= 300 && statusCode < 400) {
+        logger.debug(
+          `Skipping already captured response [${colorizeStatusCode(statusCode)}] ${responseUrl}`,
+        );
+        return;
+      }
+
+      const responseHost = getHostFromUrl(responseUrl) ?? "";
       logger.debug(
-        `Skipping already captured response [${colorizeStatusCode(statusCode)}] ${responseUrl}`,
+        `Received response [${colorizeStatusCode(statusCode)}] ${responseUrl}`,
       );
-      return;
-    }
+      const request = response.request();
+      if (request.isNavigationRequest() && request.frame() === page.mainFrame()) {
+        urls.push({ url: responseUrl, status: statusCode });
+      }
 
-    const responseHost = getHostFromUrl(responseUrl) ?? "";
-    logger.debug(
-      `Received response [${colorizeStatusCode(statusCode)}] ${responseUrl}`,
-    );
-    const request = response.request();
-    if (request.isNavigationRequest() && request.frame() === page.mainFrame()) {
-      urls.push({ url: responseUrl, status: statusCode });
-    }
+      const res: Response = {
+        url: responseUrl,
+        host: responseHost,
+        isFirstParty: responseHost
+          ? isFirstPartyHost(pageHost, responseHost)
+          : false,
+        status: statusCode,
+        headers: response.headers(),
+      };
 
-    const res: Response = {
-      url: responseUrl,
-      host: responseHost,
-      isFirstParty: responseHost
-        ? isFirstPartyHost(pageHost, responseHost)
-        : false,
-      status: statusCode,
-      headers: response.headers(),
-    };
+      const body = await response.text().catch(() => null);
+      if (body) {
+        res.body = body;
+      }
 
-    const body = await response.text().catch(() => null);
-    if (body) {
-      res.body = body;
-    }
-
-    responses.push(res);
+      responses.push(res);
+    })();
+    pendingResponseWork.add(work);
+    work.finally(() => {
+      pendingResponseWork.delete(work);
+    });
   });
 
   let timeoutOccurred = false;
@@ -277,20 +301,27 @@ export async function openPage(
   ]);
 
   // onload 後に発火する遅延スクリプトの二次リクエストを取りこぼさないよう、
-  // 一定時間ネットワーク活動が途絶えるか、全体タイムアウトに達するまで待機する。
+  // 全 in-flight リクエストが完了し、かつ一定時間ネットワーク活動が途絶える
+  // （もしくは全体タイムアウトに達する）まで待機する。
+  // in-flight を条件に含めることで、「リクエスト発行後にレスポンスが
+  // `NETWORK_IDLE_THRESHOLD_MS` 以上遅延する」ケースで途中で抜けてレスポンス
+  // を取りこぼすことを防ぐ。
   if (result === "loaded") {
     while (true) {
       const now = Date.now();
-      const idleFor = now - lastNetworkActivityAt;
       const elapsed = now - navigationStartedAt;
-      if (idleFor >= NETWORK_IDLE_THRESHOLD_MS) break;
       if (elapsed >= timeoutMs) break;
-      const waitMs = Math.min(
-        NETWORK_IDLE_THRESHOLD_MS - idleFor,
-        timeoutMs - elapsed,
-        NETWORK_IDLE_POLL_INTERVAL_MS,
-      );
-      await sleep(waitMs);
+      const idleFor = now - lastNetworkActivityAt;
+      if (inFlightRequestCount === 0 && idleFor >= NETWORK_IDLE_THRESHOLD_MS) {
+        break;
+      }
+      const remainingBudget = timeoutMs - elapsed;
+      await sleep(Math.min(NETWORK_IDLE_POLL_INTERVAL_MS, remainingBudget));
+    }
+    // ループ終了時点でまだ走っているレスポンスハンドラ（response.text() の
+    // 待機中など）が残っていれば、取りこぼしを防ぐために完了を待つ。
+    if (pendingResponseWork.size > 0) {
+      await Promise.allSettled(Array.from(pendingResponseWork));
     }
   }
 


### PR DESCRIPTION
## Summary

- Replace Playwright's built-in `waitUntil: "networkidle"` (fixed 500ms quiet period) with `waitUntil: "load"` followed by custom idle detection (2-second quiet period), so that secondary requests fired by deferred scripts after the onload event are no longer missed.
- Root cause: when a page loads CSS/JS dynamically from within a script, the gap between the script response and its subsequent triggered request can exceed 500ms. In that case, `networkidle` fires early and all remaining dynamic requests are dropped, leading to flaky technology detection that depends on script-execution timing jitter.
- Implementation: track the timestamp of the most recent network activity via `page.on("request")` and `page.on("response")`, then wait until `NETWORK_IDLE_THRESHOLD_MS = 2000` of quiet has elapsed (or the overall `timeoutMs` budget is reached) before considering the page loaded.

## Behavior change

- Before: `page.goto(url, { waitUntil: "networkidle" })` — flaky on pages with deferred dynamic loading.
- After: `page.goto(url, { waitUntil: "load" })` + custom 2s idle loop bounded by `timeoutMs`.

A minimum of ~2 seconds is now spent waiting after onload, in exchange for stable capture of late-firing requests. This is well within existing timeout budgets.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (existing test expecting `waitUntil: "networkidle"` updated to `"load"`)
- [x] Verified stable detection on a real-world page that previously exhibited flaky results due to script-driven CSS loading
- [ ] Sanity-check on simple static pages to confirm no regression in the common case

🤖 Generated with [Claude Code](https://claude.com/claude-code)