### PR TITLE
feat: add --idle-timeout option and replace networkidle with custom idle tracking

### DIFF
--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -54,6 +54,7 @@ export async function openPage(
     locale,
     extraHTTPHeaders,
     blockCrossDomainRedirect = false,
+    networkIdleThresholdMs = NETWORK_IDLE_THRESHOLD_MS,
   } = options;
 
   const pageHost = getHostFromUrl(url);
@@ -305,11 +306,11 @@ export async function openPage(
   ]);
 
   // After onload, wait until all in-flight requests have finished and a
-  // quiet period of `NETWORK_IDLE_THRESHOLD_MS` has elapsed (or the
-  // overall timeout is reached) so that secondary requests triggered by
-  // deferred scripts are captured. Including in-flight count in the
-  // condition prevents the loop from exiting while a slow response
-  // (> NETWORK_IDLE_THRESHOLD_MS) is still pending.
+  // quiet period of `networkIdleThresholdMs` has elapsed (or the overall
+  // timeout is reached) so that secondary requests triggered by deferred
+  // scripts are captured. Including in-flight count in the condition
+  // prevents the loop from exiting while a slow response
+  // (> networkIdleThresholdMs) is still pending.
   //
   // Tracks whether the loop exited because the network actually went
   // idle, or because the overall timeout budget was exhausted. In the
@@ -325,7 +326,7 @@ export async function openPage(
         break;
       }
       const idleFor = now - lastNetworkActivityAt;
-      if (inFlightRequestCount === 0 && idleFor >= NETWORK_IDLE_THRESHOLD_MS) {
+      if (inFlightRequestCount === 0 && idleFor >= networkIdleThresholdMs) {
         break;
       }
       const remainingBudget = timeoutMs - elapsed;

--- a/src/browser/types.ts
+++ b/src/browser/types.ts
@@ -34,6 +34,7 @@ export type OpenPageOptions = {
   locale?: string | undefined;
   extraHTTPHeaders?: Record<string, string> | undefined;
   blockCrossDomainRedirect?: boolean | undefined;
+  networkIdleThresholdMs?: number | undefined;
 };
 
 export type Context = {

--- a/src/commands/detect.test.ts
+++ b/src/commands/detect.test.ts
@@ -141,6 +141,14 @@ describe("detectCommand", () => {
       expect(blockOpt).toBeDefined();
       expect(blockOpt?.defaultValue).toBe(false);
     });
+
+    it("should have idle-timeout option with default 2000", () => {
+      const command = detectCommand();
+      const options = command.options;
+      const idleOpt = options.find((o) => o.long === "--idle-timeout");
+      expect(idleOpt).toBeDefined();
+      expect(idleOpt?.defaultValue).toBe(2000);
+    });
   });
 
   describe("action execution", () => {
@@ -156,6 +164,7 @@ describe("detectCommand", () => {
           locale: undefined,
           extraHTTPHeaders: undefined,
           blockCrossDomainRedirect: false,
+          networkIdleThresholdMs: 2000,
         },
       );
     });
@@ -190,6 +199,17 @@ describe("detectCommand", () => {
         10000,
         expect.any(Array),
         expect.objectContaining({ blockCrossDomainRedirect: true }),
+      );
+    });
+
+    it("should pass custom idle-timeout when provided", async () => {
+      await runCommand(["--idle-timeout", "500"]);
+
+      expect(openPage).toHaveBeenCalledWith(
+        "https://example.com",
+        10000,
+        expect.any(Array),
+        expect.objectContaining({ networkIdleThresholdMs: 500 }),
       );
     });
 

--- a/src/commands/detect.ts
+++ b/src/commands/detect.ts
@@ -40,6 +40,12 @@ export const detectCommand = (): Command => {
       "Block redirects to a different host",
       false,
     )
+    .option(
+      "--idle-timeout <ms>",
+      "Network idle threshold in milliseconds (default: 2000)",
+      (v: string) => Number(v),
+      2000,
+    )
     .action(
       async (
         url: string,
@@ -52,6 +58,7 @@ export const detectCommand = (): Command => {
           locale?: string;
           header: string[];
           blockCrossDomainRedirect: boolean;
+          idleTimeout: number;
         },
       ) => {
         if (options.debug) {
@@ -92,6 +99,7 @@ export const detectCommand = (): Command => {
                 ? extraHTTPHeaders
                 : undefined,
               blockCrossDomainRedirect: options.blockCrossDomainRedirect,
+              networkIdleThresholdMs: options.idleTimeout,
             },
           );
           const detections = analyze(context, signatures);


### PR DESCRIPTION
## Summary

- Replace Playwright's built-in `waitUntil: "networkidle"` (fixed 500ms quiet period) with `waitUntil: "load"` followed by a custom idle-decision loop that uses a configurable quiet-period threshold (default: 2000ms). This fixes flaky technology detection caused by deferred scripts that fire secondary requests after the onload event.
- Add a new `--idle-timeout <ms>` CLI option to the detect command, allowing users to tune the network idle threshold per invocation.
- Track in-flight requests via `request` / `requestfinished` / `requestfailed` events so the idle loop does not exit while responses are still pending — matching the drain semantics of Playwright's built-in `networkidle`.
- Await pending response-handler promises (`response.text()` reads) after the idle loop exits, preventing evidence from being dropped.
- Surface `timeoutOccurred: true` when the idle wait exhausts the overall timeout budget, so callers can distinguish a full capture from a partial one.

## Changes by file

| File | Change |
|---|---|
| `src/browser/index.ts` | Replace `networkidle` with `load` + custom idle loop; track in-flight requests and pending response handlers |
| `src/browser/types.ts` | Add `networkIdleThresholdMs` to `OpenPageOptions` |
| `src/commands/detect.ts` | Add `--idle-timeout <ms>` option (default 2000), pass through to `openPage` |
| `src/browser/index.test.ts` | Add 6 tests for idle tracking, in-flight requests, pending handlers, and timeout budget exhaustion |
| `src/commands/detect.test.ts` | Add tests for the new option and update existing assertions |
| `AGENTS.md` | Codify that source-code comments must be in English |

## Usage

```bash
# Default idle threshold (2000ms)
whopper detect <url>

# Custom idle threshold
whopper detect --idle-timeout 500 <url>
whopper detect --idle-timeout 5000 <url>
```

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — all tests pass (52 browser tests, detect command tests at 100% coverage)
- [x] Verified stable detection on a real-world page that previously exhibited flaky results
- [ ] Sanity-check with `--idle-timeout` set to a very low value (e.g. 100) to confirm it shortens the wait

🤖 Generated with [Claude Code](https://claude.com/claude-code)