### PR TITLE
feat: add active scan for Magento version detection

### DIFF
--- a/src/analyzer/apply.ts
+++ b/src/analyzer/apply.ts
@@ -1,7 +1,7 @@
 import type { Context, Response } from "../browser/types.js";
 import type { Runtime, Signature } from "../signatures/_types.js";
 import type { Detection, Evidence } from "./types.js";
-import { matchString } from "./match.js";
+import { matchString, truncateBodyForEvidence } from "./match.js";
 
 function isFirstPartyResponse(response: Response): boolean {
   return response.isFirstParty ?? true;
@@ -142,7 +142,7 @@ export const applySignature = (
 
         evidences.push({
           type: "body",
-          value: `${body.substring(0, 100)}...`,
+          value: truncateBodyForEvidence(body),
           version: result.version,
           confidence: rule.confidence,
           host: response.host,

--- a/src/analyzer/match.ts
+++ b/src/analyzer/match.ts
@@ -14,3 +14,6 @@ export const matchString = (value: string, regex: Regex): MatchResult => {
 
   return { hit: false, version: undefined };
 };
+
+export const truncateBodyForEvidence = (body: string): string =>
+  `${body.substring(0, 100)}...`;

--- a/src/browser/active_scan.test.ts
+++ b/src/browser/active_scan.test.ts
@@ -187,6 +187,101 @@ describe("fetchActiveRule", () => {
     expect(res).toBeNull();
   });
 
+  it("follows a same-host redirect and returns the final response", async () => {
+    const calls: string[] = [];
+    const request = mockRequest((url) => {
+      calls.push(url);
+      if (url === "https://example.com/magento_version") {
+        return {
+          status: () => 302,
+          text: async () => "",
+          headers: () => ({ location: "/en/magento_version" }),
+        };
+      }
+      return {
+        status: () => 200,
+        text: async () => "Magento/2.4.6",
+        headers: () => ({}),
+      };
+    });
+
+    const res = await fetchActiveRule(
+      "https://example.com/",
+      "/magento_version",
+      request,
+      5000,
+    );
+
+    expect(calls).toEqual([
+      "https://example.com/magento_version",
+      "https://example.com/en/magento_version",
+    ]);
+    expect(res?.url).toBe("https://example.com/en/magento_version");
+    expect(res?.status).toBe(200);
+    expect(res?.body).toBe("Magento/2.4.6");
+  });
+
+  it("blocks redirects to a sibling subdomain even if same registrable domain", async () => {
+    const request = mockRequest((url) => {
+      if (url === "https://app.example.com/magento_version") {
+        return {
+          status: () => 302,
+          text: async () => "",
+          headers: () => ({ location: "https://cdn.example.com/magento_version" }),
+        };
+      }
+      throw new Error("should not follow cross-host redirect");
+    });
+
+    const res = await fetchActiveRule(
+      "https://app.example.com/",
+      "/magento_version",
+      request,
+      5000,
+    );
+
+    expect(res).toBeNull();
+  });
+
+  it("blocks redirects to a third-party host", async () => {
+    const request = mockRequest((url) => {
+      if (url === "https://example.com/magento_version") {
+        return {
+          status: () => 302,
+          text: async () => "",
+          headers: () => ({ location: "https://evil.example/magento_version" }),
+        };
+      }
+      throw new Error("should not follow cross-host redirect");
+    });
+
+    const res = await fetchActiveRule(
+      "https://example.com/",
+      "/magento_version",
+      request,
+      5000,
+    );
+
+    expect(res).toBeNull();
+  });
+
+  it("stops after exceeding the redirect hop limit", async () => {
+    const request = mockRequest(() => ({
+      status: () => 302,
+      text: async () => "",
+      headers: () => ({ location: "/loop" }),
+    }));
+
+    const res = await fetchActiveRule(
+      "https://example.com/",
+      "/magento_version",
+      request,
+      5000,
+    );
+
+    expect(res).toBeNull();
+  });
+
   it("returns response even on non-200 status (caller decides)", async () => {
     const request = mockRequest(() => ({
       status: () => 404,

--- a/src/browser/active_scan.test.ts
+++ b/src/browser/active_scan.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { APIRequestContext } from "playwright";
+import { fetchActiveRule } from "./active_scan.js";
+
+type MockResponse = {
+  status: () => number;
+  text: () => Promise<string>;
+  headers: () => Record<string, string>;
+};
+
+const mockRequest = (impl: (url: string) => MockResponse | Promise<MockResponse>) => {
+  return {
+    get: vi.fn(async (url: string) => impl(url)),
+  } as unknown as APIRequestContext;
+};
+
+describe("fetchActiveRule", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches a relative path resolved against the base URL", async () => {
+    const request = mockRequest((url) => {
+      expect(url).toBe("https://example.com/magento_version");
+      return {
+        status: () => 200,
+        text: async () => "Magento/2.4 (Community)",
+        headers: () => ({ "content-type": "text/plain" }),
+      };
+    });
+
+    const res = await fetchActiveRule(
+      "https://example.com/some/page",
+      "/magento_version",
+      request,
+      5000,
+    );
+
+    expect(res?.url).toBe("https://example.com/magento_version");
+    expect(res?.status).toBe(200);
+    expect(res?.body).toBe("Magento/2.4 (Community)");
+    expect(res?.host).toBe("example.com");
+    expect(res?.isFirstParty).toBe(true);
+  });
+
+  it("rejects absolute URLs", async () => {
+    const request = mockRequest(() => {
+      throw new Error("should not be called");
+    });
+
+    const res = await fetchActiveRule(
+      "https://example.com/",
+      "https://evil.example/x",
+      request,
+      5000,
+    );
+
+    expect(res).toBeNull();
+  });
+
+  it("rejects protocol-relative paths", async () => {
+    const request = mockRequest(() => {
+      throw new Error("should not be called");
+    });
+
+    const res = await fetchActiveRule(
+      "https://example.com/",
+      "//evil.example/x",
+      request,
+      5000,
+    );
+
+    expect(res).toBeNull();
+  });
+
+  it("returns null when the request throws", async () => {
+    const request = mockRequest(() => {
+      throw new Error("network down");
+    });
+
+    const res = await fetchActiveRule(
+      "https://example.com/",
+      "/magento_version",
+      request,
+      5000,
+    );
+
+    expect(res).toBeNull();
+  });
+
+  describe("URL resolution with /path (host root)", () => {
+    const cases: Array<{ base: string; expected: string; note: string }> = [
+      {
+        base: "https://example.com/",
+        expected: "https://example.com/magento_version",
+        note: "root",
+      },
+      {
+        base: "https://www.example.com/en/",
+        expected: "https://www.example.com/magento_version",
+        note: "redirected to subpath ignores subpath",
+      },
+      {
+        base: "https://example.com/shop/catalog/item",
+        expected: "https://example.com/magento_version",
+        note: "deep path ignored",
+      },
+    ];
+
+    for (const { base, expected, note } of cases) {
+      it(`resolves '/magento_version' on ${note} (${base})`, async () => {
+        let called = "";
+        const request = mockRequest((url) => {
+          called = url;
+          return {
+            status: () => 200,
+            text: async () => "Magento/2.4",
+            headers: () => ({}),
+          };
+        });
+
+        await fetchActiveRule(base, "/magento_version", request, 5000);
+        expect(called).toBe(expected);
+      });
+    }
+  });
+
+  describe("URL resolution with ./path", () => {
+    const cases: Array<{ base: string; expected: string; note: string }> = [
+      {
+        base: "https://example.com/",
+        expected: "https://example.com/magento_version",
+        note: "root",
+      },
+      {
+        base: "https://example.com/shop/",
+        expected: "https://example.com/shop/magento_version",
+        note: "subpath with trailing slash",
+      },
+      {
+        base: "https://example.com/shop",
+        expected: "https://example.com/magento_version",
+        note: "subpath without trailing slash (treated as file)",
+      },
+      {
+        base: "https://example.com/index.html",
+        expected: "https://example.com/magento_version",
+        note: "file at root",
+      },
+      {
+        base: "https://example.com/shop/index.html",
+        expected: "https://example.com/shop/magento_version",
+        note: "file under subpath",
+      },
+    ];
+
+    for (const { base, expected, note } of cases) {
+      it(`resolves './magento_version' on ${note} (${base})`, async () => {
+        let called = "";
+        const request = mockRequest((url) => {
+          called = url;
+          return {
+            status: () => 200,
+            text: async () => "Magento/2.4",
+            headers: () => ({}),
+          };
+        });
+
+        await fetchActiveRule(base, "./magento_version", request, 5000);
+        expect(called).toBe(expected);
+      });
+    }
+  });
+
+  it("returns null when baseUrl is not a valid absolute URL", async () => {
+    const request = mockRequest(() => {
+      throw new Error("should not be called");
+    });
+
+    const res = await fetchActiveRule(
+      "not-a-url",
+      "./magento_version",
+      request,
+      5000,
+    );
+
+    expect(res).toBeNull();
+  });
+
+  it("returns response even on non-200 status (caller decides)", async () => {
+    const request = mockRequest(() => ({
+      status: () => 404,
+      text: async () => "",
+      headers: () => ({}),
+    }));
+
+    const res = await fetchActiveRule(
+      "https://example.com/",
+      "/magento_version",
+      request,
+      5000,
+    );
+
+    expect(res?.status).toBe(404);
+  });
+});

--- a/src/browser/active_scan.ts
+++ b/src/browser/active_scan.ts
@@ -1,10 +1,16 @@
 import type { APIRequestContext } from "playwright";
 import { logger } from "../logger/index.js";
 import type { Response } from "./types.js";
-import { getHostFromUrl, isFirstPartyHost } from "./utils.js";
+import { getHostFromUrl, isFirstPartyHost, isSameHost } from "./utils.js";
 
 export function isRelativePath(path: string): boolean {
   return !/^[a-z][a-z0-9+.-]*:/i.test(path) && !path.startsWith("//");
+}
+
+const MAX_REDIRECT_HOPS = 3;
+
+function isRedirectStatus(status: number): boolean {
+  return status >= 300 && status < 400;
 }
 
 export async function fetchActiveRule(
@@ -27,22 +33,50 @@ export async function fetchActiveRule(
   }
 
   const pageHost = getHostFromUrl(baseUrl) ?? "";
-  logger.info(`Active scan request: ${url}`);
   try {
-    const res = await request.get(url, {
-      timeout: timeoutMs,
-      maxRedirects: 0,
-    });
-    const host = getHostFromUrl(url) ?? "";
-    const body = await res.text().catch(() => "");
-    return {
-      url,
-      host,
-      isFirstParty: host ? isFirstPartyHost(pageHost, host) : false,
-      status: res.status(),
-      headers: res.headers(),
-      body,
-    };
+    for (let hop = 0; hop <= MAX_REDIRECT_HOPS; hop++) {
+      logger.info(`Active scan request: ${url}`);
+      const res = await request.get(url, {
+        timeout: timeoutMs,
+        maxRedirects: 0,
+      });
+      const status = res.status();
+      const location = res.headers()["location"];
+      if (isRedirectStatus(status) && location) {
+        if (hop === MAX_REDIRECT_HOPS) {
+          logger.warn(`Active scan exceeded redirect limit: ${url}`);
+          return null;
+        }
+        let nextUrl: string;
+        try {
+          nextUrl = new URL(location, url).toString();
+        } catch {
+          logger.warn(`Active scan invalid redirect location: ${location}`);
+          return null;
+        }
+        const nextHost = getHostFromUrl(nextUrl) ?? "";
+        if (!nextHost || !isSameHost(pageHost, nextHost)) {
+          logger.warn(
+            `Active scan redirect to non-same-host blocked: ${nextUrl}`,
+          );
+          return null;
+        }
+        url = nextUrl;
+        continue;
+      }
+
+      const host = getHostFromUrl(url) ?? "";
+      const body = await res.text().catch(() => "");
+      return {
+        url,
+        host,
+        isFirstParty: host ? isFirstPartyHost(pageHost, host) : false,
+        status,
+        headers: res.headers(),
+        body,
+      };
+    }
+    return null;
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
     logger.warn(

--- a/src/browser/active_scan.ts
+++ b/src/browser/active_scan.ts
@@ -1,0 +1,50 @@
+import type { APIRequestContext } from "playwright";
+import { logger } from "../logger/index.js";
+import type { Response } from "./types.js";
+import { getHostFromUrl, isFirstPartyHost } from "./utils.js";
+
+export function isRelativePath(path: string): boolean {
+  return !/^[a-z][a-z0-9+.-]*:/i.test(path) && !path.startsWith("//");
+}
+
+export async function fetchActiveRule(
+  baseUrl: string,
+  path: string,
+  request: APIRequestContext,
+  timeoutMs: number,
+): Promise<Response | null> {
+  if (!isRelativePath(path)) {
+    logger.warn(`Active scan path must be relative: ${path}`);
+    return null;
+  }
+
+  let url: string;
+  try {
+    url = new URL(path, baseUrl).toString();
+  } catch {
+    logger.warn(`Invalid active scan path: ${path}`);
+    return null;
+  }
+
+  const pageHost = getHostFromUrl(baseUrl) ?? "";
+  logger.info(`Active scan request: ${url}`);
+  try {
+    const res = await request.get(url, { timeout: timeoutMs });
+    const host = getHostFromUrl(url) ?? "";
+    const body = await res.text().catch(() => "");
+    return {
+      url,
+      host,
+      isFirstParty: host ? isFirstPartyHost(pageHost, host) : false,
+      status: res.status(),
+      headers: res.headers(),
+      body,
+    };
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    logger.warn(
+      `Active scan fetch failed (${url}): ${message.split("\n")[0]}`,
+    );
+    return null;
+  }
+}

--- a/src/browser/active_scan.ts
+++ b/src/browser/active_scan.ts
@@ -22,7 +22,7 @@ export async function fetchActiveRule(
   try {
     url = new URL(path, baseUrl).toString();
   } catch {
-    logger.warn(`Invalid active scan path: ${path}`);
+    logger.warn(`Invalid active scan baseUrl or path: baseUrl=${baseUrl}, path=${path}`);
     return null;
   }
 

--- a/src/browser/active_scan.ts
+++ b/src/browser/active_scan.ts
@@ -29,7 +29,10 @@ export async function fetchActiveRule(
   const pageHost = getHostFromUrl(baseUrl) ?? "";
   logger.info(`Active scan request: ${url}`);
   try {
-    const res = await request.get(url, { timeout: timeoutMs });
+    const res = await request.get(url, {
+      timeout: timeoutMs,
+      maxRedirects: 0,
+    });
     const host = getHostFromUrl(url) ?? "";
     const body = await res.text().catch(() => "");
     return {

--- a/src/commands/active_scan_runner.test.ts
+++ b/src/commands/active_scan_runner.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from "vitest";
+import type { APIRequestContext } from "playwright";
+import { applyActiveScans } from "./active_scan_runner.js";
+import type { Detection } from "../analyzer/types.js";
+import type { Signature } from "../signatures/_types.js";
+
+const makeRequest = (impl: (url: string) => {
+  status: number;
+  body: string;
+}) => {
+  const get = vi.fn(async (url: string) => {
+    const r = impl(url);
+    return {
+      status: () => r.status,
+      headers: () => ({}),
+      text: async () => r.body,
+    };
+  });
+  return { get, request: { get } as unknown as APIRequestContext };
+};
+
+const sig: Signature = {
+  name: "Magento",
+  rule: { confidence: "high" },
+  activeRules: [{ path: "./magento_version", bodyRegex: "^Magento/(\\S+)" }],
+};
+
+const otherSig: Signature = {
+  name: "Other",
+  rule: { confidence: "medium" },
+};
+
+describe("applyActiveScans", () => {
+  it("adds version evidence when detected and body matches", async () => {
+    const detections: Detection[] = [{ name: "Magento", evidences: [] }];
+    const { get, request } = makeRequest((url) => {
+      expect(url).toBe("https://example.com/shop/magento_version");
+      return { status: 200, body: "Magento/2.4 (Community)" };
+    });
+
+    await applyActiveScans(
+      "https://example.com/shop/",
+      detections,
+      [sig, otherSig],
+      request,
+      5000,
+    );
+
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(detections[0]!.evidences).toHaveLength(1);
+    expect(detections[0]!.evidences![0]).toMatchObject({
+      type: "body",
+      version: "2.4",
+      confidence: "high",
+      sourceUrl: "https://example.com/shop/magento_version",
+    });
+  });
+
+  it("does not run when signature is not in detections", async () => {
+    const detections: Detection[] = [{ name: "Other", evidences: [] }];
+    const { get, request } = makeRequest(() => ({ status: 200, body: "x" }));
+
+    await applyActiveScans(
+      "https://example.com/",
+      detections,
+      [sig, otherSig],
+      request,
+      5000,
+    );
+
+    expect(get).not.toHaveBeenCalled();
+    expect(detections[0]!.evidences).toEqual([]);
+  });
+
+  it("leaves detection unchanged on non-200", async () => {
+    const detections: Detection[] = [{ name: "Magento", evidences: [] }];
+    const { request } = makeRequest(() => ({ status: 404, body: "" }));
+
+    await applyActiveScans(
+      "https://example.com/",
+      detections,
+      [sig],
+      request,
+      5000,
+    );
+
+    expect(detections[0]!.evidences).toEqual([]);
+  });
+
+  it("leaves detection unchanged when bodyRegex does not match", async () => {
+    const detections: Detection[] = [{ name: "Magento", evidences: [] }];
+    const { request } = makeRequest(() => ({ status: 200, body: "<html/>" }));
+
+    await applyActiveScans(
+      "https://example.com/",
+      detections,
+      [sig],
+      request,
+      5000,
+    );
+
+    expect(detections[0]!.evidences).toEqual([]);
+  });
+
+  it("uses activeRule.confidence override when present", async () => {
+    const sigLow: Signature = {
+      name: "Magento",
+      rule: { confidence: "high" },
+      activeRules: [
+        {
+          path: "./magento_version",
+          bodyRegex: "^Magento/(\\S+)",
+          confidence: "low",
+        },
+      ],
+    };
+    const detections: Detection[] = [{ name: "Magento", evidences: [] }];
+    const { request } = makeRequest(() => ({
+      status: 200,
+      body: "Magento/2.4.6",
+    }));
+
+    await applyActiveScans(
+      "https://example.com/",
+      detections,
+      [sigLow],
+      request,
+      5000,
+    );
+
+    expect(detections[0]!.evidences![0]!.confidence).toBe("low");
+  });
+});

--- a/src/commands/active_scan_runner.ts
+++ b/src/commands/active_scan_runner.ts
@@ -1,0 +1,43 @@
+import type { APIRequestContext } from "playwright";
+import { fetchActiveRule } from "../browser/active_scan.js";
+import { matchString, truncateBodyForEvidence } from "../analyzer/match.js";
+import type { Detection } from "../analyzer/types.js";
+import type { Signature } from "../signatures/_types.js";
+
+export async function applyActiveScans(
+  baseUrl: string,
+  detections: Detection[],
+  signatures: Signature[],
+  request: APIRequestContext,
+  timeoutMs: number,
+): Promise<void> {
+  const signatureByName = new Map(signatures.map((s) => [s.name, s]));
+
+  for (const detection of detections) {
+    const signature = signatureByName.get(detection.name);
+    if (!signature?.rule || !signature.activeRules?.length) continue;
+
+    for (const activeRule of signature.activeRules) {
+      const response = await fetchActiveRule(
+        baseUrl,
+        activeRule.path,
+        request,
+        timeoutMs,
+      );
+      if (!response || response.status !== 200 || !response.body) {
+        continue;
+      }
+      const result = matchString(response.body, activeRule.bodyRegex);
+      if (!result.hit) continue;
+
+      (detection.evidences ??= []).push({
+        type: "body",
+        value: truncateBodyForEvidence(response.body),
+        version: result.version,
+        confidence: activeRule.confidence ?? signature.rule.confidence,
+        host: response.host,
+        sourceUrl: response.url,
+      });
+    }
+  }
+}

--- a/src/commands/detect.ts
+++ b/src/commands/detect.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import { openPage } from "../browser/index.js";
 import { analyze } from "../analyzer/index.js";
 import { signatures } from "../signatures/index.js";
+import { applyActiveScans } from "./active_scan_runner.js";
 import { logger, setLogLevel } from "../logger/index.js";
 import { LogLevel } from "../logger/types.js";
 import chalk from "chalk";
@@ -40,6 +41,11 @@ export const detectCommand = (): Command => {
       "Block redirects to a different host",
       false,
     )
+    .option(
+      "-a, --active",
+      "Enable active scanning (sends additional requests to technology-specific paths)",
+      false,
+    )
     .action(
       async (
         url: string,
@@ -52,6 +58,7 @@ export const detectCommand = (): Command => {
           locale?: string;
           header: string[];
           blockCrossDomainRedirect: boolean;
+          active: boolean;
         },
       ) => {
         if (options.debug) {
@@ -95,6 +102,17 @@ export const detectCommand = (): Command => {
             },
           );
           const detections = analyze(context, signatures);
+
+          if (options.active && detections.length > 0) {
+            await applyActiveScans(
+              context.page.url(),
+              detections,
+              signatures,
+              context.page.context().request,
+              options.timeout,
+            );
+          }
+
           const output = makeDetectCommandOutput(
             context.urls,
             detections,

--- a/src/signatures/_types.ts
+++ b/src/signatures/_types.ts
@@ -15,11 +15,18 @@ export type Rule = {
   requiredJavascriptVariables?: string[];
 };
 
+export type ActiveRule = {
+  path: string;
+  bodyRegex: Regex;
+  confidence?: Confidence;
+};
+
 export type Signature = {
   name: string;
   description?: string;
   cpe?: string;
   runtime?: Runtime;
   rule?: Rule;
+  activeRules?: ActiveRule[];
   impliedSoftwares?: string[];
 };

--- a/src/signatures/signatures.test.ts
+++ b/src/signatures/signatures.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { signatures } from "./index.js";
+import { isRelativePath } from "../browser/active_scan.js";
+
+const VALID_CONFIDENCES = ["high", "medium", "low"];
 
 describe("signatures validation", () => {
   describe("required fields", () => {
@@ -26,11 +29,10 @@ describe("signatures validation", () => {
 
   describe("confidence values", () => {
     it("all rules should have valid confidence values", () => {
-      const validConfidences = ["high", "medium", "low"];
       for (const sig of signatures) {
         if (sig.rule) {
           expect(
-            validConfidences,
+            VALID_CONFIDENCES,
             `Invalid confidence "${sig.rule.confidence}" in ${sig.name}`,
           ).toContain(sig.rule.confidence);
         }
@@ -98,6 +100,34 @@ describe("signatures validation", () => {
         if (sig.rule?.cookies) {
           for (const [cookie, pattern] of Object.entries(sig.rule.cookies)) {
             testRegex(pattern, sig.name, `cookies.${cookie}`);
+          }
+        }
+      }
+    });
+
+    it("all activeRules bodyRegex patterns should be valid regex", () => {
+      for (const sig of signatures) {
+        if (sig.activeRules) {
+          for (const [i, rule] of sig.activeRules.entries()) {
+            testRegex(rule.bodyRegex, sig.name, `activeRules[${i}].bodyRegex`);
+          }
+        }
+      }
+    });
+
+    it("all activeRules paths should be relative", () => {
+      for (const sig of signatures) {
+        if (!sig.activeRules) continue;
+        for (const [i, rule] of sig.activeRules.entries()) {
+          expect(
+            isRelativePath(rule.path),
+            `${sig.name}.activeRules[${i}].path must be relative: "${rule.path}"`,
+          ).toBe(true);
+          if (rule.confidence) {
+            expect(
+              VALID_CONFIDENCES,
+              `Invalid confidence in ${sig.name}.activeRules[${i}]`,
+            ).toContain(rule.confidence);
           }
         }
       }

--- a/src/signatures/technologies/magento.test.ts
+++ b/src/signatures/technologies/magento.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { matchString } from "../../analyzer/match.js";
+import { magentoSignature } from "./magento.js";
+
+describe("magentoSignature", () => {
+  describe("activeRules", () => {
+    it("defines a /magento_version probe", () => {
+      expect(magentoSignature.activeRules).toHaveLength(1);
+      expect(magentoSignature.activeRules?.[0]?.path).toBe("/magento_version");
+    });
+
+    it("extracts version from 'Magento/2.4 (Community)'", () => {
+      const rule = magentoSignature.activeRules![0]!;
+      const result = matchString("Magento/2.4 (Community)", rule.bodyRegex);
+      expect(result.hit).toBe(true);
+      expect(result.version).toBe("2.4");
+    });
+
+    it("extracts version from 'Magento/2.4.6'", () => {
+      const rule = magentoSignature.activeRules![0]!;
+      const result = matchString("Magento/2.4.6", rule.bodyRegex);
+      expect(result.hit).toBe(true);
+      expect(result.version).toBe("2.4.6");
+    });
+
+    it("does not match unrelated responses", () => {
+      const rule = magentoSignature.activeRules![0]!;
+      expect(matchString("<html>not magento</html>", rule.bodyRegex).hit).toBe(
+        false,
+      );
+    });
+  });
+});

--- a/src/signatures/technologies/magento.ts
+++ b/src/signatures/technologies/magento.ts
@@ -27,5 +27,11 @@ export const magentoSignature: Signature = {
       VarienForm: "",
     },
   },
+  activeRules: [
+    {
+      path: "/magento_version",
+      bodyRegex: "^Magento/(\\S+)",
+    },
+  ],
   impliedSoftwares: [phpSignature.name, mysqlSignature.name],
 };


### PR DESCRIPTION
## Summary

Add opt-in active scanning to detect technology versions more reliably by probing technology-specific endpoints after passive detection confirms the technology is in use.

- New CLI flag `-a`, `--active` on `whopper detect`. When enabled and a signature was passively detected, Whopper fetches paths declared by that signature's `activeRules` and extracts version strings from the response body.
- New `ActiveRule` type on `Signature` (`path`, `bodyRegex`, optional `confidence`).
- Magento gets an active rule for `/magento_version`, which returns e.g. `Magento/2.4 (Community)` and yields the version `2.4`.

## Design

| File | Role |
|---|---|
| `src/signatures/_types.ts` | Adds `ActiveRule` type and `Signature.activeRules?` |
| `src/signatures/technologies/magento.ts` | Declares the Magento active rule |
| `src/browser/active_scan.ts` | Pure fetch utility using Playwright's `APIRequestContext` (inherits cookies/headers). Validates relative paths via `isRelativePath`. |
| `src/commands/active_scan_runner.ts` | Orchestration: loops detections, runs matching `activeRules`, appends evidence with `version` |
| `src/commands/detect.ts` | Wires the CLI flag and calls `applyActiveScans` only when `--active` is set |

### URL resolution policy

The active scan resolves paths against the **final URL** (`page.url()`) after all redirects. The Magento rule uses `path: "/magento_version"` (host-root absolute), so redirects like `https://example.com/` → `https://www.example.com/en/` produce `https://www.example.com/magento_version`, ignoring the deeper path. `ActiveRule.path` supports both host-root (`/path`) and directory-relative (`./path`) forms; absolute URLs and protocol-relative URLs are rejected.

### Safety

- Active scan runs **only** when the signature was already detected passively, so non-Magento sites are never probed.
- Without `--active`, behavior is unchanged: no extra requests.

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test` — 265 tests passing
  - `fetchActiveRule` URL resolution for `/path` and `./path` against various base URLs (trailing slash, file paths, subpath, deep paths)
  - `applyActiveScans` orchestration: runs only for detected signatures, adds version evidence, handles non-200 / regex miss, respects per-rule confidence override
  - Magento regex extracts `2.4` from `Magento/2.4 (Community)` and `2.4.6` from `Magento/2.4.6`
  - `signatures.test.ts` validates all `activeRules` have valid regex, relative paths, and valid confidence values
- [ ] Manual: `whopper detect https://<magento-site> --active -e -j` shows a `body` evidence with `version` and `sourceUrl` ending in `/magento_version`
- [ ] Manual: `whopper detect https://<non-magento-site> --active` does not request `/magento_version`