### PR TITLE
feat: detect Magento via CSP header widgets.magentocommerce.com

### DIFF
--- a/src/signatures/technologies/magento.test.ts
+++ b/src/signatures/technologies/magento.test.ts
@@ -3,6 +3,30 @@ import { matchString } from "../../analyzer/match.js";
 import { magentoSignature } from "./magento.js";
 
 describe("magentoSignature", () => {
+  describe("rule.headers", () => {
+    const cspRegex =
+      magentoSignature.rule?.headers?.["Content-Security-Policy"];
+    const cspReportOnlyRegex =
+      magentoSignature.rule?.headers?.["Content-Security-Policy-Report-Only"];
+
+    it("defines CSP header detection for both enforce and report-only variants", () => {
+      expect(cspRegex).toBeDefined();
+      expect(cspReportOnlyRegex).toBeDefined();
+    });
+
+    it("matches CSP values referencing widgets.magentocommerce.com", () => {
+      const csp =
+        "default-src 'self'; img-src widgets.magentocommerce.com data:";
+      expect(matchString(csp, cspRegex!).hit).toBe(true);
+      expect(matchString(csp, cspReportOnlyRegex!).hit).toBe(true);
+    });
+
+    it("does not match CSP values without the Magento widget CDN", () => {
+      const csp = "default-src 'self'; img-src cdn.example.com data:";
+      expect(matchString(csp, cspRegex!).hit).toBe(false);
+    });
+  });
+
   describe("activeRules", () => {
     it("defines a /magento_version probe", () => {
       expect(magentoSignature.activeRules).toHaveLength(1);

--- a/src/signatures/technologies/magento.ts
+++ b/src/signatures/technologies/magento.ts
@@ -8,6 +8,10 @@ export const magentoSignature: Signature = {
   cpe: "cpe:/a:magento:magento",
   rule: {
     confidence: "high",
+    headers: {
+      "Content-Security-Policy": "widgets\\.magentocommerce\\.com",
+      "Content-Security-Policy-Report-Only": "widgets\\.magentocommerce\\.com",
+    },
     urls: ["js/mage", "static/_requirejs", "skin/frontend/"],
     bodies: [
       "data-requiremodule=\"[^\"]*(?:mage/|Magento_)",


### PR DESCRIPTION
## Summary
Detect Magento via the `widgets.magentocommerce.com` reference in the `Content-Security-Policy` / `Content-Security-Policy-Report-Only` response headers. This catches Magento storefronts whose HTML/body signatures are hidden behind a redirect 302s before any Magento-specific markup is served), but whose CSP still enumerates Magento's official widget CDN.

## Changes
- Add `headers` rule to the Magento signature matching `widgets\.magentocommerce\.com` on both CSP header variants.

## Test plan
- [x] `npm test`
- [x] Run detection against a site that returns a 302 with a Magento CSP header and confirm Magento is detected.
- [x] Confirm no false positives on non-Magento sites that merely mention `magentocommerce.com` elsewhere.