### PR TITLE
feat: extract header evidence snippet around regex match

### DIFF
--- a/src/analyzer/apply.test.ts
+++ b/src/analyzer/apply.test.ts
@@ -84,6 +84,33 @@ describe("applySignature", () => {
       });
     });
 
+    it("should truncate long header values around the match", () => {
+      const signature: Signature = {
+        name: "Magento",
+        rule: {
+          confidence: "high",
+          headers: {
+            "Content-Security-Policy": "widgets\\.magentocommerce\\.com",
+          },
+        },
+      };
+
+      const longCsp = `${"a".repeat(200)} widgets.magentocommerce.com ${"b".repeat(200)}`;
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            headers: { "content-security-policy": longCsp },
+          }),
+        ],
+      });
+
+      const evidence = applySignature(context, signature)?.evidences?.[0];
+      expect(evidence?.type).toBe("header");
+      expect(evidence?.value).toMatch(
+        /^Content-Security-Policy: \.\.\.a{39} widgets\.magentocommerce\.com b{39}\.\.\.$/,
+      );
+    });
+
     it("should not detect when header does not match", () => {
       const signature: Signature = {
         name: "Nginx",

--- a/src/analyzer/apply.ts
+++ b/src/analyzer/apply.ts
@@ -1,7 +1,11 @@
 import type { Context, Response } from "../browser/types.js";
 import type { Runtime, Signature } from "../signatures/_types.js";
 import type { Detection, Evidence } from "./types.js";
-import { matchString, truncateBodyForEvidence } from "./match.js";
+import {
+  extractMatchSnippet,
+  matchString,
+  truncateBodyForEvidence,
+} from "./match.js";
 
 function isFirstPartyResponse(response: Response): boolean {
   return response.isFirstParty ?? true;
@@ -112,9 +116,13 @@ export const applySignature = (
         continue;
       }
 
+      const snippet =
+        result.index !== undefined && result.matchLength !== undefined
+          ? extractMatchSnippet(headerValue, result.index, result.matchLength)
+          : headerValue;
       evidences.push({
         type: "header",
-        value: `${header}: ${headerValue}`,
+        value: `${header}: ${snippet}`,
         version: result.version,
         confidence: rule.confidence,
         host: response.host,

--- a/src/analyzer/match.test.ts
+++ b/src/analyzer/match.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { matchString } from "./match.js";
+import { extractMatchSnippet, matchString } from "./match.js";
 
 describe("matchString", () => {
   describe("basic matching", () => {
@@ -56,5 +56,25 @@ describe("matchString", () => {
       expect(result.hit).toBe(true);
       expect(result.version).toBe("3.6.0");
     });
+  });
+});
+
+describe("extractMatchSnippet", () => {
+  it("returns the value unchanged when shorter than the context window", () => {
+    expect(extractMatchSnippet("nginx/1.20.0", 0, 5)).toBe("nginx/1.20.0");
+  });
+
+  it("truncates both sides with ellipsis when the match is in the middle", () => {
+    const value = `${"a".repeat(60)}MATCH${"b".repeat(60)}`;
+    expect(extractMatchSnippet(value, 60, 5, 10)).toBe(
+      `...${"a".repeat(10)}MATCH${"b".repeat(10)}...`,
+    );
+  });
+
+  it("omits the leading ellipsis when the match is near the start", () => {
+    const value = `MATCH${"b".repeat(60)}`;
+    expect(extractMatchSnippet(value, 0, 5, 10)).toBe(
+      `MATCH${"b".repeat(10)}...`,
+    );
   });
 });

--- a/src/analyzer/match.test.ts
+++ b/src/analyzer/match.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { extractMatchSnippet, matchString } from "./match.js";
+import {
+  extractMatchSnippet,
+  matchString,
+  truncateBodyForEvidence,
+} from "./match.js";
 
 describe("matchString", () => {
   describe("basic matching", () => {
@@ -75,6 +79,19 @@ describe("extractMatchSnippet", () => {
     const value = `MATCH${"b".repeat(60)}`;
     expect(extractMatchSnippet(value, 0, 5, 10)).toBe(
       `MATCH${"b".repeat(10)}...`,
+    );
+  });
+});
+
+describe("truncateBodyForEvidence", () => {
+  it("appends ellipsis when the body exceeds 100 characters", () => {
+    const body = "a".repeat(120);
+    expect(truncateBodyForEvidence(body)).toBe(`${"a".repeat(100)}...`);
+  });
+
+  it("returns the body unchanged when it is 100 characters or shorter", () => {
+    expect(truncateBodyForEvidence("Magento/2.4 (Community)")).toBe(
+      "Magento/2.4 (Community)",
     );
   });
 });

--- a/src/analyzer/match.ts
+++ b/src/analyzer/match.ts
@@ -23,7 +23,7 @@ export const matchString = (value: string, regex: Regex): MatchResult => {
 };
 
 export const truncateBodyForEvidence = (body: string): string =>
-  `${body.substring(0, 100)}...`;
+  body.length > 100 ? `${body.substring(0, 100)}...` : body;
 
 export const extractMatchSnippet = (
   value: string,

--- a/src/analyzer/match.ts
+++ b/src/analyzer/match.ts
@@ -3,17 +3,37 @@ import type { Regex } from "../signatures/_types.js";
 type MatchResult = {
   hit: boolean;
   version: string | undefined;
+  index: number | undefined;
+  matchLength: number | undefined;
 };
 
 export const matchString = (value: string, regex: Regex): MatchResult => {
   const regexExp = new RegExp(regex, "i");
   const match = value.match(regexExp);
   if (match) {
-    return { hit: true, version: match.length > 1 ? match[1] : undefined };
+    return {
+      hit: true,
+      version: match.length > 1 ? match[1] : undefined,
+      index: match.index,
+      matchLength: match[0].length,
+    };
   }
 
-  return { hit: false, version: undefined };
+  return { hit: false, version: undefined, index: undefined, matchLength: undefined };
 };
 
 export const truncateBodyForEvidence = (body: string): string =>
   `${body.substring(0, 100)}...`;
+
+export const extractMatchSnippet = (
+  value: string,
+  index: number,
+  matchLength: number,
+  context = 40,
+): string => {
+  const start = Math.max(0, index - context);
+  const end = Math.min(value.length, index + matchLength + context);
+  const prefix = start > 0 ? "..." : "";
+  const suffix = end < value.length ? "..." : "";
+  return `${prefix}${value.substring(start, end)}${suffix}`;
+};


### PR DESCRIPTION
## Summary
- Header evidence values now show only the matched substring with 40 chars of surrounding context (plus `...` ellipsis) instead of the entire header, so long headers like CSP no longer produce unreadable multi-KB evidence strings.
- `matchString` now returns the match `index` and `matchLength`, letting `applySignature` build the snippet without re-running the regex.
- Fix: `truncateBodyForEvidence` only appends `...` when the body actually exceeds 100 characters (previously short bodies like `Magento/2.4 (Community)` were incorrectly rendered as `Magento/2.4 (Community)...`).

## Test plan
- [x] `npm test`
- [x] Run detection against a site with a long CSP header and confirm header evidence is truncated around the matched token.
- [x] Run the Magento active scan against a site returning a short body (e.g. `Magento/2.4 (Community)`) and confirm the evidence value has no trailing `...`.