### PR TITLE
feat: add Magento CSP header detection and header evidence snippets

### DIFF
--- a/src/analyzer/apply.test.ts
+++ b/src/analyzer/apply.test.ts
@@ -84,6 +84,33 @@ describe("applySignature", () => {
       });
     });
 
+    it("should truncate long header values around the match", () => {
+      const signature: Signature = {
+        name: "Magento",
+        rule: {
+          confidence: "high",
+          headers: {
+            "Content-Security-Policy": "widgets\\.magentocommerce\\.com",
+          },
+        },
+      };
+
+      const longCsp = `${"a".repeat(200)} widgets.magentocommerce.com ${"b".repeat(200)}`;
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            headers: { "content-security-policy": longCsp },
+          }),
+        ],
+      });
+
+      const evidence = applySignature(context, signature)?.evidences?.[0];
+      expect(evidence?.type).toBe("header");
+      expect(evidence?.value).toMatch(
+        /^Content-Security-Policy: \.\.\.a{39} widgets\.magentocommerce\.com b{39}\.\.\.$/,
+      );
+    });
+
     it("should not detect when header does not match", () => {
       const signature: Signature = {
         name: "Nginx",

--- a/src/analyzer/apply.ts
+++ b/src/analyzer/apply.ts
@@ -1,7 +1,11 @@
 import type { Context, Response } from "../browser/types.js";
 import type { Runtime, Signature } from "../signatures/_types.js";
 import type { Detection, Evidence } from "./types.js";
-import { matchString, truncateBodyForEvidence } from "./match.js";
+import {
+  extractMatchSnippet,
+  matchString,
+  truncateBodyForEvidence,
+} from "./match.js";
 
 function isFirstPartyResponse(response: Response): boolean {
   return response.isFirstParty ?? true;
@@ -112,9 +116,13 @@ export const applySignature = (
         continue;
       }
 
+      const snippet =
+        result.index !== undefined && result.matchLength !== undefined
+          ? extractMatchSnippet(headerValue, result.index, result.matchLength)
+          : headerValue;
       evidences.push({
         type: "header",
-        value: `${header}: ${headerValue}`,
+        value: `${header}: ${snippet}`,
         version: result.version,
         confidence: rule.confidence,
         host: response.host,

--- a/src/analyzer/match.test.ts
+++ b/src/analyzer/match.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { matchString } from "./match.js";
+import { extractMatchSnippet, matchString } from "./match.js";
 
 describe("matchString", () => {
   describe("basic matching", () => {
@@ -56,5 +56,25 @@ describe("matchString", () => {
       expect(result.hit).toBe(true);
       expect(result.version).toBe("3.6.0");
     });
+  });
+});
+
+describe("extractMatchSnippet", () => {
+  it("returns the value unchanged when shorter than the context window", () => {
+    expect(extractMatchSnippet("nginx/1.20.0", 0, 5)).toBe("nginx/1.20.0");
+  });
+
+  it("truncates both sides with ellipsis when the match is in the middle", () => {
+    const value = `${"a".repeat(60)}MATCH${"b".repeat(60)}`;
+    expect(extractMatchSnippet(value, 60, 5, 10)).toBe(
+      `...${"a".repeat(10)}MATCH${"b".repeat(10)}...`,
+    );
+  });
+
+  it("omits the leading ellipsis when the match is near the start", () => {
+    const value = `MATCH${"b".repeat(60)}`;
+    expect(extractMatchSnippet(value, 0, 5, 10)).toBe(
+      `MATCH${"b".repeat(10)}...`,
+    );
   });
 });

--- a/src/analyzer/match.test.ts
+++ b/src/analyzer/match.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { extractMatchSnippet, matchString } from "./match.js";
+import {
+  extractMatchSnippet,
+  matchString,
+  truncateBodyForEvidence,
+} from "./match.js";
 
 describe("matchString", () => {
   describe("basic matching", () => {
@@ -75,6 +79,19 @@ describe("extractMatchSnippet", () => {
     const value = `MATCH${"b".repeat(60)}`;
     expect(extractMatchSnippet(value, 0, 5, 10)).toBe(
       `MATCH${"b".repeat(10)}...`,
+    );
+  });
+});
+
+describe("truncateBodyForEvidence", () => {
+  it("appends ellipsis when the body exceeds 100 characters", () => {
+    const body = "a".repeat(120);
+    expect(truncateBodyForEvidence(body)).toBe(`${"a".repeat(100)}...`);
+  });
+
+  it("returns the body unchanged when it is 100 characters or shorter", () => {
+    expect(truncateBodyForEvidence("Magento/2.4 (Community)")).toBe(
+      "Magento/2.4 (Community)",
     );
   });
 });

--- a/src/analyzer/match.ts
+++ b/src/analyzer/match.ts
@@ -23,7 +23,7 @@ export const matchString = (value: string, regex: Regex): MatchResult => {
 };
 
 export const truncateBodyForEvidence = (body: string): string =>
-  `${body.substring(0, 100)}...`;
+  body.length > 100 ? `${body.substring(0, 100)}...` : body;
 
 export const extractMatchSnippet = (
   value: string,

--- a/src/analyzer/match.ts
+++ b/src/analyzer/match.ts
@@ -3,17 +3,37 @@ import type { Regex } from "../signatures/_types.js";
 type MatchResult = {
   hit: boolean;
   version: string | undefined;
+  index: number | undefined;
+  matchLength: number | undefined;
 };
 
 export const matchString = (value: string, regex: Regex): MatchResult => {
   const regexExp = new RegExp(regex, "i");
   const match = value.match(regexExp);
   if (match) {
-    return { hit: true, version: match.length > 1 ? match[1] : undefined };
+    return {
+      hit: true,
+      version: match.length > 1 ? match[1] : undefined,
+      index: match.index,
+      matchLength: match[0].length,
+    };
   }
 
-  return { hit: false, version: undefined };
+  return { hit: false, version: undefined, index: undefined, matchLength: undefined };
 };
 
 export const truncateBodyForEvidence = (body: string): string =>
   `${body.substring(0, 100)}...`;
+
+export const extractMatchSnippet = (
+  value: string,
+  index: number,
+  matchLength: number,
+  context = 40,
+): string => {
+  const start = Math.max(0, index - context);
+  const end = Math.min(value.length, index + matchLength + context);
+  const prefix = start > 0 ? "..." : "";
+  const suffix = end < value.length ? "..." : "";
+  return `${prefix}${value.substring(start, end)}${suffix}`;
+};

--- a/src/signatures/technologies/magento.test.ts
+++ b/src/signatures/technologies/magento.test.ts
@@ -3,6 +3,30 @@ import { matchString } from "../../analyzer/match.js";
 import { magentoSignature } from "./magento.js";
 
 describe("magentoSignature", () => {
+  describe("rule.headers", () => {
+    const cspRegex =
+      magentoSignature.rule?.headers?.["Content-Security-Policy"];
+    const cspReportOnlyRegex =
+      magentoSignature.rule?.headers?.["Content-Security-Policy-Report-Only"];
+
+    it("defines CSP header detection for both enforce and report-only variants", () => {
+      expect(cspRegex).toBeDefined();
+      expect(cspReportOnlyRegex).toBeDefined();
+    });
+
+    it("matches CSP values referencing widgets.magentocommerce.com", () => {
+      const csp =
+        "default-src 'self'; img-src widgets.magentocommerce.com data:";
+      expect(matchString(csp, cspRegex!).hit).toBe(true);
+      expect(matchString(csp, cspReportOnlyRegex!).hit).toBe(true);
+    });
+
+    it("does not match CSP values without the Magento widget CDN", () => {
+      const csp = "default-src 'self'; img-src cdn.example.com data:";
+      expect(matchString(csp, cspRegex!).hit).toBe(false);
+    });
+  });
+
   describe("activeRules", () => {
     it("defines a /magento_version probe", () => {
       expect(magentoSignature.activeRules).toHaveLength(1);

--- a/src/signatures/technologies/magento.ts
+++ b/src/signatures/technologies/magento.ts
@@ -8,6 +8,10 @@ export const magentoSignature: Signature = {
   cpe: "cpe:/a:magento:magento",
   rule: {
     confidence: "high",
+    headers: {
+      "Content-Security-Policy": "widgets\\.magentocommerce\\.com",
+      "Content-Security-Policy-Report-Only": "widgets\\.magentocommerce\\.com",
+    },
     urls: ["js/mage", "static/_requirejs", "skin/frontend/"],
     bodies: [
       "data-requiremodule=\"[^\"]*(?:mage/|Magento_)",


### PR DESCRIPTION
## Summary
- Detect Magento via the `Content-Security-Policy` header referencing `widgets.magentocommerce.com`.
- Extract a focused snippet of header evidence around the regex match instead of returning the full header value.
- Only append the ellipsis to body evidence when the snippet was actually truncated.

## Changes
- `src/signatures/technologies/magento.ts`: add CSP header signature + tests.
- `src/analyzer/match.ts`: expose match index/length so callers can slice around the hit.
- `src/analyzer/apply.ts`: use `extractMatchSnippet` for header evidence; fix ellipsis logic for body evidence.
- Tests added for each of the above.

## Test plan
- [x] `npm test` passes
- [x] Verify Magento detection on a site serving the CSP header
- [x] Confirm header evidence shows a trimmed snippet rather than the full header
- [x] Confirm body evidence no longer shows a trailing `…` when not truncated
