### PR TITLE
feat: include match snippet in body evidence value

### DIFF
--- a/src/analyzer/apply.test.ts
+++ b/src/analyzer/apply.test.ts
@@ -208,6 +208,35 @@ describe("applySignature", () => {
       expect(result?.evidences?.[0]?.version).toBe("3.6.0");
     });
 
+    it("should include a snippet around the match in body evidence value", () => {
+      const signature: Signature = {
+        name: "jQuery",
+        rule: {
+          confidence: "medium",
+          bodies: ["jquery[.-]([\\d.]+)(?:\\.min)?\\.js"],
+        },
+      };
+
+      const prefix = "a".repeat(200);
+      const suffix = "b".repeat(200);
+      const match = "jquery-3.6.0.min.js";
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            headers: { "content-type": "text/html" },
+            body: `${prefix}${match}${suffix}`,
+          }),
+        ],
+      });
+
+      const result = applySignature(context, signature);
+      const value = result?.evidences?.[0]?.value ?? "";
+      expect(value).toContain(match);
+      expect(value.startsWith("...")).toBe(true);
+      expect(value.endsWith("...")).toBe(true);
+      expect(value.length).toBeLessThan(200);
+    });
+
     it("should not match body when content-type is not text", () => {
       const signature: Signature = {
         name: "jQuery",

--- a/src/analyzer/apply.ts
+++ b/src/analyzer/apply.ts
@@ -148,9 +148,13 @@ export const applySignature = (
           continue;
         }
 
+        const snippet =
+          result.index !== undefined && result.matchLength !== undefined
+            ? extractMatchSnippet(body, result.index, result.matchLength)
+            : truncateBodyForEvidence(body);
         evidences.push({
           type: "body",
-          value: truncateBodyForEvidence(body),
+          value: snippet,
           version: result.version,
           confidence: rule.confidence,
           host: response.host,


### PR DESCRIPTION
## Summary
- Body evidence previously showed only the head of the response body, making it unclear where the pattern actually matched.
- Use `extractMatchSnippet` for body matches so the evidence value surfaces the surrounding context, matching the behavior already used for header evidence.
- Add a unit test verifying the snippet is centered on the match and trimmed with ellipses.

## Test plan
- [x] `npx vitest run src/analyzer/apply.test.ts`