### PR TITLE
fix: freeze response snapshot after idle wait

### DIFF
--- a/src/browser/index.test.ts
+++ b/src/browser/index.test.ts
@@ -5,6 +5,7 @@ import { openPage } from "./index.js";
 vi.mock("playwright", () => {
   const mockPage = {
     on: vi.fn(),
+    off: vi.fn(),
     route: vi.fn(),
     mainFrame: vi.fn(),
     goto: vi.fn(),
@@ -56,6 +57,7 @@ import { sleep } from "./utils.js";
 describe("openPage", () => {
   let mockPage: {
     on: ReturnType<typeof vi.fn>;
+    off: ReturnType<typeof vi.fn>;
     route: ReturnType<typeof vi.fn>;
     mainFrame: ReturnType<typeof vi.fn>;
     goto: ReturnType<typeof vi.fn>;
@@ -79,6 +81,7 @@ describe("openPage", () => {
     // Get references to mocked objects
     mockPage = {
       on: vi.fn(),
+      off: vi.fn(),
       route: vi.fn(),
       mainFrame: vi.fn(),
       goto: vi.fn(() => Promise.resolve()),
@@ -124,7 +127,9 @@ describe("openPage", () => {
     });
 
     it("should pass custom userAgent to browser context", async () => {
-      await openPage("https://example.com", 10000, [], { userAgent: "MyCustomAgent/1.0" });
+      await openPage("https://example.com", 10000, [], {
+        userAgent: "MyCustomAgent/1.0",
+      });
 
       expect(mockBrowser.newContext).toHaveBeenCalledWith({
         ignoreHTTPSErrors: true,
@@ -199,7 +204,10 @@ describe("openPage", () => {
     it("should block cross-domain navigation when blocking is enabled", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
-        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+        async (
+          _pattern: string,
+          handler: (route: unknown) => Promise<void>,
+        ) => {
           routeHandler = handler;
         },
       );
@@ -238,12 +246,17 @@ describe("openPage", () => {
     it("should allow any redirect when blocking is disabled", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
-        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+        async (
+          _pattern: string,
+          handler: (route: unknown) => Promise<void>,
+        ) => {
           routeHandler = handler;
         },
       );
 
-      await openPage("https://example.com", 10000, [], { blockCrossDomainRedirect: false });
+      await openPage("https://example.com", 10000, [], {
+        blockCrossDomainRedirect: false,
+      });
 
       const mockResponse = { status: () => 200, headers: () => ({}) };
       const continueMock = vi.fn(() => Promise.resolve());
@@ -270,7 +283,10 @@ describe("openPage", () => {
     it("should continue for non-navigation requests", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
-        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+        async (
+          _pattern: string,
+          handler: (route: unknown) => Promise<void>,
+        ) => {
           routeHandler = handler;
         },
       );
@@ -298,7 +314,10 @@ describe("openPage", () => {
     it("should continue for non-main-frame navigation requests", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
-        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+        async (
+          _pattern: string,
+          handler: (route: unknown) => Promise<void>,
+        ) => {
           routeHandler = handler;
         },
       );
@@ -326,7 +345,10 @@ describe("openPage", () => {
     it("should continue when navigation target host cannot be parsed", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
-        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+        async (
+          _pattern: string,
+          handler: (route: unknown) => Promise<void>,
+        ) => {
           routeHandler = handler;
         },
       );
@@ -374,7 +396,10 @@ describe("openPage", () => {
     it("should block subdomain redirect when blocking is enabled", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
-        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+        async (
+          _pattern: string,
+          handler: (route: unknown) => Promise<void>,
+        ) => {
           routeHandler = handler;
         },
       );
@@ -421,7 +446,10 @@ describe("openPage", () => {
     it("should block HTTP 301 redirect to cross-domain when blocking is enabled", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
-        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+        async (
+          _pattern: string,
+          handler: (route: unknown) => Promise<void>,
+        ) => {
           routeHandler = handler;
         },
       );
@@ -458,14 +486,19 @@ describe("openPage", () => {
       expect(abortMock).toHaveBeenCalledWith("blockedbyclient");
       expect(fulfillMock).not.toHaveBeenCalled();
       expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining("Blocked cross-domain redirect: https://example.com/"),
+        expect.stringContaining(
+          "Blocked cross-domain redirect: https://example.com/",
+        ),
       );
     });
 
     it("should allow HTTP 301 redirect to same host", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
-        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+        async (
+          _pattern: string,
+          handler: (route: unknown) => Promise<void>,
+        ) => {
           routeHandler = handler;
         },
       );
@@ -506,7 +539,10 @@ describe("openPage", () => {
     it("should fulfill response when Location header is malformed", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
-        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+        async (
+          _pattern: string,
+          handler: (route: unknown) => Promise<void>,
+        ) => {
           routeHandler = handler;
         },
       );
@@ -547,7 +583,10 @@ describe("openPage", () => {
     it("should block HTTP 302 redirect to cross-domain when blocking is enabled", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
-        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+        async (
+          _pattern: string,
+          handler: (route: unknown) => Promise<void>,
+        ) => {
           routeHandler = handler;
         },
       );
@@ -591,7 +630,10 @@ describe("openPage", () => {
     it("should abort when route.fetch() throws an error", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
-        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+        async (
+          _pattern: string,
+          handler: (route: unknown) => Promise<void>,
+        ) => {
           routeHandler = handler;
         },
       );
@@ -605,7 +647,9 @@ describe("openPage", () => {
 
       const continueMock = vi.fn(() => Promise.resolve());
       const abortMock = vi.fn(() => Promise.resolve());
-      const fetchMock = vi.fn(() => Promise.reject(new Error("net::ERR_CONNECTION_REFUSED")));
+      const fetchMock = vi.fn(() =>
+        Promise.reject(new Error("net::ERR_CONNECTION_REFUSED")),
+      );
       const fulfillMock = vi.fn(() => Promise.resolve());
       await routeHandler({
         request: () => ({
@@ -627,7 +671,10 @@ describe("openPage", () => {
     it("should record non-Error thrown by route.fetch() in urls", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
-        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+        async (
+          _pattern: string,
+          handler: (route: unknown) => Promise<void>,
+        ) => {
           routeHandler = handler;
         },
       );
@@ -659,7 +706,10 @@ describe("openPage", () => {
     it("should continue for already-inspected URLs on route re-entry", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
-        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+        async (
+          _pattern: string,
+          handler: (route: unknown) => Promise<void>,
+        ) => {
           routeHandler = handler;
         },
       );
@@ -797,7 +847,10 @@ describe("openPage", () => {
     it("should abort when redirect chain fetch fails mid-chain", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
-        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+        async (
+          _pattern: string,
+          handler: (route: unknown) => Promise<void>,
+        ) => {
           routeHandler = handler;
         },
       );
@@ -842,7 +895,10 @@ describe("openPage", () => {
     it("should record non-Error thrown by redirect chain fetch in urls", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
-        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+        async (
+          _pattern: string,
+          handler: (route: unknown) => Promise<void>,
+        ) => {
           routeHandler = handler;
         },
       );
@@ -884,7 +940,10 @@ describe("openPage", () => {
     it("should break loop when Location URL cannot be parsed", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
-        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+        async (
+          _pattern: string,
+          handler: (route: unknown) => Promise<void>,
+        ) => {
           routeHandler = handler;
         },
       );
@@ -927,7 +986,10 @@ describe("openPage", () => {
     it("should capture 3xx response headers and body into responses array", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
-        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+        async (
+          _pattern: string,
+          handler: (route: unknown) => Promise<void>,
+        ) => {
           routeHandler = handler;
         },
       );
@@ -981,7 +1043,10 @@ describe("openPage", () => {
     it("should capture multi-hop 3xx chain into responses array", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
-        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+        async (
+          _pattern: string,
+          handler: (route: unknown) => Promise<void>,
+        ) => {
           routeHandler = handler;
         },
       );
@@ -1005,8 +1070,7 @@ describe("openPage", () => {
           location: "https://example.com/final",
           server: "cloudflare",
         }),
-        text: () =>
-          Promise.resolve("<html><body>Found</body></html>"),
+        text: () => Promise.resolve("<html><body>Found</body></html>"),
       };
       const mock200Response = {
         status: () => 200,
@@ -1046,10 +1110,14 @@ describe("openPage", () => {
 
     it("should not duplicate 3xx responses in page.on response listener", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
-      let responseListener: (response: unknown) => Promise<void> =
-        async () => {};
+      let responseListener: (
+        response: unknown,
+      ) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
-        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+        async (
+          _pattern: string,
+          handler: (route: unknown) => Promise<void>,
+        ) => {
           routeHandler = handler;
         },
       );
@@ -1115,7 +1183,10 @@ describe("openPage", () => {
     it("should omit body from 3xx response when body is empty", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
-        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+        async (
+          _pattern: string,
+          handler: (route: unknown) => Promise<void>,
+        ) => {
           routeHandler = handler;
         },
       );
@@ -1157,7 +1228,10 @@ describe("openPage", () => {
     it("should capture 3xx response without Location header", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
-        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+        async (
+          _pattern: string,
+          handler: (route: unknown) => Promise<void>,
+        ) => {
           routeHandler = handler;
         },
       );
@@ -1202,7 +1276,10 @@ describe("openPage", () => {
     it("should handle 3xx response where URL has no extractable host", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
-        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+        async (
+          _pattern: string,
+          handler: (route: unknown) => Promise<void>,
+        ) => {
           routeHandler = handler;
         },
       );
@@ -1473,7 +1550,10 @@ describe("openPage", () => {
     it("should not duplicate error in urls when route handler already recorded entries", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
-        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+        async (
+          _pattern: string,
+          handler: (route: unknown) => Promise<void>,
+        ) => {
           routeHandler = handler;
         },
       );
@@ -1487,7 +1567,9 @@ describe("openPage", () => {
           }),
           continue: vi.fn(() => Promise.resolve()),
           abort: vi.fn(() => Promise.resolve()),
-          fetch: vi.fn(() => Promise.reject(new Error("net::ERR_NAME_NOT_RESOLVED"))),
+          fetch: vi.fn(() =>
+            Promise.reject(new Error("net::ERR_NAME_NOT_RESOLVED")),
+          ),
           fulfill: vi.fn(() => Promise.resolve()),
         });
         throw new Error("page.goto: net::ERR_FAILED");
@@ -1506,7 +1588,10 @@ describe("openPage", () => {
     it("should not log error when navigation is blocked by redirect policy", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
-        async (_pattern: string, handler: (route: unknown) => Promise<void>) => {
+        async (
+          _pattern: string,
+          handler: (route: unknown) => Promise<void>,
+        ) => {
           routeHandler = handler;
         },
       );

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import { chromium } from "playwright";
+import { chromium, type Response as PlaywrightResponse } from "playwright";
 import { logger } from "../logger/index.js";
 import type { Context, OpenPageOptions, Response, UrlEntry } from "./types.js";
 import {
@@ -109,13 +109,8 @@ export async function openPage(
       return;
     }
 
-    if (
-      blockCrossDomainRedirect &&
-      !isSameHost(pageHost, targetHost)
-    ) {
-      logger.warn(
-        `Blocked cross-domain redirect: ${targetUrl}`,
-      );
+    if (blockCrossDomainRedirect && !isSameHost(pageHost, targetHost)) {
+      logger.warn(`Blocked cross-domain redirect: ${targetUrl}`);
       blockedByRedirectPolicy = true;
       urls.push({ url: targetUrl, error: "Blocked cross-domain redirect" });
       await route.abort("blockedbyclient");
@@ -124,9 +119,7 @@ export async function openPage(
 
     // Log client-side redirects (JS / meta refresh)
     if (targetUrl !== lastNavigationUrl) {
-      logger.info(
-        `Following redirect: ${lastNavigationUrl} -> ${targetUrl}`,
-      );
+      logger.info(`Following redirect: ${lastNavigationUrl} -> ${targetUrl}`);
     }
     lastNavigationUrl = targetUrl;
 
@@ -141,7 +134,8 @@ export async function openPage(
     try {
       response = await route.fetch({ maxRedirects: 0 });
     } catch (e) {
-      const message = (e instanceof Error ? e.message : String(e)).split("\n")[0] ?? "";
+      const message =
+        (e instanceof Error ? e.message : String(e)).split("\n")[0] ?? "";
       urls.push({ url: targetUrl, error: message });
       await route.abort("failed");
       return;
@@ -154,7 +148,13 @@ export async function openPage(
     // URLs captured here are added to preInspectedUrls so that the
     // page.on("response") listener can skip them and avoid duplicates.
     const firstResponse = response;
-    for (let hop = 0; hop < MAX_REDIRECT_HOPS && response.status() >= 300 && response.status() < 400; hop++) {
+    for (
+      let hop = 0;
+      hop < MAX_REDIRECT_HOPS &&
+      response.status() >= 300 &&
+      response.status() < 400;
+      hop++
+    ) {
       // Capture intermediate 3xx responses so their headers (e.g. server,
       // x-powered-by) are available for analysis even though the browser
       // never sees these responses directly.
@@ -190,9 +190,7 @@ export async function openPage(
         redirectHost &&
         !isSameHost(pageHost, redirectHost)
       ) {
-        logger.warn(
-          `Blocked cross-domain redirect: ${redirectUrl}`,
-        );
+        logger.warn(`Blocked cross-domain redirect: ${redirectUrl}`);
         blockedByRedirectPolicy = true;
         urls.push({ url: redirectUrl, error: "Blocked cross-domain redirect" });
         await route.abort("blockedbyclient");
@@ -207,7 +205,8 @@ export async function openPage(
       try {
         response = await route.fetch({ url: redirectUrl, maxRedirects: 0 });
       } catch (e) {
-        const message = (e instanceof Error ? e.message : String(e)).split("\n")[0] ?? "";
+        const message =
+          (e instanceof Error ? e.message : String(e)).split("\n")[0] ?? "";
         urls.push({ url: redirectUrl, error: message });
         await route.abort("failed");
         return;
@@ -233,19 +232,19 @@ export async function openPage(
   // in-progress body reads from being dropped.
   const pendingResponseWork = new Set<Promise<void>>();
 
-  page.on("request", () => {
+  const onRequest = () => {
     inFlightRequestCount++;
     lastNetworkActivityAt = Date.now();
-  });
-  page.on("requestfinished", () => {
+  };
+  const onRequestFinished = () => {
     inFlightRequestCount = Math.max(0, inFlightRequestCount - 1);
     lastNetworkActivityAt = Date.now();
-  });
-  page.on("requestfailed", () => {
+  };
+  const onRequestFailed = () => {
     inFlightRequestCount = Math.max(0, inFlightRequestCount - 1);
     lastNetworkActivityAt = Date.now();
-  });
-  page.on("response", (response) => {
+  };
+  const onResponse = (response: PlaywrightResponse) => {
     lastNetworkActivityAt = Date.now();
     const work = (async () => {
       const responseUrl = response.url();
@@ -253,7 +252,11 @@ export async function openPage(
 
       // Skip responses already captured by the pre-inspection loop to
       // avoid duplicates.
-      if (preInspectedUrls.has(responseUrl) && statusCode >= 300 && statusCode < 400) {
+      if (
+        preInspectedUrls.has(responseUrl) &&
+        statusCode >= 300 &&
+        statusCode < 400
+      ) {
         logger.debug(
           `Skipping already captured response [${colorizeStatusCode(statusCode)}] ${responseUrl}`,
         );
@@ -265,7 +268,10 @@ export async function openPage(
         `Received response [${colorizeStatusCode(statusCode)}] ${responseUrl}`,
       );
       const request = response.request();
-      if (request.isNavigationRequest() && request.frame() === page.mainFrame()) {
+      if (
+        request.isNavigationRequest() &&
+        request.frame() === page.mainFrame()
+      ) {
         urls.push({ url: responseUrl, status: statusCode });
       }
 
@@ -290,7 +296,11 @@ export async function openPage(
     work.finally(() => {
       pendingResponseWork.delete(work);
     });
-  });
+  };
+  page.on("request", onRequest);
+  page.on("requestfinished", onRequestFinished);
+  page.on("requestfailed", onRequestFailed);
+  page.on("response", onResponse);
 
   let timeoutOccurred = false;
   const navigationStartedAt = Date.now();
@@ -351,6 +361,15 @@ export async function openPage(
       }
     }
   }
+
+  // Detach network listeners so that the `responses` snapshot is frozen
+  // at this point. Subsequent activity from cookie/JS extraction (or any
+  // delayed in-flight responses) must not mutate the captured set, since
+  // those entries would not be awaited and could race with the return.
+  page.off("request", onRequest);
+  page.off("requestfinished", onRequestFinished);
+  page.off("requestfailed", onRequestFailed);
+  page.off("response", onResponse);
 
   logger.info(`${responses.length} responses captured`);
   if (result === "loaded") {


### PR DESCRIPTION
## Summary

- The page network listeners (`request` / `requestfinished` / `requestfailed` / `response`) were registered once and never detached, so any response arriving after `logger.info(\`${responses.length} responses captured\`)` would still mutate the `responses` array and push new promises onto `pendingResponseWork`.
- Detach all four listeners with `page.off` immediately after the idle-wait loop completes so the response snapshot is frozen at that point.
- Extract the handlers into named constants and alias-import Playwright's `Response` type as `PlaywrightResponse` to avoid colliding with the local `Response` type.

## Motivation

After the idle wait exits, the page context is still alive for `page.context().cookies()` and `page.evaluate(...)`. If a delayed response arrives during that window:

- The logged `responses.length` snapshot diverges from the array actually returned to the caller.
- No one awaits the body read (`response.text()`), so a late `push` may slip in after `return`, or an in-flight read may be dropped entirely.
- The behavior is inconsistent with the overall timeout enforcement added in #42.

## Test plan

- [x] `npm run build`
- [x] `npm run lint` (no errors in the changed files; pre-existing `dist/` warnings are unrelated)
- [x] `npm test` (278 passed / 1 skipped)
- [x] Added `off: vi.fn()` to the mocked `page` so the new detach calls are observable in tests