### PR TITLE
fix: tighten loose body patterns to reduce false positives

### DIFF
--- a/src/signatures/technologies/astra.test.ts
+++ b/src/signatures/technologies/astra.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { astraSignature } from "./astra.js";
+
+function createMockContext(
+  overrides: Partial<Pick<Context, "responses">> = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: { "content-type": "text/html" },
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("astraSignature", () => {
+  describe("body matching", () => {
+    it("detects Astra from astra-theme class", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<body class="astra-theme"></body>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, astraSignature);
+      expect(result).toBeDefined();
+    });
+
+    it("does not detect Astra from unrelated class substrings", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<div class="my-astra-theme-wrapper"></div>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, astraSignature);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("url matching", () => {
+    it("detects Astra from themes/astra JS URL with version", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/wp-content/themes/astra/assets/js/frontend.js?ver=3.0.0",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, astraSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "3.0.0")).toBe(true);
+    });
+  });
+});

--- a/src/signatures/technologies/astra.ts
+++ b/src/signatures/technologies/astra.ts
@@ -3,14 +3,15 @@ import { wordpressSignature } from "./wordpress.js";
 
 export const astraSignature: Signature = {
   name: "Astra",
-  description: "Astra is a fast, lightweight, and highly customizable WordPress Theme.",
+  description:
+    "Astra is a fast, lightweight, and highly customizable WordPress Theme.",
   rule: {
     confidence: "high",
     urls: [
       "themes/astra\\S*\\.js(?:\\?ver=([0-9.]+))?",
       "astra\\S*\\.css(?:\\?ver=([0-9.]+))?",
     ],
-    bodies: ["astra-theme", "astra-"],
+    bodies: ["(?<![\\w-])astra-theme(?![\\w-])"],
   },
   impliedSoftwares: [wordpressSignature.name],
 };

--- a/src/signatures/technologies/helix_ultimate.test.ts
+++ b/src/signatures/technologies/helix_ultimate.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { helixUltimateSignature } from "./helix_ultimate.js";
+
+function createMockContext(
+  overrides: Partial<Pick<Context, "responses">> = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: { "content-type": "text/html" },
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("helixUltimateSignature", () => {
+  describe("body matching", () => {
+    it("detects Helix Ultimate from sp-header class", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<header class="sp-header"></header>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, helixUltimateSignature);
+      expect(result).toBeDefined();
+    });
+
+    it("detects Helix Ultimate from helix-ultimate class", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<body class="helix-ultimate"></body>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, helixUltimateSignature);
+      expect(result).toBeDefined();
+    });
+
+    it("does not detect Helix Ultimate from unrelated hyphen-suffixed names", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<div class="group-sp-header-item my-helix-ultimate-v2"></div>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, helixUltimateSignature);
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/src/signatures/technologies/helix_ultimate.ts
+++ b/src/signatures/technologies/helix_ultimate.ts
@@ -7,8 +7,8 @@ export const helixUltimateSignature: Signature = {
   rule: {
     confidence: "high",
     bodies: [
-      "sp-header",
-      "helix-ultimate",
+      "(?<![\\w-])sp-header(?![\\w-])",
+      "(?<![\\w-])helix-ultimate(?![\\w-])",
     ],
   },
   impliedSoftwares: [joomlaSignature.name],

--- a/src/signatures/technologies/jss.test.ts
+++ b/src/signatures/technologies/jss.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { jssSignature } from "./jss.js";
+
+function createMockContext(
+  overrides: Partial<Pick<Context, "responses">> = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: { "content-type": "text/html" },
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("jssSignature", () => {
+  describe("body matching", () => {
+    it("detects JSS from data-jss attribute", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<style data-jss="">.foo{}</style>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, jssSignature);
+      expect(result).toBeDefined();
+    });
+
+    it("does not detect JSS from unrelated hyphenated attribute names", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<div class="my-data-jss-wrapper" other-data-jss-x="y"></div>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, jssSignature);
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/src/signatures/technologies/jss.ts
+++ b/src/signatures/technologies/jss.ts
@@ -2,11 +2,10 @@ import type { Signature } from "../_types.js";
 
 export const jssSignature: Signature = {
   name: "JSS",
-  description: "JSS is an authoring tool for CSS which allows you to use JavaScript to describe styles in a declarative, conflict-free and reusable way.",
+  description:
+    "JSS is an authoring tool for CSS which allows you to use JavaScript to describe styles in a declarative, conflict-free and reusable way.",
   rule: {
     confidence: "high",
-    bodies: [
-      "data-jss",
-    ],
+    bodies: ["(?<![\\w-])data-jss(?![\\w-])"],
   },
 };

--- a/src/signatures/technologies/lite_youtube_embed.test.ts
+++ b/src/signatures/technologies/lite_youtube_embed.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { liteYoutubeEmbedSignature } from "./lite_youtube_embed.js";
+
+function createMockContext(
+  overrides: Partial<Pick<Context, "responses">> = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: { "content-type": "text/html" },
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("liteYoutubeEmbedSignature", () => {
+  describe("body matching", () => {
+    it("detects lite-youtube-embed from <lite-youtube> element with attrs", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<lite-youtube videoid="abcd1234"></lite-youtube>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, liteYoutubeEmbedSignature);
+      expect(result).toBeDefined();
+    });
+
+    it("detects lite-youtube-embed from self-closing element", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: "<lite-youtube>fallback</lite-youtube>",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, liteYoutubeEmbedSignature);
+      expect(result).toBeDefined();
+    });
+
+    it("does not detect lite-youtube-embed from text mentions or class names", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<div class="lite-youtube-wrapper">See lite-youtube in docs.</div>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, liteYoutubeEmbedSignature);
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/src/signatures/technologies/lite_youtube_embed.test.ts
+++ b/src/signatures/technologies/lite_youtube_embed.test.ts
@@ -46,7 +46,7 @@ describe("liteYoutubeEmbedSignature", () => {
       expect(result).toBeDefined();
     });
 
-    it("detects lite-youtube-embed from self-closing element", () => {
+    it("detects lite-youtube-embed from bare opening tag without attrs", () => {
       const context = createMockContext({
         responses: [
           createMockResponse({

--- a/src/signatures/technologies/lite_youtube_embed.ts
+++ b/src/signatures/technologies/lite_youtube_embed.ts
@@ -2,11 +2,10 @@ import type { Signature } from "../_types.js";
 
 export const liteYoutubeEmbedSignature: Signature = {
   name: "lite-youtube-embed",
-  description: "The lite-youtube-embed technique renders the YouTube video inside the IFRAME tag only when the play button in clicked thus improving the core web vitals score of your website.",
+  description:
+    "The lite-youtube-embed technique renders the YouTube video inside the IFRAME tag only when the play button in clicked thus improving the core web vitals score of your website.",
   rule: {
     confidence: "high",
-    bodies: [
-      "lite-youtube",
-    ],
+    bodies: ["<lite-youtube[\\s>]"],
   },
 };

--- a/src/signatures/technologies/lite_youtube_embed.ts
+++ b/src/signatures/technologies/lite_youtube_embed.ts
@@ -3,7 +3,7 @@ import type { Signature } from "../_types.js";
 export const liteYoutubeEmbedSignature: Signature = {
   name: "lite-youtube-embed",
   description:
-    "The lite-youtube-embed technique renders the YouTube video inside the IFRAME tag only when the play button in clicked thus improving the core web vitals score of your website.",
+    "The lite-youtube-embed technique renders the YouTube video inside the IFRAME tag only when the play button is clicked, thus improving the core web vitals score of your website.",
   rule: {
     confidence: "high",
     bodies: ["<lite-youtube[\\s>]"],

--- a/src/signatures/technologies/neve.test.ts
+++ b/src/signatures/technologies/neve.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { neveSignature } from "./neve.js";
+
+function createMockContext(
+  overrides: Partial<Pick<Context, "responses">> = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: { "content-type": "text/html" },
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("neveSignature", () => {
+  describe("body matching", () => {
+    it("detects Neve from neve-theme class", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<body class="neve-theme"></body>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, neveSignature);
+      expect(result).toBeDefined();
+    });
+
+    it("detects Neve from neve*.css reference", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<link rel="stylesheet" href="/wp-content/themes/neve/style.min.css">',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, neveSignature);
+      expect(result).toBeDefined();
+    });
+
+    it("does not detect Neve from unrelated hyphen-suffixed class names", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<div class="my-neve-theme-wrapper"></div>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, neveSignature);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("url matching", () => {
+    it("detects Neve from themes/neve JS URL with version", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/wp-content/themes/neve/assets/js/frontend.js?ver=3.5.0",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, neveSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "3.5.0")).toBe(true);
+    });
+  });
+});

--- a/src/signatures/technologies/neve.ts
+++ b/src/signatures/technologies/neve.ts
@@ -8,7 +8,7 @@ export const neveSignature: Signature = {
   rule: {
     confidence: "high",
     urls: ["themes/neve\\S*\\.js(?:\\?ver=([0-9.]+))?"],
-    bodies: ["neve\\S*\\.css", "neve-theme"],
+    bodies: ["neve\\S*\\.css", "(?<![\\w-])neve-theme(?![\\w-])"],
   },
   impliedSoftwares: [wordpressSignature.name],
 };

--- a/src/signatures/technologies/styled_components.test.ts
+++ b/src/signatures/technologies/styled_components.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { styledComponentsSignature } from "./styled_components.js";
+
+function createMockContext(
+  overrides: Partial<Pick<Context, "responses">> = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: { "content-type": "text/html" },
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("styledComponentsSignature", () => {
+  describe("body matching", () => {
+    it("detects styled-components from data-styled attribute", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<style data-styled="active">.sc-abc{}</style>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, styledComponentsSignature);
+      expect(result).toBeDefined();
+    });
+
+    it("detects styled-components from sc-component-id attribute", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<div sc-component-id="Button-abc123"></div>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, styledComponentsSignature);
+      expect(result).toBeDefined();
+    });
+
+    it("does not detect styled-components from unrelated hyphenated names", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<div my-data-styled-attr="x" class="prefix-sc-component-id-wrap"></div>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, styledComponentsSignature);
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/src/signatures/technologies/styled_components.ts
+++ b/src/signatures/technologies/styled_components.ts
@@ -7,7 +7,10 @@ export const styledComponentsSignature: Signature = {
     "Styled components is a CSS-in-JS styling framework that uses tagged template literals in JavaScript.",
   rule: {
     confidence: "high",
-    bodies: ["data-styled", "sc-component-id"],
+    bodies: [
+      "(?<![\\w-])data-styled(?![\\w-])",
+      "(?<![\\w-])sc-component-id(?![\\w-])",
+    ],
     javascriptVariables: {
       styled: "",
     },

--- a/src/signatures/technologies/tailwind_css.test.ts
+++ b/src/signatures/technologies/tailwind_css.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { tailwindCssSignature } from "./tailwind_css.js";
+
+function createMockContext(
+  overrides: Partial<Pick<Context, "responses">> = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: { "content-type": "text/html" },
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("tailwindCssSignature", () => {
+  describe("body matching", () => {
+    it("detects Tailwind from --tw-* CSS custom properties", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: ".foo{--tw-rotate: 45deg; transform: rotate(var(--tw-rotate));}",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, tailwindCssSignature);
+      expect(result).toBeDefined();
+    });
+
+    it("detects Tailwind from CDN link with version", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.0/base.min.css">',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, tailwindCssSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "3.4.0")).toBe(true);
+    });
+
+    it("detects Tailwind from href containing 'tailwind'", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<link rel="stylesheet" href="/assets/tailwind.min.css">',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, tailwindCssSignature);
+      expect(result).toBeDefined();
+    });
+
+    it("does not detect Tailwind from a generic stylesheet link", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<link rel="stylesheet" id="wp-block-library-css" href="/assets/block-library.css">',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, tailwindCssSignature);
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/src/signatures/technologies/tailwind_css.ts
+++ b/src/signatures/technologies/tailwind_css.ts
@@ -8,14 +8,11 @@ export const tailwindCssSignature: Signature = {
     bodies: [
       "--tw-(?:rotate|translate|space-x|text-opacity|border-opacity)",
       "href[^>]+tailwindcss[@|/](?:\\^)?([\\d.]+)(?:/[a-z]+)?/(?:tailwind|base|components|utilities)(?:\\.min)?\\.css",
-      "rel[^>]+stylesheet",
       "href[^>]+tailwind",
     ],
-    urls: [
-      "\\.tailwindcss(?:tailwind-config-cdn)?\\.(?:com|js)",
-    ],
+    urls: ["\\.tailwindcss(?:tailwind-config-cdn)?\\.(?:com|js)"],
     javascriptVariables: {
-      "tailwind": "",
+      tailwind: "",
     },
   },
 };

--- a/src/signatures/technologies/tdesign.test.ts
+++ b/src/signatures/technologies/tdesign.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { tdesignSignature } from "./tdesign.js";
+
+function createMockContext(
+  overrides: Partial<Pick<Context, "responses">> = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: { "content-type": "text/html" },
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("tdesignSignature", () => {
+  describe("body matching", () => {
+    it("detects TDesign from t-button__text class", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<div class="t-button__text">Click</div>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, tdesignSignature);
+      expect(result).toBeDefined();
+    });
+
+    it("detects TDesign from t-layout class", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<section class="t-layout"></section>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, tdesignSignature);
+      expect(result).toBeDefined();
+    });
+
+    it("does not detect TDesign from unrelated suffixed class names", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<article class="post-layout post-button__text"></article>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, tdesignSignature);
+      expect(result).toBeUndefined();
+    });
+
+    it("does not detect TDesign from hyphen-prefixed class names", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<div class="post-t-layout-wrapper"></div>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, tdesignSignature);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("url matching", () => {
+    it("detects TDesign from tdesign.gtimg.com CDN", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://tdesign.gtimg.com/cdn/tdesign.min.css",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, tdesignSignature);
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/src/signatures/technologies/tdesign.ts
+++ b/src/signatures/technologies/tdesign.ts
@@ -2,15 +2,14 @@ import type { Signature } from "../_types.js";
 
 export const tdesignSignature: Signature = {
   name: "TDesign",
-  description: "TDesign launched by Tencent contains rich and reusable design component resources, such as color system, text system, motion design, etc.",
+  description:
+    "TDesign launched by Tencent contains rich and reusable design component resources, such as color system, text system, motion design, etc.",
   rule: {
     confidence: "high",
     bodies: [
-      "t-button__text",
-      "t-layout",
+      "(?<![\\w-])t-button__text(?![\\w-])",
+      "(?<![\\w-])t-layout(?![\\w-])",
     ],
-    urls: [
-      "tdesign\\.gtimg\\.com/",
-    ],
+    urls: ["tdesign\\.gtimg\\.com/"],
   },
 };

--- a/src/signatures/technologies/vuetify.test.ts
+++ b/src/signatures/technologies/vuetify.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { vuetifySignature } from "./vuetify.js";
+
+function createMockContext(
+  overrides: Partial<Pick<Context, "responses">> = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: { "content-type": "text/html" },
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("vuetifySignature", () => {
+  describe("body matching", () => {
+    it("detects Vuetify from v-application class", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<div class="v-application"></div>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, vuetifySignature);
+      expect(result).toBeDefined();
+    });
+
+    it("detects Vuetify from vuetify-theme-stylesheet id", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<style id="vuetify-theme-stylesheet">...</style>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, vuetifySignature);
+      expect(result).toBeDefined();
+    });
+
+    it("does not detect Vuetify from unrelated suffixed class names", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<div class="post-v-application-wrapper"></div>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, vuetifySignature);
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/src/signatures/technologies/vuetify.ts
+++ b/src/signatures/technologies/vuetify.ts
@@ -3,13 +3,11 @@ import { vueJsSignature } from "./vue_js.js";
 
 export const vuetifySignature: Signature = {
   name: "Vuetify",
-  description: "Vuetify is a reusable semantic component framework for Vue.js that aims to provide clean, semantic and reusable components.",
+  description:
+    "Vuetify is a reusable semantic component framework for Vue.js that aims to provide clean, semantic and reusable components.",
   rule: {
     confidence: "high",
-    bodies: [
-      "vuetify-theme-stylesheet",
-      "v-application",
-    ],
+    bodies: ["vuetify-theme-stylesheet", "(?<![\\w-])v-application(?![\\w-])"],
   },
   impliedSoftwares: [vueJsSignature.name],
 };

--- a/src/signatures/technologies/wp_royal_ashe.test.ts
+++ b/src/signatures/technologies/wp_royal_ashe.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { wpRoyalAsheSignature } from "./wp_royal_ashe.js";
+
+function createMockContext(
+  overrides: Partial<Pick<Context, "responses">> = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: { "content-type": "text/html" },
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("wpRoyalAsheSignature", () => {
+  describe("body matching", () => {
+    it("detects WP-Royal Ashe from ashe-style-css id", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<link rel="stylesheet" id="ashe-style-css" href="/style.css">',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, wpRoyalAsheSignature);
+      expect(result).toBeDefined();
+    });
+
+    it("does not detect WP-Royal Ashe from unrelated hyphen-suffixed names", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<div id="my-ashe-style-css-wrapper"></div>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, wpRoyalAsheSignature);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("url matching", () => {
+    it("detects WP-Royal Ashe from themes/ashe path", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/wp-content/themes/ashe/style.css",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, wpRoyalAsheSignature);
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/src/signatures/technologies/wp_royal_ashe.ts
+++ b/src/signatures/technologies/wp_royal_ashe.ts
@@ -3,18 +3,15 @@ import { wordpressSignature } from "./wordpress.js";
 
 export const wpRoyalAsheSignature: Signature = {
   name: "WP-Royal Ashe",
-  description: "WP-Royal Ashe is a personal and multi-author WordPress blog theme.",
+  description:
+    "WP-Royal Ashe is a personal and multi-author WordPress blog theme.",
   rule: {
     confidence: "high",
-    bodies: [
-      "ashe-style-css",
-    ],
-    urls: [
-      "/wp-content/themes/ashe(?:-pro-premium)?/",
-    ],
+    bodies: ["(?<![\\w-])ashe-style-css(?![\\w-])"],
+    urls: ["/wp-content/themes/ashe(?:-pro-premium)?/"],
     javascriptVariables: {
-      "ashePreloader": "",
-      "asheStickySidebar": "",
+      ashePreloader: "",
+      asheStickySidebar: "",
     },
   },
   impliedSoftwares: [wordpressSignature.name],


### PR DESCRIPTION
## Summary

- Several signatures used unanchored short class-name or attribute substrings in their body regex, causing detections on unrelated sites. For example, on a WordPress site that uses neither Tailwind CSS nor TDesign, both were incorrectly detected because:
  - Tailwind's `rel[^>]+stylesheet` matched any `<link rel="stylesheet">` tag.
  - TDesign's `t-layout` matched `post-layout` as a substring.
- Tighten 10 high-risk signatures by adding word/hyphen boundary lookarounds (`(?<![\w-])...(?![\w-])`) around loose body patterns, or by replacing them with more specific shapes:
  - **TDesign**: anchor `t-button__text` and `t-layout`.
  - **Tailwind CSS**: drop the generic `rel[^>]+stylesheet` pattern.
  - **Vuetify**: anchor `v-application`.
  - **Helix Ultimate**: anchor `sp-header` and `helix-ultimate`.
  - **Astra**: remove the bare `astra-` prefix pattern; anchor `astra-theme`.
  - **styled-components**: anchor `data-styled` and `sc-component-id`.
  - **JSS**: anchor `data-jss`.
  - **lite-youtube-embed**: replace `lite-youtube` substring with the `<lite-youtube` custom element shape.
  - **Neve**: anchor `neve-theme`.
  - **WP-Royal Ashe**: anchor `ashe-style-css`.
- Add unit tests for each of the 10 signatures using `applySignature`, covering both positive matches (realistic HTML / CDN URLs) and the previously-false-positive negative case (e.g. `post-layout`, generic stylesheet link, `my-*-wrapper` substrings).

## Test plan

- [x] `npm run build` passes.
- [x] `npm test` passes (321 tests passed, up from 288; +33 new tests across 10 new test files).
- [x] Each new test file exercises both positive and negative cases for the tightened regex.