### PR TITLE
fix: correct signature names for ASP.NET and Yaws

### DIFF
--- a/src/signatures/index.ts
+++ b/src/signatures/index.ts
@@ -13,7 +13,7 @@ import { mysqlSignature } from "./technologies/mysql.js";
 import { corejsSignature } from "./technologies/corejs.js";
 import { jqueryCookieSignature } from "./technologies/jquery_cookie.js";
 import { slickSignature } from "./technologies/slick.js";
-import { yawsHttpServerSignature } from "./technologies/yaws.js";
+import { yawsSignature } from "./technologies/yaws.js";
 import { bootstrapSignature } from "./technologies/bootstrap.js";
 import { jqueryUiSignature } from "./technologies/jquery_ui.js";
 import { jqueryMigrateSignature } from "./technologies/jquery_migrate.js";
@@ -609,7 +609,7 @@ export const signatures: Signature[] = [
   yuiSignature,
   asciidoctorSignature,
   yoastSeoSignature,
-  yawsHttpServerSignature,
+  yawsSignature,
   mustacheSignature,
   zurbFoundationSignature,
   windowsServerSignature,

--- a/src/signatures/index.ts
+++ b/src/signatures/index.ts
@@ -18,7 +18,7 @@ import { bootstrapSignature } from "./technologies/bootstrap.js";
 import { jqueryUiSignature } from "./technologies/jquery_ui.js";
 import { jqueryMigrateSignature } from "./technologies/jquery_migrate.js";
 import { swiperSignature } from "./technologies/swiper.js";
-import { microsoftAspSignature } from "./technologies/microsoft_asp.js";
+import { aspNetSignature } from "./technologies/asp_net.js";
 import { microsoftIisSignature } from "./technologies/microsoft_iis.js";
 import { gsapSignature } from "./technologies/gsap.js";
 import { contactForm7Signature } from "./technologies/contact_form_7.js";
@@ -556,7 +556,7 @@ export const signatures: Signature[] = [
   perlSignature,
   pixiJsSignature,
   microsoftHttpApiSignature,
-  microsoftAspSignature,
+  aspNetSignature,
   microsoftIisSignature,
   modernizrSignature,
   mysqlSignature,

--- a/src/signatures/technologies/asp_net.ts
+++ b/src/signatures/technologies/asp_net.ts
@@ -1,7 +1,7 @@
 import type { Signature } from "../_types.js";
 
-export const microsoftAspSignature: Signature = {
-  name: "Microsoft ASP",
+export const aspNetSignature: Signature = {
+  name: "ASP.NET",
   description:
     "ASP.NET is an open-source, server-side web-application framework designed for web development to produce dynamic web pages.",
   cpe: "cpe:/a:microsoft:asp.net",

--- a/src/signatures/technologies/blazor.ts
+++ b/src/signatures/technologies/blazor.ts
@@ -1,5 +1,5 @@
 import type { Signature } from "../_types.js";
-import { microsoftAspSignature } from "./microsoft_asp.js";
+import { aspNetSignature } from "./asp_net.js";
 
 export const blazorSignature: Signature = {
   name: "Blazor",
@@ -11,5 +11,5 @@ export const blazorSignature: Signature = {
       "blazor\\.webassembly\\.js",
     ],
   },
-  impliedSoftwares: [microsoftAspSignature.name],
+  impliedSoftwares: [aspNetSignature.name],
 };

--- a/src/signatures/technologies/kestrel.ts
+++ b/src/signatures/technologies/kestrel.ts
@@ -1,5 +1,5 @@
 import type { Signature } from "../_types.js";
-import { microsoftAspSignature } from "./microsoft_asp.js";
+import { aspNetSignature } from "./asp_net.js";
 
 export const kestrelSignature: Signature = {
   name: "Kestrel",
@@ -10,5 +10,5 @@ export const kestrelSignature: Signature = {
       "Server": "^Kestrel",
     },
   },
-  impliedSoftwares: [microsoftAspSignature.name],
+  impliedSoftwares: [aspNetSignature.name],
 };

--- a/src/signatures/technologies/outlook_web_app.ts
+++ b/src/signatures/technologies/outlook_web_app.ts
@@ -1,5 +1,5 @@
 import type { Signature } from "../_types.js";
-import { microsoftAspSignature } from "./microsoft_asp.js";
+import { aspNetSignature } from "./asp_net.js";
 
 export const outlookWebAppSignature: Signature = {
   name: "Outlook Web App",
@@ -20,5 +20,5 @@ export const outlookWebAppSignature: Signature = {
       "IsOwaPremiumBrowser": "",
     },
   },
-  impliedSoftwares: [microsoftAspSignature.name],
+  impliedSoftwares: [aspNetSignature.name],
 };

--- a/src/signatures/technologies/sitecore.ts
+++ b/src/signatures/technologies/sitecore.ts
@@ -1,5 +1,5 @@
 import type { Signature } from "../_types.js";
-import { microsoftAspSignature } from "./microsoft_asp.js";
+import { aspNetSignature } from "./asp_net.js";
 
 export const sitecoreSignature: Signature = {
   name: "Sitecore",
@@ -22,5 +22,5 @@ export const sitecoreSignature: Signature = {
       "SitecoreUtilities": "",
     },
   },
-  impliedSoftwares: [microsoftAspSignature.name],
+  impliedSoftwares: [aspNetSignature.name],
 };

--- a/src/signatures/technologies/yaws.ts
+++ b/src/signatures/technologies/yaws.ts
@@ -1,9 +1,9 @@
 import type { Signature } from "../_types.js";
 
-export const yawsHttpServerSignature: Signature = {
+export const yawsSignature: Signature = {
   name: "Yaws",
   description:
-    "Yaws is a HTTP high perfomance 1.1 webserver particularly well suited for dynamic-content web applications.",
+    "Yaws is a HTTP high performance 1.1 webserver particularly well suited for dynamic-content web applications.",
   cpe: "cpe:/a:yaws:yaws",
   rule: {
     confidence: "high",

--- a/src/signatures/technologies/yaws.ts
+++ b/src/signatures/technologies/yaws.ts
@@ -1,7 +1,7 @@
 import type { Signature } from "../_types.js";
 
 export const yawsHttpServerSignature: Signature = {
-  name: "Yaws HTTP Server",
+  name: "Yaws",
   description:
     "Yaws is a HTTP high perfomance 1.1 webserver particularly well suited for dynamic-content web applications.",
   cpe: "cpe:/a:yaws:yaws",


### PR DESCRIPTION
## Summary
- Rename signature `Microsoft ASP` → `ASP.NET`. The signature actually detects ASP.NET (via `.aspx`, `__VIEWSTATE`, `.AspNetCore`, etc.), not Classic ASP, so the old name was misleading.
- Rename signature `Yaws HTTP Server` → `Yaws` to match the official project name and drop the redundant "HTTP Server" suffix.
- Rename file/symbol accordingly: `microsoft_asp.ts` → `asp_net.ts`, `microsoftAspSignature` → `aspNetSignature`. Updated all `impliedSoftwares` references in `blazor.ts`, `kestrel.ts`, `outlook_web_app.ts`, and `sitecore.ts`.

## Motivation
Cross-referencing whopper's signature names against wappalyzer surfaced these two naming inconsistencies. Aligning them improves interoperability and removes a factually incorrect label (`Microsoft ASP` implied Classic ASP).

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Existing test suite passes
- [x] No remaining references to the old names/symbols (`Microsoft ASP`, `Yaws HTTP Server`, `microsoftAspSignature`, `microsoft_asp`)