### PR TITLE
fix: correct invalid CPEs in signatures

### DIFF
--- a/src/commands/detect_utils.test.ts
+++ b/src/commands/detect_utils.test.ts
@@ -27,7 +27,7 @@ describe("colorizeConfidence", () => {
 
 describe("makeDetectCommandOutput", () => {
   const baseSignatures: Signature[] = [
-    { name: "nginx", description: "Web server", cpe: "cpe:2.3:a:nginx:nginx" },
+    { name: "nginx", description: "Web server", cpe: "cpe:2.3:a:f5:nginx" },
     { name: "jQuery", description: "JavaScript library" },
     { name: "PHP", description: "Programming language" },
     {
@@ -80,7 +80,7 @@ describe("makeDetectCommandOutput", () => {
       const result = makeDetectCommandOutput([], detections, baseSignatures);
 
       expect(result.detectedSoftwares[0]!.cpe).toBe(
-        "cpe:2.3:a:nginx:nginx:1.20.0",
+        "cpe:2.3:a:f5:nginx:1.20.0",
       );
     });
 
@@ -286,7 +286,7 @@ describe("makeDetectCommandOutput", () => {
 
     it("should create separate entries when same software has different versions", () => {
       const signatures: Signature[] = [
-        { name: "nginx", cpe: "cpe:2.3:a:nginx:nginx" },
+        { name: "nginx", cpe: "cpe:2.3:a:f5:nginx" },
       ];
 
       const detections: Detection[] = [
@@ -323,13 +323,13 @@ describe("makeDetectCommandOutput", () => {
 
       const v1180 = nginxEntries.find((s) => s.version === "1.18.0");
       expect(v1180).toBeDefined();
-      expect(v1180!.cpe).toBe("cpe:2.3:a:nginx:nginx:1.18.0");
+      expect(v1180!.cpe).toBe("cpe:2.3:a:f5:nginx:1.18.0");
       expect(v1180!.confidence).toBe("medium");
       expect(v1180!.evidences).toHaveLength(1);
 
       const v1200 = nginxEntries.find((s) => s.version === "1.20.0");
       expect(v1200).toBeDefined();
-      expect(v1200!.cpe).toBe("cpe:2.3:a:nginx:nginx:1.20.0");
+      expect(v1200!.cpe).toBe("cpe:2.3:a:f5:nginx:1.20.0");
       expect(v1200!.confidence).toBe("high");
       expect(v1200!.evidences).toHaveLength(1);
     });

--- a/src/signatures/technologies/nginx.ts
+++ b/src/signatures/technologies/nginx.ts
@@ -4,7 +4,7 @@ export const nginxSignature: Signature = {
   name: "Nginx",
   description:
     "An HTTP web server, reverse proxy, content cache, load balancer, TCP/UDP proxy server, and mail proxy server.",
-  cpe: "cpe:/a:nginx:nginx",
+  cpe: "cpe:/a:f5:nginx",
   rule: {
     confidence: "high",
     headers: {

--- a/src/signatures/technologies/salesforce.ts
+++ b/src/signatures/technologies/salesforce.ts
@@ -3,7 +3,6 @@ import type { Signature } from "../_types.js";
 export const salesforceSignature: Signature = {
   name: "Salesforce",
   description: "Salesforce is a cloud computing service software (SaaS) that specializes in customer relationship management (CRM).",
-  cpe: "cpe:/a:salesforce:salesforce",
   rule: {
     confidence: "high",
     cookies: {

--- a/src/signatures/technologies/sitecore.ts
+++ b/src/signatures/technologies/sitecore.ts
@@ -4,7 +4,6 @@ import { microsoftAspSignature } from "./microsoft_asp.js";
 export const sitecoreSignature: Signature = {
   name: "Sitecore",
   description: "Sitecore provides web content management, and multichannel marketing automation software.",
-  cpe: "cpe:/a:sitecore:sitecore",
   rule: {
     confidence: "high",
     cookies: {


### PR DESCRIPTION
## Summary
- Fix incorrect CPE for Nginx: `cpe:/a:nginx:nginx` → `cpe:/a:f5:nginx` (the vendor registered in the NVD CPE dictionary is `f5`)
- Remove invalid CPEs from Salesforce and Sitecore signatures (no matching entries exist in the NVD CPE dictionary)
- Update test fixtures in `detect_utils.test.ts` to match the new Nginx CPE

## Test plan
- [x] `npx vitest run` passes
- [x] `npx tsc --noEmit` passes
- [x] Manually verify the Nginx CPE resolves against the NVD CPE dictionary
