### PR TITLE
fix: prevent cross-resource version miscapture in signatures

### DIFF
--- a/src/signatures/technologies/animate_css.test.ts
+++ b/src/signatures/technologies/animate_css.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { animateCssSignature } from "./animate_css.js";
+
+function createMockContext(
+  overrides: Partial<Pick<Context, "responses">> = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: { "content-type": "text/css" },
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("animateCssSignature", () => {
+  describe("URL matching", () => {
+    it("captures version from cdnjs (animate.css/version/) URL", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://cdn.example.com/ajax/libs/animate.css/4.1.1/animate.min.css",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, animateCssSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "4.1.1")).toBe(true);
+    });
+
+    it("captures version from npm animate.css@version path", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://cdn.example.com/npm/animate.css@4.1.1/animate.min.css",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, animateCssSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "4.1.1")).toBe(true);
+    });
+
+    it("does not capture version from an unrelated parent directory", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/libs/5.6.7/animate.min.css",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, animateCssSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.every((e) => e.version !== "5.6.7")).toBe(true);
+    });
+
+    it("detects self-hosted presence without version", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/css/animate.min.css",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, animateCssSignature);
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/src/signatures/technologies/animate_css.ts
+++ b/src/signatures/technologies/animate_css.ts
@@ -6,7 +6,10 @@ export const animateCssSignature: Signature = {
     "Animate.css is a ready-to-use library collection of CSS3 animation effects.",
   rule: {
     confidence: "high",
-    urls: ["(?:/([\\d.]+))?/animate\\.min\\.css"],
+    urls: [
+      "animate\\.css[/@]([\\d.]+)[^\"'\\s]*?animate(?:\\.min)?\\.css",
+      "/animate(?:\\.min)?\\.css",
+    ],
     bodies: ["animate__animated"],
   },
 };

--- a/src/signatures/technologies/bootstrap.test.ts
+++ b/src/signatures/technologies/bootstrap.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { bootstrapSignature } from "./bootstrap.js";
+
+function createMockContext(
+  overrides: Partial<Pick<Context, "responses">> = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: { "content-type": "text/html" },
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("bootstrapSignature", () => {
+  describe("body matching", () => {
+    it("captures version from bootstrap.min.css reference", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<link href="/css/bootstrap-4.0.0.min.css">',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, bootstrapSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "4.0.0")).toBe(true);
+    });
+
+    it("captures version from bootstrap.min.js reference", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<script src="/js/bootstrap-4.0.0.min.js"></script>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, bootstrapSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "4.0.0")).toBe(true);
+    });
+
+    it("does not miscapture popper.js version when bootstrap CSS and popper JS coexist", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<link rel="stylesheet" href="/css/bootstrap4.0.0-beta2.min.css"/><script src="/js/jquery-3.2.1.min.js"></script><script src="/js/popper-1.12.3.min.js"></script>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, bootstrapSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.every((e) => e.version !== "1.12.3")).toBe(true);
+      expect(result?.evidences?.every((e) => e.version !== "3.2.1")).toBe(true);
+    });
+
+    it("captures version from Bootstrap v header comment", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: "/*! Bootstrap v5.3.0 */",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, bootstrapSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "5.3.0")).toBe(true);
+    });
+  });
+});

--- a/src/signatures/technologies/bootstrap.ts
+++ b/src/signatures/technologies/bootstrap.ts
@@ -9,8 +9,8 @@ export const bootstrapSignature: Signature = {
     confidence: "high",
     bodies: [
       "Bootstrap v(\\d+\\.\\d+\\.\\d+)",
-      "bootstrap.*(\\d+\\.\\d+\\.\\d+)\\.min\\.css",
-      "bootstrap.*(\\d+\\.\\d+\\.\\d+)\\.min\\.js",
+      "bootstrap[^\"'\\s<>]*?(\\d+\\.\\d+\\.\\d+)[^\"'\\s<>]*?\\.min\\.css",
+      "bootstrap[^\"'\\s<>]*?(\\d+\\.\\d+\\.\\d+)[^\"'\\s<>]*?\\.min\\.js",
     ],
     javascriptVariables: {
       "bootstrap.Alert.VERSION": "(\\d+\\.\\d+\\.\\d+)",

--- a/src/signatures/technologies/firebase.test.ts
+++ b/src/signatures/technologies/firebase.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { firebaseSignature } from "./firebase.js";
+
+function createMockContext(
+  overrides: Partial<Pick<Context, "responses">> = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: { "content-type": "text/html" },
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("firebaseSignature", () => {
+  describe("URL matching", () => {
+    it("captures version from gstatic firebasejs URL", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://www.gstatic.com/firebasejs/9.22.0/firebase-app.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, firebaseSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "9.22.0")).toBe(true);
+    });
+
+    it("captures version from cdnjs firebase path", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://cdn.example.com/ajax/libs/firebase/8.10.1/firebase.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, firebaseSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "8.10.1")).toBe(true);
+    });
+
+    it("does not capture version from an unrelated parent directory", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/libs/5.6.7/firebase.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, firebaseSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.every((e) => e.version !== "5.6.7")).toBe(true);
+    });
+
+    it("detects self-hosted presence without version", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/js/firebase.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, firebaseSignature);
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/src/signatures/technologies/firebase.ts
+++ b/src/signatures/technologies/firebase.ts
@@ -11,9 +11,11 @@ export const firebaseSignature: Signature = {
       Vary: "x-fh-requested-host",
     },
     urls: [
-      "/(?:([\\d.]+)/)?firebase(?:\\.min)?\\.js",
+      "/firebase/([\\d.]+)/firebase(?:\\.min)?\\.js",
+      "firebase@([\\d.]+)[^\"'\\s]*?firebase(?:\\.min)?\\.js",
       "/firebasejs/([\\d.]+)/firebase",
       "\\.gstatic\\.com/firebasejs/([\\d\\.]+)/",
+      "/firebase(?:\\.min)?\\.js",
     ],
     javascriptVariables: {
       "firebase.SDK_VERSION": "([\\d.]+)$",

--- a/src/signatures/technologies/foogallery.test.ts
+++ b/src/signatures/technologies/foogallery.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { fooGallerySignature } from "./foogallery.js";
+
+function createMockContext(
+  overrides: Partial<Pick<Context, "responses">> = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: { "content-type": "text/html" },
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("fooGallerySignature", () => {
+  describe("body matching", () => {
+    it("captures version from FooGallery CSS link", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<link href="/wp-content/plugins/foogallery/assets/gallery.css?ver=2.3.1">',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, fooGallerySignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "2.3.1")).toBe(true);
+    });
+
+    it("does not miscapture version from a different plugin loaded after FooGallery", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<link href="/wp-content/plugins/foogallery/assets/gallery.css?ver=2.3.1"><link href="/wp-content/plugins/other-plugin/style.css?ver=9.9.9">',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, fooGallerySignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.every((e) => e.version !== "9.9.9")).toBe(true);
+      expect(result?.evidences?.some((e) => e.version === "2.3.1")).toBe(true);
+    });
+
+    it("detects presence when no version query is present", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<link href="/wp-content/plugins/foogallery/gallery.css">',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, fooGallerySignature);
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/src/signatures/technologies/foogallery.ts
+++ b/src/signatures/technologies/foogallery.ts
@@ -7,7 +7,7 @@ export const fooGallerySignature: Signature = {
   rule: {
     confidence: "high",
     bodies: [
-      "/wp-content/plugins/foogallery/.+\\.css(?:\\?ver=(\\d+(?:\\.\\d+)+))?",
+      "/wp-content/plugins/foogallery/[^\"'\\s<>]+\\.css(?:\\?ver=(\\d+(?:\\.\\d+)+))?",
     ],
     javascriptVariables: {
       FooGallery: "",

--- a/src/signatures/technologies/highlight_js.test.ts
+++ b/src/signatures/technologies/highlight_js.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { highlightSignature } from "./highlight_js.js";
+
+function createMockContext(
+  overrides: Partial<Pick<Context, "responses">> = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: { "content-type": "text/html" },
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("highlightSignature", () => {
+  describe("URL matching", () => {
+    it("captures full version from cdnjs URL", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://cdn.example.com/ajax/libs/highlight.js/11.9.0/highlight.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, highlightSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "11.9.0")).toBe(true);
+    });
+
+    it("captures version from cdn-release URL (highlightjs/cdn-release@version)", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://cdn.example.com/gh/highlightjs/cdn-release@11.9.0/build/highlight.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, highlightSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "11.9.0")).toBe(true);
+    });
+
+    it("does not capture version from unrelated parent directory", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/libs/5.6.7/highlight.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, highlightSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.every((e) => e.version !== "5.6.7")).toBe(true);
+    });
+
+    it("detects self-hosted presence without version", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/js/highlight.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, highlightSignature);
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/src/signatures/technologies/highlight_js.ts
+++ b/src/signatures/technologies/highlight_js.ts
@@ -5,7 +5,9 @@ export const highlightSignature: Signature = {
   rule: {
     confidence: "high",
     urls: [
-      "/(?:([\\d.])+/)?highlight(?:\\.min)?\\.js",
+      "highlight\\.?js[/@]([\\d.]+)[^\"'\\s]*?/highlight(?:\\.min)?\\.js",
+      "highlightjs/cdn-(?:assets|release)@([\\d.]+)[^\"'\\s]*?/highlight(?:\\.min)?\\.js",
+      "/highlight(?:\\.min)?\\.js",
     ],
     javascriptVariables: {
       "hljs.highlightBlock": "",

--- a/src/signatures/technologies/jquery_ui.test.ts
+++ b/src/signatures/technologies/jquery_ui.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { jqueryUiSignature } from "./jquery_ui.js";
+
+function createMockContext(
+  overrides: Partial<Pick<Context, "responses">> = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: { "content-type": "text/html" },
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("jqueryUiSignature", () => {
+  describe("URL matching", () => {
+    it("captures version from cdnjs (jqueryui) path", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://cdn.example.com/ajax/libs/jqueryui/1.13.2/jquery-ui.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, jqueryUiSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "1.13.2")).toBe(true);
+    });
+
+    it("captures version from code.jquery.com/ui path", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://code.jquery.com/ui/1.13.2/jquery-ui.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, jqueryUiSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "1.13.2")).toBe(true);
+    });
+
+    it("does not capture version from an unrelated parent directory", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/libs/5.6.7/jquery-ui/script.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, jqueryUiSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.every((e) => e.version !== "5.6.7")).toBe(true);
+    });
+
+    it("detects self-hosted jquery-ui.js presence", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/js/jquery-ui.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, jqueryUiSignature);
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/src/signatures/technologies/jquery_ui.ts
+++ b/src/signatures/technologies/jquery_ui.ts
@@ -10,7 +10,7 @@ export const jqueryUiSignature: Signature = {
     confidence: "high",
     urls: [
       "jquery-ui[./-]?(\\d+\\.\\d+\\.\\d+)?",
-      "(\\d+\\.\\d+\\.\\d+)?/jquery-ui",
+      "(?:jqueryui|code\\.jquery\\.com/ui)/(\\d+\\.\\d+\\.\\d+)/jquery-ui",
       "jquery-ui.*\\.js",
     ],
     javascriptVariables: {

--- a/src/signatures/technologies/jsrender.test.ts
+++ b/src/signatures/technologies/jsrender.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { jsrenderSignature } from "./jsrender.js";
+
+function createMockContext(
+  overrides: Partial<Pick<Context, "responses">> = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: { "content-type": "text/html" },
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("jsrenderSignature", () => {
+  describe("URL matching", () => {
+    it("captures version from cdnjs URL", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://cdn.example.com/ajax/libs/jsrender/1.0.14/jsrender.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, jsrenderSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "1.0.14")).toBe(true);
+    });
+
+    it("captures version from npm jsrender@version path", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://cdn.example.com/npm/jsrender@1.0.14/jsrender.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, jsrenderSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "1.0.14")).toBe(true);
+    });
+
+    it("does not capture version from an unrelated parent directory", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/libs/5.6.7/jsrender.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, jsrenderSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.every((e) => e.version !== "5.6.7")).toBe(true);
+    });
+
+    it("detects self-hosted presence without version", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/js/jsrender.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, jsrenderSignature);
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/src/signatures/technologies/jsrender.ts
+++ b/src/signatures/technologies/jsrender.ts
@@ -7,7 +7,8 @@ export const jsrenderSignature: Signature = {
   rule: {
     confidence: "high",
     urls: [
-      "([\\d\\.]+)?/jsrender(?:\\.min)?\\.js",
+      "jsrender[/@]([\\d.]+)[^\"'\\s]*?jsrender(?:\\.min)?\\.js",
+      "/jsrender(?:\\.min)?\\.js",
     ],
   },
   impliedSoftwares: [jsviewsSignature.name],

--- a/src/signatures/technologies/jsviews.test.ts
+++ b/src/signatures/technologies/jsviews.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { jsviewsSignature } from "./jsviews.js";
+
+function createMockContext(
+  overrides: Partial<Pick<Context, "responses">> = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: { "content-type": "text/html" },
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("jsviewsSignature", () => {
+  describe("URL matching", () => {
+    it("captures version from cdnjs URL", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://cdn.example.com/ajax/libs/jsviews/1.0.14/jsviews.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, jsviewsSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "1.0.14")).toBe(true);
+    });
+
+    it("captures version from npm jsviews@version path", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://cdn.example.com/npm/jsviews@1.0.14/jsviews.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, jsviewsSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "1.0.14")).toBe(true);
+    });
+
+    it("does not capture version from an unrelated parent directory", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/libs/5.6.7/jsviews.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, jsviewsSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.every((e) => e.version !== "5.6.7")).toBe(true);
+    });
+
+    it("detects self-hosted presence without version", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/js/jsviews.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, jsviewsSignature);
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/src/signatures/technologies/jsviews.ts
+++ b/src/signatures/technologies/jsviews.ts
@@ -7,7 +7,8 @@ export const jsviewsSignature: Signature = {
   rule: {
     confidence: "high",
     urls: [
-      "([\\d\\.]+)?/jsviews(?:\\.min)?\\.js",
+      "jsviews[/@]([\\d.]+)[^\"'\\s]*?jsviews(?:\\.min)?\\.js",
+      "/jsviews(?:\\.min)?\\.js",
     ],
   },
   impliedSoftwares: [jsobservableSignature.name, "JsRender"],

--- a/src/signatures/technologies/material_design_lite.test.ts
+++ b/src/signatures/technologies/material_design_lite.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { materialDesignLiteSignature } from "./material_design_lite.js";
+
+function createMockContext(
+  overrides: Partial<Pick<Context, "responses">> = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: { "content-type": "text/html" },
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("materialDesignLiteSignature", () => {
+  describe("URL matching", () => {
+    it("captures version from getmdl.io CDN", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://code.getmdl.io/1.3.0/material.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, materialDesignLiteSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "1.3.0")).toBe(true);
+    });
+
+    it("captures version from npm-style path (material-design-lite@version)", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://cdn.example.com/npm/material-design-lite@1.3.0/material.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, materialDesignLiteSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "1.3.0")).toBe(true);
+    });
+
+    it("does not capture version from unrelated parent directory", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/libs/5.6.7/material.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, materialDesignLiteSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.every((e) => e.version !== "5.6.7")).toBe(true);
+    });
+
+    it("detects self-hosted presence without version", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/js/material.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, materialDesignLiteSignature);
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/src/signatures/technologies/material_design_lite.ts
+++ b/src/signatures/technologies/material_design_lite.ts
@@ -9,7 +9,9 @@ export const materialDesignLiteSignature: Signature = {
       "<link[^>]* href=\"[^\"]*material(?:\\.[\\w]+-[\\w]+)?(?:\\.min)?\\.css",
     ],
     urls: [
-      "(?:/([\\d.]+))?/material(?:\\.min)?\\.js",
+      "(?:code\\.)?getmdl\\.io/([\\d.]+)/material(?:\\.min)?\\.js",
+      "material-design-lite[/@]([\\d.]+)[^\"'\\s]*?material(?:\\.min)?\\.js",
+      "/material(?:\\.min)?\\.js",
     ],
     javascriptVariables: {
       "MaterialIconToggle": "",

--- a/src/signatures/technologies/mathjax.test.ts
+++ b/src/signatures/technologies/mathjax.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { mathJaxSignature } from "./mathjax.js";
+
+function createMockContext(
+  overrides: Partial<Pick<Context, "responses">> = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: { "content-type": "text/html" },
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("mathJaxSignature", () => {
+  describe("URL matching", () => {
+    it("captures version from cdnjs URL", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://cdn.example.com/ajax/libs/mathjax/3.2.2/MathJax.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, mathJaxSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "3.2.2")).toBe(true);
+    });
+
+    it("does not capture version from an unrelated parent directory", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/libs/5.6.7/mathjax.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, mathJaxSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.every((e) => e.version !== "5.6.7")).toBe(true);
+    });
+
+    it("detects self-hosted presence without version", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/js/mathjax.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, mathJaxSignature);
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/src/signatures/technologies/mathjax.ts
+++ b/src/signatures/technologies/mathjax.ts
@@ -6,7 +6,10 @@ export const mathJaxSignature: Signature = {
     "MathJax is a cross-browser JavaScript library that displays mathematical notation in web browsers, using MathML, LaTeX and ASCIIMathML markup.",
   rule: {
     confidence: "high",
-    urls: ["([\\d.]+)?/mathjax\\.js"],
+    urls: [
+      "mathjax[/@]([\\d.]+)[^\"'\\s]*?/MathJax\\.js",
+      "/mathjax\\.js",
+    ],
     javascriptVariables: {
       MathJax: "",
       "MathJax.version": "^(.+)$",

--- a/src/signatures/technologies/mediawiki.test.ts
+++ b/src/signatures/technologies/mediawiki.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { mediaWikiSignature } from "./mediawiki.js";
+
+function createMockContext(
+  overrides: Partial<Pick<Context, "responses">> = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: { "content-type": "text/html" },
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("mediaWikiSignature", () => {
+  describe("body matching", () => {
+    it("captures clean version string from meta generator", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<meta name="generator" content="MediaWiki 1.39.0" />',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, mediaWikiSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "1.39.0")).toBe(true);
+    });
+
+    it("does not include trailing markup in captured version", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<meta name="generator" content="MediaWiki 1.39.0"/><meta name="robots" content="foo">',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, mediaWikiSignature);
+      expect(result).toBeDefined();
+      expect(
+        result?.evidences?.every(
+          (e) => e.version === undefined || !e.version.includes("<"),
+        ),
+      ).toBe(true);
+      expect(
+        result?.evidences?.every(
+          (e) => e.version === undefined || !e.version.includes(">"),
+        ),
+      ).toBe(true);
+    });
+
+    it("detects MediaWiki by body class", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<body class="mediawiki"></body>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, mediaWikiSignature);
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/src/signatures/technologies/mediawiki.ts
+++ b/src/signatures/technologies/mediawiki.ts
@@ -11,7 +11,7 @@ export const mediaWikiSignature: Signature = {
       "<body[^>]+class=\"mediawiki\"",
       "Powered by MediaWiki",
       "Special:WhatLinksHere",
-      "<meta[^>]+name=[\"']generator[\"'][^>]+content=[\"']MediaWiki ?(.+)",
+      "<meta[^>]+name=[\"']generator[\"'][^>]+content=[\"']MediaWiki ?([^\"']+)",
     ],
     javascriptVariables: {
       "mw.util.toggleToc": "",

--- a/src/signatures/technologies/metismenu.test.ts
+++ b/src/signatures/technologies/metismenu.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { metismenuSignature } from "./metismenu.js";
+
+function createMockContext(
+  overrides: Partial<Pick<Context, "responses">> = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: { "content-type": "text/html" },
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("metismenuSignature", () => {
+  describe("URL matching", () => {
+    it("captures version from cdnjs URL", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://cdn.example.com/ajax/libs/metisMenu/3.0.7/metisMenu.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, metismenuSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "3.0.7")).toBe(true);
+    });
+
+    it("captures version from metismenujs@version npm path", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://cdn.example.com/npm/metismenujs@3.0.7/dist/metismenujs.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, metismenuSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "3.0.7")).toBe(true);
+    });
+
+    it("does not treat cache-buster query string as version", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/js/metisMenu.min.js?20240101",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, metismenuSignature);
+      expect(result).toBeDefined();
+      expect(
+        result?.evidences?.every((e) => e.version !== "20240101"),
+      ).toBe(true);
+    });
+
+    it("detects self-hosted presence without version", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/js/metisMenu.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, metismenuSignature);
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/src/signatures/technologies/metismenu.ts
+++ b/src/signatures/technologies/metismenu.ts
@@ -7,7 +7,8 @@ export const metismenuSignature: Signature = {
   rule: {
     confidence: "high",
     urls: [
-      "(?:/|\\.)metisMenu(?:js)?(?:\\.min)?\\.js(?:\\?([\\d\\.]+))?",
+      "metismenu(?:js)?[/@]([\\d.]+)[^\"'\\s]*?metisMenu(?:js)?(?:\\.min)?\\.js",
+      "(?:/|\\.)metisMenu(?:js)?(?:\\.min)?\\.js",
     ],
     javascriptVariables: {
       "MetisMenu": "",

--- a/src/signatures/technologies/pure_css.test.ts
+++ b/src/signatures/technologies/pure_css.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { pureCssSignature } from "./pure_css.js";
+
+function createMockContext(
+  overrides: Partial<Pick<Context, "responses">> = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: { "content-type": "text/html" },
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("pureCssSignature", () => {
+  describe("body matching", () => {
+    it("captures full version from npm (purecss@version) link", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<link href="https://cdn.example.com/npm/purecss@2.0.6/build/pure-min.css">',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, pureCssSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "2.0.6")).toBe(true);
+    });
+
+    it("captures version from cdnjs (/pure/version/) link", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<link href="https://cdn.example.com/ajax/libs/pure/2.0.6/pure-min.css">',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, pureCssSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "2.0.6")).toBe(true);
+    });
+
+    it("detects self-hosted presence without version", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<link href="/css/pure-min.css">',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, pureCssSignature);
+      expect(result).toBeDefined();
+    });
+
+    it("detects presence via pure-u grid class", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<div class="pure-u-1-2"></div>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, pureCssSignature);
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/src/signatures/technologies/pure_css.ts
+++ b/src/signatures/technologies/pure_css.ts
@@ -6,7 +6,9 @@ export const pureCssSignature: Signature = {
   rule: {
     confidence: "high",
     bodies: [
-      "<link[^>]+(?:([\\d.])+/)?pure(?:-min)?\\.css",
+      "<link[^>]+purecss[/@]([\\d.]+)[^\"'\\s<>]*?pure(?:-min)?\\.css",
+      "<link[^>]+/pure/([\\d.]+)/pure(?:-min)?\\.css",
+      "<link[^>]+/pure(?:-min)?\\.css",
       "<div[^>]+class=\"[^\"]*pure-u-(?:sm-|md-|lg-|xl-)?\\d-\\d",
     ],
   },

--- a/src/signatures/technologies/recent_posts_widget_with_thumbnails.test.ts
+++ b/src/signatures/technologies/recent_posts_widget_with_thumbnails.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { recentPostsWidgetWithThumbnailsSignature } from "./recent_posts_widget_with_thumbnails.js";
+
+function createMockContext(
+  overrides: Partial<Pick<Context, "responses">> = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: { "content-type": "text/html" },
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("recentPostsWidgetWithThumbnailsSignature", () => {
+  describe("body matching", () => {
+    it("captures version from plugin CSS link", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<link href="/wp-content/plugins/recent-posts-widget-with-thumbnails/style.css?ver=8.0.1">',
+          }),
+        ],
+      });
+
+      const result = applySignature(
+        context,
+        recentPostsWidgetWithThumbnailsSignature,
+      );
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "8.0.1")).toBe(true);
+    });
+
+    it("does not miscapture version from an unrelated plugin loaded after", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<link href="/wp-content/plugins/recent-posts-widget-with-thumbnails/style.css?ver=8.0.1"><link href="/wp-content/plugins/other/style.css?ver=9.9.9">',
+          }),
+        ],
+      });
+
+      const result = applySignature(
+        context,
+        recentPostsWidgetWithThumbnailsSignature,
+      );
+      expect(result).toBeDefined();
+      expect(result?.evidences?.every((e) => e.version !== "9.9.9")).toBe(true);
+    });
+  });
+});

--- a/src/signatures/technologies/recent_posts_widget_with_thumbnails.ts
+++ b/src/signatures/technologies/recent_posts_widget_with_thumbnails.ts
@@ -8,7 +8,7 @@ export const recentPostsWidgetWithThumbnailsSignature: Signature = {
   rule: {
     confidence: "high",
     bodies: [
-      "/wp-content/plugins/recent-posts-widget-with-thumbnails/.+\\.css(?:\\?ver=(\\d+(?:\\.\\d+)+))?",
+      "/wp-content/plugins/recent-posts-widget-with-thumbnails/[^\"'\\s<>]+\\.css(?:\\?ver=(\\d+(?:\\.\\d+)+))?",
     ],
   },
   impliedSoftwares: [wordpressSignature.name],

--- a/src/signatures/technologies/slick.test.ts
+++ b/src/signatures/technologies/slick.test.ts
@@ -33,7 +33,35 @@ function createMockResponse(overrides: Partial<Response> = {}): Response {
 
 describe("slickSignature", () => {
   describe("URL matching", () => {
-    it("should detect Slick with version from path", () => {
+    it("should detect Slick with version from slick-carousel CDN path", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://cdn.example.com/libs/slick-carousel/1.8.1/slick.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, slickSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "1.8.1")).toBe(true);
+    });
+
+    it("should detect Slick with version from slick-carousel npm path", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://cdn.example.com/npm/slick-carousel@1.8.1/slick/slick.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, slickSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "1.8.1")).toBe(true);
+    });
+
+    it("should detect Slick presence without capturing unrelated parent-directory version", () => {
       const context = createMockContext({
         responses: [
           createMockResponse({
@@ -44,7 +72,7 @@ describe("slickSignature", () => {
 
       const result = applySignature(context, slickSignature);
       expect(result).toBeDefined();
-      expect(result?.evidences?.some((e) => e.version === "1.8.1")).toBe(true);
+      expect(result?.evidences?.every((e) => e.version === undefined)).toBe(true);
     });
 
     it("should detect Slick without version", () => {
@@ -85,6 +113,41 @@ describe("slickSignature", () => {
 
       const result = applySignature(context, slickSignature);
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe("body matching", () => {
+    it("captures version from slick-carousel CDN link", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com",
+            headers: { "content-type": "text/html" },
+            body: '<link rel="stylesheet" href="https://cdn.example.com/npm/slick-carousel@1.8.1/slick/slick-theme.css">',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, slickSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "1.8.1")).toBe(true);
+    });
+
+    it("captures slick-carousel version without miscapturing jQuery version from earlier in the body", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com",
+            headers: { "content-type": "text/html" },
+            body: '<script src="/js/jquery-3.2.1.min.js"></script><link rel="stylesheet" href="https://cdn.example.com/slick-carousel/1.8.1/slick-theme.css">',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, slickSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "1.8.1")).toBe(true);
+      expect(result?.evidences?.every((e) => e.version !== "3.2.1")).toBe(true);
     });
   });
 });

--- a/src/signatures/technologies/slick.ts
+++ b/src/signatures/technologies/slick.ts
@@ -7,8 +7,11 @@ export const slickSignature: Signature = {
     "Slick is a popular, fully responsive jQuery plugin used for creating versatile and customizable carousels and content sliders.",
   rule: {
     confidence: "high",
-    urls: ["(?:/(\\d+\\.\\d+\\.\\d+))?/slick(?:\\.min)?\\.js"],
-    bodies: ["(\\d+\\.\\d+\\.\\d+)[\\s\\S]*?slick-theme\\.css"],
+    urls: [
+      "slick(?:-carousel)?[/@](\\d+\\.\\d+\\.\\d+)[^\"'\\s]*?slick(?:\\.min)?\\.js",
+      "/slick(?:\\.min)?\\.js",
+    ],
+    bodies: ["slick[^\"'\\s<>]*?(\\d+\\.\\d+\\.\\d+)[^\"'\\s<>]*?slick-theme\\.css"],
   },
   impliedSoftwares: [jquerySignature.name],
 };

--- a/src/signatures/technologies/vue_js.test.ts
+++ b/src/signatures/technologies/vue_js.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { vueJsSignature } from "./vue_js.js";
+
+function createMockContext(
+  overrides: Partial<Pick<Context, "responses">> = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: { "content-type": "text/html" },
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("vueJsSignature", () => {
+  describe("URL matching", () => {
+    it("captures version from cdnjs URL (vue/x.y.z/)", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://cdn.example.com/ajax/libs/vue/2.7.14/vue.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, vueJsSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "2.7.14")).toBe(true);
+    });
+
+    it("captures version from npm-style vue@version path", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://cdn.example.com/npm/vue@2.7.14/dist/vue.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, vueJsSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "2.7.14")).toBe(true);
+    });
+
+    it("does not capture version from an unrelated parent directory", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/libs/5.6.7/vue.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, vueJsSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.every((e) => e.version !== "5.6.7")).toBe(true);
+    });
+
+    it("detects self-hosted presence without version", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/js/vue.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, vueJsSignature);
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/src/signatures/technologies/vue_js.ts
+++ b/src/signatures/technologies/vue_js.ts
@@ -8,7 +8,8 @@ export const vueJsSignature: Signature = {
     confidence: "high",
     urls: [
       "vue[.-]([\\d.]*\\d)[^/]*\\.js",
-      "(?:/([\\d.]+))?/vue(?:\\.min)?\\.js",
+      "vue[/@]([\\d.]+)[^\"'\\s]*?vue(?:\\.min)?\\.js",
+      "/vue(?:\\.min)?\\.js",
     ],
     bodies: ["<[^>]+\\sdata-v(?:ue)?-", "vue-app"],
     javascriptVariables: {

--- a/src/signatures/technologies/wordpress.test.ts
+++ b/src/signatures/technologies/wordpress.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { wordpressSignature } from "./wordpress.js";
+
+function createMockContext(
+  overrides: Partial<Pick<Context, "responses">> = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: { "content-type": "text/html" },
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("wordpressSignature", () => {
+  describe("body matching", () => {
+    it("captures version from meta generator with space separator", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<meta name="generator" content="WordPress 6.4.2">',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, wordpressSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "6.4.2")).toBe(true);
+    });
+
+    it("captures version from slash-separated form (e.g. WordPress/6.4.2)", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: "Powered by WordPress/6.4.2",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, wordpressSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "6.4.2")).toBe(true);
+    });
+
+    it("captures version with v prefix (WordPress v6.4.2)", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: "WordPress v6.4.2",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, wordpressSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "6.4.2")).toBe(true);
+    });
+
+    it("does not miscapture version from an unrelated script on the same page", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<link href="/wp-content/themes/foo/style.css"><script src="/jquery-3.2.1.min.js"></script>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, wordpressSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.every((e) => e.version !== "3.2.1")).toBe(true);
+    });
+
+    it("detects WordPress by wp-content reference alone (no version)", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<link href="/wp-content/themes/twentytwentyfour/style.css">',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, wordpressSignature);
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/src/signatures/technologies/wordpress.ts
+++ b/src/signatures/technologies/wordpress.ts
@@ -21,7 +21,7 @@ export const wordpressSignature: Signature = {
       "wp-includes",
       "wp-json",
       "wp\\.com",
-      "WoredPress.*(\\d+\\.\\d+(\\.\\d+)?)?",
+      "WordPress[\\s/]+v?(\\d+\\.\\d+(?:\\.\\d+)?)",
       "shareaholic:wp_version",
       "wp-embed\\.min\\.js",
     ],


### PR DESCRIPTION
## Summary

Tighten regex patterns in 17 signatures to prevent version numbers from being miscaptured from unrelated libraries or parent directories. This class of bug was originally reported for `popper-1.12.3.min.js` being detected as Bootstrap `1.12.3` because Bootstrap's greedy `bootstrap.*(\d+\.\d+\.\d+)\.min\.js` spanned across unrelated `<script>` tags.

## Changes

### Signature fixes (17 files)

- **Body-regex cross-URL miscapture**: replace greedy `.*` / `[\s\S]*?` with bounded char classes (`[^"'\s<>]*?`) that stop at URL/attribute boundaries
  - `bootstrap.ts`, `slick.ts`, `foogallery.ts`, `recent_posts_widget_with_thumbnails.ts`, `mediawiki.ts`
- **URL parent-directory miscapture**: require product-name or canonical CDN identifier before version capture, fall back to presence-only detection when the structure is unknown
  - `material_design_lite.ts`, `highlight_js.ts`, `pure_css.ts`, `jquery_ui.ts`, `metismenu.ts`, `vue_js.ts`, `firebase.ts`, `mathjax.ts`, `jsrender.ts`, `jsviews.ts`, `animate_css.ts`, `slick.ts`
- **Broken capture groups**: fix `([\d.])+` (captures only the last char) → `([\d.]+)`
  - `highlight_js.ts`, `pure_css.ts`
- **Cache-buster miscapture**: stop treating `?20240101` query strings as version
  - `metismenu.ts`
- **Trailing markup in version**: tighten `(.+)` → `([^"']+)` to stop at closing quote
  - `mediawiki.ts`
- **Typo + separator flexibility**: `WoredPress` → `WordPress`, accept space / slash / `v` prefix before the version
  - `wordpress.ts`

### Tests (16 new files + 1 update)

Each modified signature now has a unit test file covering:
1. Correct version extraction from canonical CDN paths (cdnjs, jsdelivr npm, etc.)
2. Presence-only detection for self-hosted URLs without recoverable version
3. Regression guards for the specific miscapture bugs (unrelated parent directories, neighboring plugins/libraries, cache-busters, trailing markup)

## Test plan

- [x] `npm run build` — passes
- [x] `npm test` — 385 passing / 1 skipped (up from 321)
- [x] Original reported case: `popper-1.12.3.min.js` no longer miscaptured as Bootstrap
- [x] Slick body regex: `jquery-3.2.1.min.js` + `slick-carousel@1.8.1/slick-theme.css` captures `1.8.1` only, never `3.2.1`
- [x] FooGallery / RecentPostsWidget: neighboring plugin `?ver=X.Y.Z` not captured
- [x] metisMenu cache-buster: `?20240101` not treated as version
- [x] MediaWiki: captured version no longer includes trailing markup
- [x] WordPress: `WordPress 6.4.2` / `WordPress/6.4.2` / `WordPress v6.4.2` all capture `6.4.2`
- [x] Parent-directory miscapture regression tests across all 11 `urls:`-based signatures