### PR TITLE
fix: capture pre-release suffix in bootstrap version

### DIFF
--- a/src/signatures/technologies/bootstrap.test.ts
+++ b/src/signatures/technologies/bootstrap.test.ts
@@ -4,7 +4,7 @@ import type { Context, Response } from "../../browser/types.js";
 import { bootstrapSignature } from "./bootstrap.js";
 
 function createMockContext(
-  overrides: Partial<Pick<Context, "responses">> = {},
+  overrides: Partial<Pick<Context, "responses" | "javascriptVariables">> = {},
 ): Context {
   return {
     browser: {} as Context["browser"],
@@ -88,6 +88,54 @@ describe("bootstrapSignature", () => {
       const result = applySignature(context, bootstrapSignature);
       expect(result).toBeDefined();
       expect(result?.evidences?.some((e) => e.version === "5.3.0")).toBe(true);
+    });
+
+    it("captures pre-release version from Bootstrap v header comment", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: "/*! Bootstrap v4.0.0-beta.2 */",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, bootstrapSignature);
+      expect(result).toBeDefined();
+      expect(
+        result?.evidences?.some((e) => e.version === "4.0.0-beta.2"),
+      ).toBe(true);
+    });
+
+    it("captures pre-release version from bootstrap.min.css filename", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<link rel="stylesheet" href="/css/bootstrap4.0.0-beta2.min.css"/>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, bootstrapSignature);
+      expect(result).toBeDefined();
+      expect(
+        result?.evidences?.some((e) => e.version === "4.0.0-beta2"),
+      ).toBe(true);
+    });
+  });
+
+  describe("javascript variable matching", () => {
+    it("captures pre-release version from bootstrap.Alert.VERSION", () => {
+      const context = createMockContext({
+        javascriptVariables: {
+          "bootstrap.Alert.VERSION": "4.0.0-beta.2",
+        },
+      });
+
+      const result = applySignature(context, bootstrapSignature);
+      expect(result).toBeDefined();
+      expect(
+        result?.evidences?.some((e) => e.version === "4.0.0-beta.2"),
+      ).toBe(true);
     });
   });
 });

--- a/src/signatures/technologies/bootstrap.test.ts
+++ b/src/signatures/technologies/bootstrap.test.ts
@@ -121,6 +121,38 @@ describe("bootstrapSignature", () => {
         result?.evidences?.some((e) => e.version === "4.0.0-beta2"),
       ).toBe(true);
     });
+
+    it("captures pre-release version from bootstrap.min.js filename", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<script src="/js/bootstrap4.0.0-beta2.min.js"></script>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, bootstrapSignature);
+      expect(result).toBeDefined();
+      expect(
+        result?.evidences?.some((e) => e.version === "4.0.0-beta2"),
+      ).toBe(true);
+    });
+
+    it("captures SemVer pre-release identifier containing a hyphen", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: "/*! Bootstrap v4.0.0-rc-1 */",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, bootstrapSignature);
+      expect(result).toBeDefined();
+      expect(
+        result?.evidences?.some((e) => e.version === "4.0.0-rc-1"),
+      ).toBe(true);
+    });
   });
 
   describe("javascript variable matching", () => {
@@ -128,6 +160,20 @@ describe("bootstrapSignature", () => {
       const context = createMockContext({
         javascriptVariables: {
           "bootstrap.Alert.VERSION": "4.0.0-beta.2",
+        },
+      });
+
+      const result = applySignature(context, bootstrapSignature);
+      expect(result).toBeDefined();
+      expect(
+        result?.evidences?.some((e) => e.version === "4.0.0-beta.2"),
+      ).toBe(true);
+    });
+
+    it("captures pre-release version from jQuery.fn.tooltip.Constructor.VERSION", () => {
+      const context = createMockContext({
+        javascriptVariables: {
+          "jQuery.fn.tooltip.Constructor.VERSION": "4.0.0-beta.2",
         },
       });
 

--- a/src/signatures/technologies/bootstrap.ts
+++ b/src/signatures/technologies/bootstrap.ts
@@ -8,13 +8,14 @@ export const bootstrapSignature: Signature = {
   rule: {
     confidence: "high",
     bodies: [
-      "Bootstrap v(\\d+\\.\\d+\\.\\d+)",
-      "bootstrap[^\"'\\s<>]*?(\\d+\\.\\d+\\.\\d+)[^\"'\\s<>]*?\\.min\\.css",
-      "bootstrap[^\"'\\s<>]*?(\\d+\\.\\d+\\.\\d+)[^\"'\\s<>]*?\\.min\\.js",
+      "Bootstrap v(\\d+\\.\\d+\\.\\d+(?:-[a-zA-Z0-9.]+)?)",
+      "bootstrap[^\"'\\s<>]*?(\\d+\\.\\d+\\.\\d+(?:-[a-zA-Z0-9.]+)?)[^\"'\\s<>]*?\\.min\\.css",
+      "bootstrap[^\"'\\s<>]*?(\\d+\\.\\d+\\.\\d+(?:-[a-zA-Z0-9.]+)?)[^\"'\\s<>]*?\\.min\\.js",
     ],
     javascriptVariables: {
-      "bootstrap.Alert.VERSION": "(\\d+\\.\\d+\\.\\d+)",
-      "jQuery.fn.tooltip.Constructor.VERSION": "(\\d+\\.\\d+\\.\\d+)",
+      "bootstrap.Alert.VERSION": "(\\d+\\.\\d+\\.\\d+(?:-[a-zA-Z0-9.]+)?)",
+      "jQuery.fn.tooltip.Constructor.VERSION":
+        "(\\d+\\.\\d+\\.\\d+(?:-[a-zA-Z0-9.]+)?)",
     },
   },
 };

--- a/src/signatures/technologies/bootstrap.ts
+++ b/src/signatures/technologies/bootstrap.ts
@@ -8,14 +8,14 @@ export const bootstrapSignature: Signature = {
   rule: {
     confidence: "high",
     bodies: [
-      "Bootstrap v(\\d+\\.\\d+\\.\\d+(?:-[a-zA-Z0-9.]+)?)",
-      "bootstrap[^\"'\\s<>]*?(\\d+\\.\\d+\\.\\d+(?:-[a-zA-Z0-9.]+)?)[^\"'\\s<>]*?\\.min\\.css",
-      "bootstrap[^\"'\\s<>]*?(\\d+\\.\\d+\\.\\d+(?:-[a-zA-Z0-9.]+)?)[^\"'\\s<>]*?\\.min\\.js",
+      "Bootstrap v(\\d+\\.\\d+\\.\\d+(?:-[a-zA-Z0-9.-]+)?)",
+      "bootstrap[^\"'\\s<>]*?(\\d+\\.\\d+\\.\\d+(?:-[a-zA-Z0-9.-]+)?)[^\"'\\s<>]*?\\.min\\.css",
+      "bootstrap[^\"'\\s<>]*?(\\d+\\.\\d+\\.\\d+(?:-[a-zA-Z0-9.-]+)?)[^\"'\\s<>]*?\\.min\\.js",
     ],
     javascriptVariables: {
-      "bootstrap.Alert.VERSION": "(\\d+\\.\\d+\\.\\d+(?:-[a-zA-Z0-9.]+)?)",
+      "bootstrap.Alert.VERSION": "(\\d+\\.\\d+\\.\\d+(?:-[a-zA-Z0-9.-]+)?)",
       "jQuery.fn.tooltip.Constructor.VERSION":
-        "(\\d+\\.\\d+\\.\\d+(?:-[a-zA-Z0-9.]+)?)",
+        "(\\d+\\.\\d+\\.\\d+(?:-[a-zA-Z0-9.-]+)?)",
     },
   },
 };


### PR DESCRIPTION
## Summary
- Extend the Bootstrap version regex to capture an optional SemVer pre-release suffix (e.g. `-beta.2`, `-beta2`, `-rc.1`), so versions like `4.0.0-beta.2` are no longer truncated to `4.0.0`.
- Apply the change consistently across all four matchers: the `Bootstrap v...` body comment, the `bootstrap*.min.css` / `bootstrap*.min.js` filename patterns, and the `bootstrap.Alert.VERSION` / `jQuery.fn.tooltip.Constructor.VERSION` JavaScript variables.
- Add unit tests covering pre-release versions for the body header, the filename pattern, and the JS variable path.

## Background
A real-world scan produced an evidence set where Bootstrap reported its version as `4.0.0-beta.2` in the body comment, the asset filenames (`bootstrap4.0.0-beta2.min.css` / `.min.js`), and the runtime `bootstrap.Alert.VERSION` / `jQuery.fn.tooltip.Constructor.VERSION` globals. All four signature matchers stripped the `-beta.2` suffix and recorded the version as `4.0.0`, which is incorrect for vulnerability mapping (pre-release builds and the GA release have different security profiles).

## Change
The version capture group is changed from `(\d+\.\d+\.\d+)` to `(\d+\.\d+\.\d+(?:-[a-zA-Z0-9.]+)?)`. The suffix group is optional, so existing stable-version evidence continues to match unchanged.

## Notes for reviewers
- This branch is based on `fix/signature-version-miscapture` (commit `d1dfc9d`), which introduced the `[^"'\s<>]*?` boundary patterns and the `bootstrap.test.ts` file this PR extends. Either merge that branch first, or set this PR's base to `fix/signature-version-miscapture`.
- The popper.js cross-resource miscapture regression test from the parent branch still passes under the new regex.

## Test plan
- [x] `npx vitest run src/signatures/technologies/bootstrap.test.ts` — 7/7 passing
- [x] Re-run a full scan against a site serving Bootstrap `4.0.0-beta.2` and confirm the captured `version` field reads `4.0.0-beta.2`