### PR TITLE
fix: broaden lodash and underscore detection, covering core build

### DIFF
--- a/src/analyzer/apply.test.ts
+++ b/src/analyzer/apply.test.ts
@@ -503,7 +503,7 @@ describe("applySignature", () => {
       expect(result).toBeUndefined();
     });
 
-    it("should detect when all requiredJavascriptVariables are present", () => {
+    it("should detect when any of requireAnyOfJavascriptVariables is present", () => {
       const signature: Signature = {
         name: "Lodash",
         rule: {
@@ -511,14 +511,14 @@ describe("applySignature", () => {
           javascriptVariables: {
             "_.VERSION": "(.+)",
           },
-          requiredJavascriptVariables: ["_.differenceBy"],
+          requireAnyOfJavascriptVariables: ["_.forOwn", "_.forIn", "_.merge"],
         },
       };
 
       const context = createMockContext({
         javascriptVariables: {
           "_.VERSION": "4.17.21",
-          "_.differenceBy": "function",
+          "_.forOwn": "[Function]",
         },
       });
 
@@ -529,7 +529,7 @@ describe("applySignature", () => {
       expect(result?.evidences?.[0]?.version).toBe("4.17.21");
     });
 
-    it("should discard script evidences when requiredJavascriptVariables are missing", () => {
+    it("should detect when only a non-first requireAnyOfJavascriptVariables marker is present", () => {
       const signature: Signature = {
         name: "Lodash",
         rule: {
@@ -537,7 +537,32 @@ describe("applySignature", () => {
           javascriptVariables: {
             "_.VERSION": "(.+)",
           },
-          requiredJavascriptVariables: ["_.differenceBy"],
+          requireAnyOfJavascriptVariables: ["_.forOwn", "_.forIn", "_.merge"],
+        },
+      };
+
+      const context = createMockContext({
+        javascriptVariables: {
+          "_.VERSION": "4.17.21",
+          "_.merge": "[Function]",
+        },
+      });
+
+      const result = applySignature(context, signature);
+
+      expect(result).toBeDefined();
+      expect(result?.evidences?.[0]?.version).toBe("4.17.21");
+    });
+
+    it("should discard script evidences when none of requireAnyOfJavascriptVariables is present", () => {
+      const signature: Signature = {
+        name: "Lodash",
+        rule: {
+          confidence: "high",
+          javascriptVariables: {
+            "_.VERSION": "(.+)",
+          },
+          requireAnyOfJavascriptVariables: ["_.forOwn", "_.forIn", "_.merge"],
         },
       };
 
@@ -551,7 +576,7 @@ describe("applySignature", () => {
       expect(result).toBeUndefined();
     });
 
-    it("should keep script evidences when non-script evidences exist even if requiredJavascriptVariables are missing", () => {
+    it("should keep script evidences when non-script evidences exist even if none of requireAnyOfJavascriptVariables is present", () => {
       const signature: Signature = {
         name: "Lodash",
         rule: {
@@ -560,7 +585,7 @@ describe("applySignature", () => {
           javascriptVariables: {
             "_.VERSION": "(.+)",
           },
-          requiredJavascriptVariables: ["_.differenceBy"],
+          requireAnyOfJavascriptVariables: ["_.forOwn", "_.forIn", "_.merge"],
         },
       };
 

--- a/src/analyzer/apply.ts
+++ b/src/analyzer/apply.ts
@@ -211,13 +211,13 @@ export const applySignature = (
     }
   }
 
-  if (rule?.requiredJavascriptVariables) {
+  if (rule?.requireAnyOfJavascriptVariables) {
     const jsVars = context.javascriptVariables;
-    const allPresent = rule.requiredJavascriptVariables.every(
+    const anyPresent = rule.requireAnyOfJavascriptVariables.some(
       (name) => jsVars[name] !== undefined,
     );
     const hasNonScriptEvidence = evidences.some((e) => e.type !== "script");
-    if (!allPresent && !hasNonScriptEvidence) {
+    if (!anyPresent && !hasNonScriptEvidence) {
       evidences = evidences.filter((e) => e.type !== "script");
     }
   }

--- a/src/signatures/_types.ts
+++ b/src/signatures/_types.ts
@@ -10,9 +10,9 @@ export type Rule = {
   urls?: Regex[];
   cookies?: Record<string, Regex>;
   javascriptVariables?: Record<string, Regex>;
-  // Variables that must all exist for script evidences to be kept.
+  // At least one of these variables must exist for script evidences to be kept.
   // Skipped when non-script evidences already confirm the technology.
-  requiredJavascriptVariables?: string[];
+  requireAnyOfJavascriptVariables?: string[];
 };
 
 export type ActiveRule = {

--- a/src/signatures/technologies/lodash.test.ts
+++ b/src/signatures/technologies/lodash.test.ts
@@ -122,6 +122,29 @@ describe("lodashSignature", () => {
       expect(result?.evidences?.some((e) => e.type === "script")).toBe(true);
     });
 
+    it("should extract version from the custom/core build banner URL in response body", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://www.example.com/common/js/vendor/libs.js",
+            headers: { "content-type": "application/javascript" },
+            body:
+              "/**\n * @license\n * Lodash (Custom Build) lodash.com/license | Underscore.js 1.8.3 underscorejs.org/LICENSE\n" +
+              " * Build: `lodash core -o ./dist/lodash.core.js`\n" +
+              " * https://raw.githubusercontent.com/lodash/lodash/4.17.21/dist/lodash.core.min.js\n */",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, lodashSignature);
+      expect(result).toBeDefined();
+      expect(
+        result?.evidences?.some(
+          (e) => e.type === "body" && e.version === "4.17.21",
+        ),
+      ).toBe(true);
+    });
+
     it("should detect Lodash core build when only core-build markers are present", () => {
       // lodash 4.x core build strips forOwn/forIn/merge but keeps thru/flattenDeep/concat/assignIn.
       const context = createMockContext({

--- a/src/signatures/technologies/lodash.test.ts
+++ b/src/signatures/technologies/lodash.test.ts
@@ -4,9 +4,7 @@ import type { Context, Response } from "../../browser/types.js";
 import { lodashSignature } from "./lodash.js";
 
 function createMockContext(
-  overrides: Partial<
-    Pick<Context, "responses" | "javascriptVariables">
-  > = {},
+  overrides: Partial<Pick<Context, "responses" | "javascriptVariables">> = {},
 ): Context {
   return {
     browser: {} as Context["browser"],
@@ -64,17 +62,19 @@ describe("lodashSignature", () => {
   });
 
   describe("JavaScript variable matching", () => {
-    it("should detect Lodash when _.VERSION and _.differenceBy are present", () => {
+    it("should detect Lodash when a lodash-only marker and _.VERSION are present", () => {
       const context = createMockContext({
         javascriptVariables: {
+          "_.forOwn": "[Function]",
           "_.VERSION": "4.17.21",
-          "_.differenceBy": "function",
         },
       });
 
       const result = applySignature(context, lodashSignature);
       expect(result).toBeDefined();
-      expect(result?.evidences?.some((e) => e.version === "4.17.21")).toBe(true);
+      expect(result?.evidences?.some((e) => e.version === "4.17.21")).toBe(
+        true,
+      );
     });
 
     it("should not detect Lodash when only _.VERSION is present", () => {
@@ -103,21 +103,42 @@ describe("lodashSignature", () => {
       const result = applySignature(context, lodashSignature);
       expect(result).toBeDefined();
       expect(result?.evidences?.some((e) => e.type === "url")).toBe(true);
-      expect(result?.evidences?.some((e) => e.type === "script" && e.version === "4.17.21")).toBe(true);
+      expect(
+        result?.evidences?.some(
+          (e) => e.type === "script" && e.version === "4.17.21",
+        ),
+      ).toBe(true);
     });
 
-    it("should detect Lodash from templateSettings path", () => {
+    it("should detect Lodash when only the required lodash-only marker is present", () => {
       const context = createMockContext({
         javascriptVariables: {
-          "_.templateSettings.imports._.templateSettings.imports._.VERSION":
-            "4.17.21",
-          "_.differenceBy": "function",
+          "_.forOwn": "[Function]",
         },
       });
 
       const result = applySignature(context, lodashSignature);
       expect(result).toBeDefined();
-      expect(result?.evidences?.some((e) => e.version === "4.17.21")).toBe(true);
+      expect(result?.evidences?.some((e) => e.type === "script")).toBe(true);
+    });
+
+    it("should detect Lodash core build when only core-build markers are present", () => {
+      // lodash 4.x core build strips forOwn/forIn/merge but keeps thru/flattenDeep/concat/assignIn.
+      const context = createMockContext({
+        javascriptVariables: {
+          "_.thru": "[Function]",
+          "_.flattenDeep": "[Function]",
+          "_.concat": "[Function]",
+          "_.assignIn": "[Function]",
+          "_.VERSION": "4.17.21",
+        },
+      });
+
+      const result = applySignature(context, lodashSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "4.17.21")).toBe(
+        true,
+      );
     });
   });
 });

--- a/src/signatures/technologies/lodash.ts
+++ b/src/signatures/technologies/lodash.ts
@@ -10,9 +10,24 @@ export const lodashSignature: Signature = {
     urls: ["lodash.*\\.js"],
     javascriptVariables: {
       "_.VERSION": "(.+)",
-      "_.differenceBy": "",
-      "_.templateSettings.imports._.templateSettings.imports._.VERSION": "(.+)",
+      // Full build markers
+      "_.forOwn": "",
+      "_.forIn": "",
+      "_.merge": "",
+      // Core build markers
+      "_.thru": "",
+      "_.flattenDeep": "",
+      "_.concat": "",
+      "_.assignIn": "",
     },
-    requiredJavascriptVariables: ["_.differenceBy"],
+    requireAnyOfJavascriptVariables: [
+      "_.forOwn",
+      "_.forIn",
+      "_.merge",
+      "_.thru",
+      "_.flattenDeep",
+      "_.concat",
+      "_.assignIn",
+    ],
   },
 };

--- a/src/signatures/technologies/lodash.ts
+++ b/src/signatures/technologies/lodash.ts
@@ -8,6 +8,9 @@ export const lodashSignature: Signature = {
   rule: {
     confidence: "high",
     urls: ["lodash.*\\.js"],
+    bodies: [
+      "raw\\.githubusercontent\\.com/lodash/lodash/(\\d+\\.\\d+\\.\\d+)/dist/",
+    ],
     javascriptVariables: {
       "_.VERSION": "(.+)",
       // Full build markers

--- a/src/signatures/technologies/underscore_js.test.ts
+++ b/src/signatures/technologies/underscore_js.test.ts
@@ -4,9 +4,7 @@ import type { Context, Response } from "../../browser/types.js";
 import { underscoreJsSignature } from "./underscore_js.js";
 
 function createMockContext(
-  overrides: Partial<
-    Pick<Context, "responses" | "javascriptVariables">
-  > = {},
+  overrides: Partial<Pick<Context, "responses" | "javascriptVariables">> = {},
 ): Context {
   return {
     browser: {} as Context["browser"],
@@ -65,11 +63,11 @@ describe("underscoreJsSignature", () => {
   });
 
   describe("JavaScript variable matching", () => {
-    it("should detect Underscore.js when _.VERSION and _.restArguments are present", () => {
+    it("should detect Underscore.js when an underscore-only marker and _.VERSION are present", () => {
       const context = createMockContext({
         javascriptVariables: {
+          "_.mapObject": "[Function]",
           "_.VERSION": "1.13.6",
-          "_.restArguments": "function",
         },
       });
 
@@ -93,7 +91,11 @@ describe("underscoreJsSignature", () => {
       const result = applySignature(context, underscoreJsSignature);
       expect(result).toBeDefined();
       expect(result?.evidences?.some((e) => e.type === "url")).toBe(true);
-      expect(result?.evidences?.some((e) => e.type === "script" && e.version === "1.13.6")).toBe(true);
+      expect(
+        result?.evidences?.some(
+          (e) => e.type === "script" && e.version === "1.13.6",
+        ),
+      ).toBe(true);
     });
 
     it("should not detect Underscore.js when only _.VERSION is present", () => {
@@ -105,6 +107,18 @@ describe("underscoreJsSignature", () => {
 
       const result = applySignature(context, underscoreJsSignature);
       expect(result).toBeUndefined();
+    });
+
+    it("should detect Underscore.js when only the required underscore-only marker is present", () => {
+      const context = createMockContext({
+        javascriptVariables: {
+          "_.mapObject": "[Function]",
+        },
+      });
+
+      const result = applySignature(context, underscoreJsSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.type === "script")).toBe(true);
     });
   });
 });

--- a/src/signatures/technologies/underscore_js.ts
+++ b/src/signatures/technologies/underscore_js.ts
@@ -9,9 +9,11 @@ export const underscoreJsSignature: Signature = {
     confidence: "high",
     urls: ["underscore.*\\.js(?:\\?ver=([\\d.]+))?"],
     javascriptVariables: {
-      "_.VERSION": "^(.+)$",
-      "_.restArguments": "",
+      "_.VERSION": "(.+)",
+      "_.mapObject": "",
+      "_.matcher": "",
+      "_.allKeys": "",
     },
-    requiredJavascriptVariables: ["_.restArguments"],
+    requireAnyOfJavascriptVariables: ["_.mapObject", "_.matcher", "_.allKeys"],
   },
 };


### PR DESCRIPTION
## Summary

- Replace version-specific markers (`_.differenceBy` for lodash 4.0+, `_.restArguments` for underscore 1.10+) with stable library-exclusive markers that cover older releases and the lodash 4.x core build.
- Rename `requiredJavascriptVariables` (AND semantics) to `requireAnyOfJavascriptVariables` (OR semantics) so a signature can list several interchangeable markers, any of which is sufficient.
- Extract the lodash version from the upstream-source URL embedded in custom/core-build banners (e.g. `raw.githubusercontent.com/lodash/lodash/4.17.21/dist/…`), since `_.VERSION` is unreachable when the library is bundled and not exposed globally.

## Motivation

The previous signatures missed many real-world cases:

- lodash pre-4.0 builds (no `_.differenceBy`)
- lodash 4.x core build (strips `_.differenceBy`, `_.forOwn`, `_.forIn`, `_.merge`)
- underscore pre-1.10 (no `_.restArguments`)
- bundled files where the library is not named `lodash.*.js` / `underscore.*.js` and `_` is not exposed on `window`

## Detection coverage

| Build | Markers used |
|---|---|
| lodash full 0.5 – 4.x | `_.forOwn` / `_.forIn` / `_.merge` |
| lodash 4.x core | `_.thru` / `_.flattenDeep` / `_.concat` / `_.assignIn` |
| underscore 1.8.0 – 1.13.x | `_.mapObject` / `_.matcher` / `_.allKeys` |
| lodash custom/core build served from bundle | `raw.githubusercontent.com/lodash/lodash/X.Y.Z/dist/` in body (version extracted) |

The marker sets were verified against every lodash release 0.5.0 – 4.17.21 and every underscore release 0.3.3 – 1.13.6; none of the lodash markers ever appear on underscore and vice versa.

## Framework change

`requiredJavascriptVariables` was only used by the lodash and underscore signatures, so the rename is safe for the rest of the codebase. The evaluation switches from `every` (AND) to `some` (OR); the `hasNonScriptEvidence` bypass that keeps script evidence when URL/body evidence already exists is preserved.

## Known limitations (acceptable)

- lodash 0.1.0 – 0.4.x: no exclusive static marker; relies on URL match.
- underscore 0.x – 1.7.x: no exclusive static marker; relies on URL match.
- lodash FP build: exposed as `fp`, not `_`. Out of scope.
- Per-method npm packages (`lodash.debounce`, etc.): no `_` global. Out of scope.

## Test plan

- [x] `npm run build`
- [x] `npm test` — 396 passing (added cases for OR semantics, core-build markers, banner-URL version extraction)
- [x] `npx eslint src/`