### PR TITLE
fix: cap oversized evidence values across all match types

### DIFF
--- a/src/analyzer/apply.ts
+++ b/src/analyzer/apply.ts
@@ -1,11 +1,7 @@
 import type { Context, Response } from "../browser/types.js";
 import type { Runtime, Signature } from "../signatures/_types.js";
 import type { Detection, Evidence } from "./types.js";
-import {
-  extractMatchSnippet,
-  matchString,
-  truncateBodyForEvidence,
-} from "./match.js";
+import { buildEvidenceValue, matchString } from "./match.js";
 
 function isFirstPartyResponse(response: Response): boolean {
   return response.isFirstParty ?? true;
@@ -91,7 +87,7 @@ export const applySignature = (
 
         evidences.push({
           type: "url",
-          value: url,
+          value: buildEvidenceValue(url, result),
           version: result.version,
           confidence: rule.confidence,
           host: response.host,
@@ -116,13 +112,9 @@ export const applySignature = (
         continue;
       }
 
-      const snippet =
-        result.index !== undefined && result.matchLength !== undefined
-          ? extractMatchSnippet(headerValue, result.index, result.matchLength)
-          : headerValue;
       evidences.push({
         type: "header",
-        value: `${header}: ${snippet}`,
+        value: buildEvidenceValue(headerValue, result, header),
         version: result.version,
         confidence: rule.confidence,
         host: response.host,
@@ -148,13 +140,9 @@ export const applySignature = (
           continue;
         }
 
-        const snippet =
-          result.index !== undefined && result.matchLength !== undefined
-            ? extractMatchSnippet(body, result.index, result.matchLength)
-            : truncateBodyForEvidence(body);
         evidences.push({
           type: "body",
-          value: snippet,
+          value: buildEvidenceValue(body, result),
           version: result.version,
           confidence: rule.confidence,
           host: response.host,
@@ -180,7 +168,7 @@ export const applySignature = (
 
       evidences.push({
         type: "cookie",
-        value: `${cookie.name}: ${cookie.value}`,
+        value: buildEvidenceValue(cookie.value, result, cookie.name),
         version: result.version,
         confidence: rule.confidence,
         host: cookie.host,
@@ -204,7 +192,7 @@ export const applySignature = (
 
       evidences.push({
         type: "script",
-        value: `${name}: ${valStr}`,
+        value: buildEvidenceValue(valStr, result, name),
         version: result.version,
         confidence: rule.confidence,
       });

--- a/src/analyzer/match.test.ts
+++ b/src/analyzer/match.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  buildEvidenceValue,
   extractMatchSnippet,
   matchString,
   truncateBodyForEvidence,
@@ -64,22 +65,80 @@ describe("matchString", () => {
 });
 
 describe("extractMatchSnippet", () => {
-  it("returns the value unchanged when shorter than the context window", () => {
+  it("returns the value unchanged when shorter than maxValueLength", () => {
     expect(extractMatchSnippet("nginx/1.20.0", 0, 5)).toBe("nginx/1.20.0");
+  });
+
+  it("returns the value unchanged when length is exactly maxValueLength", () => {
+    const value = "a".repeat(200);
+    expect(extractMatchSnippet(value, 50, 5)).toBe(value);
   });
 
   it("truncates both sides with ellipsis when the match is in the middle", () => {
     const value = `${"a".repeat(60)}MATCH${"b".repeat(60)}`;
-    expect(extractMatchSnippet(value, 60, 5, 10)).toBe(
+    expect(extractMatchSnippet(value, 60, 5, 10, 120, 0)).toBe(
       `...${"a".repeat(10)}MATCH${"b".repeat(10)}...`,
     );
   });
 
   it("omits the leading ellipsis when the match is near the start", () => {
     const value = `MATCH${"b".repeat(60)}`;
-    expect(extractMatchSnippet(value, 0, 5, 10)).toBe(
+    expect(extractMatchSnippet(value, 0, 5, 10, 120, 0)).toBe(
       `MATCH${"b".repeat(10)}...`,
     );
+  });
+
+  it("compresses the match itself when it exceeds maxMatchLength", () => {
+    const match = `${"x".repeat(100)}MIDDLE${"y".repeat(100)}`;
+    const value = `${"a".repeat(20)}${match}${"b".repeat(20)}`;
+    const snippet = extractMatchSnippet(value, 20, match.length, 5, 20, 0);
+    expect(snippet).toBe(
+      `...${"a".repeat(5)}${"x".repeat(10)}...${"y".repeat(10)}${"b".repeat(5)}...`,
+    );
+  });
+
+  it("does not compress when the match is within maxMatchLength", () => {
+    const match = "M".repeat(100);
+    const value = `${"a".repeat(20)}${match}${"b".repeat(20)}`;
+    const snippet = extractMatchSnippet(value, 20, match.length, 5, 200, 0);
+    expect(snippet).toBe(`...${"a".repeat(5)}${match}${"b".repeat(5)}...`);
+  });
+});
+
+describe("buildEvidenceValue", () => {
+  it("returns the raw value as-is when short and no prefix is given", () => {
+    expect(
+      buildEvidenceValue("nginx/1.20.0", { index: 0, matchLength: 5 }),
+    ).toBe("nginx/1.20.0");
+  });
+
+  it("attaches the prefix with a colon separator", () => {
+    expect(
+      buildEvidenceValue(
+        "X-Inertia",
+        { index: 0, matchLength: 9 },
+        "Vary",
+      ),
+    ).toBe("Vary: X-Inertia");
+  });
+
+  it("applies snippet extraction when the raw value exceeds maxValueLength", () => {
+    const rawValue = `${"a".repeat(300)}MATCH${"b".repeat(300)}`;
+    const result = buildEvidenceValue(
+      rawValue,
+      { index: 300, matchLength: 5 },
+      "Server",
+    );
+    expect(result.startsWith("Server: ...")).toBe(true);
+    expect(result.endsWith("...")).toBe(true);
+    expect(result).toContain("MATCH");
+    expect(result.length).toBeLessThan(rawValue.length);
+  });
+
+  it("returns the raw value untouched when match info is missing", () => {
+    const empty = { index: undefined, matchLength: undefined };
+    expect(buildEvidenceValue("short", empty)).toBe("short");
+    expect(buildEvidenceValue("short", empty, "Cookie")).toBe("Cookie: short");
   });
 });
 

--- a/src/analyzer/match.test.ts
+++ b/src/analyzer/match.test.ts
@@ -76,22 +76,26 @@ describe("extractMatchSnippet", () => {
 
   it("truncates both sides with ellipsis when the match is in the middle", () => {
     const value = `${"a".repeat(60)}MATCH${"b".repeat(60)}`;
-    expect(extractMatchSnippet(value, 60, 5, 10, 120, 0)).toBe(
-      `...${"a".repeat(10)}MATCH${"b".repeat(10)}...`,
-    );
+    expect(
+      extractMatchSnippet(value, 60, 5, { context: 10, maxValueLength: 0 }),
+    ).toBe(`...${"a".repeat(10)}MATCH${"b".repeat(10)}...`);
   });
 
   it("omits the leading ellipsis when the match is near the start", () => {
     const value = `MATCH${"b".repeat(60)}`;
-    expect(extractMatchSnippet(value, 0, 5, 10, 120, 0)).toBe(
-      `MATCH${"b".repeat(10)}...`,
-    );
+    expect(
+      extractMatchSnippet(value, 0, 5, { context: 10, maxValueLength: 0 }),
+    ).toBe(`MATCH${"b".repeat(10)}...`);
   });
 
   it("compresses the match itself when it exceeds maxMatchLength", () => {
     const match = `${"x".repeat(100)}MIDDLE${"y".repeat(100)}`;
     const value = `${"a".repeat(20)}${match}${"b".repeat(20)}`;
-    const snippet = extractMatchSnippet(value, 20, match.length, 5, 20, 0);
+    const snippet = extractMatchSnippet(value, 20, match.length, {
+      context: 5,
+      maxMatchLength: 20,
+      maxValueLength: 0,
+    });
     expect(snippet).toBe(
       `...${"a".repeat(5)}${"x".repeat(10)}...${"y".repeat(10)}${"b".repeat(5)}...`,
     );
@@ -100,7 +104,11 @@ describe("extractMatchSnippet", () => {
   it("does not compress when the match is within maxMatchLength", () => {
     const match = "M".repeat(100);
     const value = `${"a".repeat(20)}${match}${"b".repeat(20)}`;
-    const snippet = extractMatchSnippet(value, 20, match.length, 5, 200, 0);
+    const snippet = extractMatchSnippet(value, 20, match.length, {
+      context: 5,
+      maxMatchLength: 200,
+      maxValueLength: 0,
+    });
     expect(snippet).toBe(`...${"a".repeat(5)}${match}${"b".repeat(5)}...`);
   });
 });

--- a/src/analyzer/match.ts
+++ b/src/analyzer/match.ts
@@ -25,14 +25,19 @@ export const matchString = (value: string, regex: Regex): MatchResult => {
 export const truncateBodyForEvidence = (body: string): string =>
   body.length > 100 ? `${body.substring(0, 100)}...` : body;
 
+export type SnippetOptions = {
+  context?: number;
+  maxMatchLength?: number;
+  maxValueLength?: number;
+};
+
 export const extractMatchSnippet = (
   value: string,
   index: number,
   matchLength: number,
-  context = 40,
-  maxMatchLength = 120,
-  maxValueLength = 200,
+  options: SnippetOptions = {},
 ): string => {
+  const { context = 40, maxMatchLength = 120, maxValueLength = 200 } = options;
   if (value.length <= maxValueLength) return value;
 
   const start = Math.max(0, index - context);
@@ -58,9 +63,9 @@ export const buildEvidenceValue = (
   result: Pick<MatchResult, "index" | "matchLength">,
   prefix?: string,
 ): string => {
-  const body =
+  const evidenceValue =
     result.index !== undefined && result.matchLength !== undefined
       ? extractMatchSnippet(rawValue, result.index, result.matchLength)
       : rawValue;
-  return prefix ? `${prefix}: ${body}` : body;
+  return prefix ? `${prefix}: ${evidenceValue}` : evidenceValue;
 };

--- a/src/analyzer/match.ts
+++ b/src/analyzer/match.ts
@@ -1,6 +1,6 @@
 import type { Regex } from "../signatures/_types.js";
 
-type MatchResult = {
+export type MatchResult = {
   hit: boolean;
   version: string | undefined;
   index: number | undefined;
@@ -30,10 +30,37 @@ export const extractMatchSnippet = (
   index: number,
   matchLength: number,
   context = 40,
+  maxMatchLength = 120,
+  maxValueLength = 200,
 ): string => {
+  if (value.length <= maxValueLength) return value;
+
   const start = Math.max(0, index - context);
   const end = Math.min(value.length, index + matchLength + context);
   const prefix = start > 0 ? "..." : "";
   const suffix = end < value.length ? "..." : "";
+
+  // Compress the match itself when it is excessively long (e.g. greedy
+  // [^"']* against a large JSON blob), keeping head/tail so the evidence
+  // stays informative without bloating output.
+  if (matchLength > maxMatchLength) {
+    const half = Math.floor(maxMatchLength / 2);
+    const leading = value.substring(start, index + half);
+    const trailing = value.substring(index + matchLength - half, end);
+    return `${prefix}${leading}...${trailing}${suffix}`;
+  }
+
   return `${prefix}${value.substring(start, end)}${suffix}`;
+};
+
+export const buildEvidenceValue = (
+  rawValue: string,
+  result: Pick<MatchResult, "index" | "matchLength">,
+  prefix?: string,
+): string => {
+  const body =
+    result.index !== undefined && result.matchLength !== undefined
+      ? extractMatchSnippet(rawValue, result.index, result.matchLength)
+      : rawValue;
+  return prefix ? `${prefix}: ${body}` : body;
 };


### PR DESCRIPTION
## Summary

- Centralize evidence `value` construction into a single `buildEvidenceValue` helper, eliminating per-type duplication across the five match types (url / header / body / cookie / script) in `applySignature`.
- Apply the same length-cap policy uniformly to all match types. Previously only `header` and `body` went through `extractMatchSnippet`, while `url` / `cookie` / `script` emitted raw values verbatim — letting large cookie values or stringified JS variables bloat evidence output.
- Add a short-circuit in `extractMatchSnippet` (`maxValueLength = 200`): values that are already short are returned as-is, so concise evidence (e.g. `Server: nginx/1.20.0`) no longer picks up unnecessary ellipses.
- Drop a dead `truncateBodyForEvidence` fallback path in the body branch that was unreachable after the `result.hit` check.

## Behavior

| type   | before                              | after (≤ 200 chars)                | after (> 200 chars)             |
|--------|-------------------------------------|------------------------------------|---------------------------------|
| url    | full url                            | unchanged                          | snippet around match            |
| header | `${header}: ${snippet}` (sliced)    | `${header}: ${value}` (no `...`)   | `${header}: ${snippet}`         |
| body   | `${snippet}`                        | full body                          | snippet around match            |
| cookie | `${name}: ${full value}`            | unchanged                          | `${name}: ${snippet}`           |
| script | `${name}: ${full JSON}`             | unchanged                          | `${name}: ${snippet}`           |

Maximum evidence value length is bounded at roughly 200 characters even for greedy regex matches on very large blobs (e.g. `data-page="..."` JSON in Inertia.js detection).

## Test plan

- [x] `npm test` — all 398 tests pass (5 new tests added)
- [x] `npm run lint` — clean for `src/analyzer`
- [x] Coverage for `src/analyzer` remains at 100%