### PR TITLE
fix: tighten overly loose body patterns to prevent false positives

### DIFF
--- a/src/signatures/technologies/ant_design.test.ts
+++ b/src/signatures/technologies/ant_design.test.ts
@@ -59,11 +59,25 @@ describe("antDesignSignature", () => {
       expect(result).toBeDefined();
     });
 
-    it("detects Ant Design from CDN stylesheet with version", () => {
+    it("detects Ant Design from CDN stylesheet with @-delimited version", () => {
       const context = createMockContext({
         responses: [
           createMockResponse({
             body: '<link rel="stylesheet" href="https://cdn.example.com/npm/antd@5.12.0/dist/reset.min.css">',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, antDesignSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "5.12.0")).toBe(true);
+    });
+
+    it("detects Ant Design from CDN stylesheet with /-delimited version (cdnjs-style)", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<link rel="stylesheet" href="https://cdn.example.com/ajax/libs/antd/5.12.0/antd.min.css">',
           }),
         ],
       });
@@ -142,7 +156,7 @@ describe("antDesignSignature", () => {
       const context = createMockContext({
         responses: [
           createMockResponse({
-            body: '<link rel="stylesheet" href="/assets/relevantDashboard.css">',
+            body: '<link rel="stylesheet" href="/assets/merchantDashboard.css">',
           }),
         ],
       });

--- a/src/signatures/technologies/ant_design.test.ts
+++ b/src/signatures/technologies/ant_design.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { antDesignSignature } from "./ant_design.js";
+
+function createMockContext(
+  overrides: Partial<Pick<Context, "responses" | "javascriptVariables">> = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: { "content-type": "text/html" },
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("antDesignSignature", () => {
+  describe("body matching", () => {
+    it("detects Ant Design from ant-* class name", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<button class="ant-btn ant-btn-primary">Click</button>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, antDesignSignature);
+      expect(result).toBeDefined();
+    });
+
+    it("detects Ant Design from anticon icon markup", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<i class="anticon anticon-search"></i>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, antDesignSignature);
+      expect(result).toBeDefined();
+    });
+
+    it("detects Ant Design from CDN stylesheet with version", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<link rel="stylesheet" href="https://cdn.example.com/npm/antd@5.12.0/dist/reset.min.css">',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, antDesignSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "5.12.0")).toBe(true);
+    });
+
+    it("detects Ant Design from CDN stylesheet path without version", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<link rel="stylesheet" href="/vendor/antd/dist/antd.min.css">',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, antDesignSignature);
+      expect(result).toBeDefined();
+    });
+
+    it("detects Ant Design from a stylesheet named antd.css without any path prefix", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<link rel="stylesheet" href="/assets/antd.css">',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, antDesignSignature);
+      expect(result).toBeDefined();
+    });
+
+    it("detects Ant Design from a minified antd.min.css filename", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<link rel="stylesheet" href="/cdn/antd.min.css">',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, antDesignSignature);
+      expect(result).toBeDefined();
+    });
+
+    it("does not detect Ant Design when 'antd' is embedded inside a longer word (e.g. antdate.css)", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<link rel="stylesheet" href="/assets/antdate.css">',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, antDesignSignature);
+      expect(result).toBeUndefined();
+    });
+
+    it("does not detect Ant Design from minified JavaScript that incidentally contains 'antD' inside an unrelated identifier", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: "var a=someObject.href,b=a.relevantData;function c(x){return x.importantDetails}",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, antDesignSignature);
+      expect(result).toBeUndefined();
+    });
+
+    it("does not detect Ant Design from an unrelated stylesheet whose filename contains 'antd' as a sub-word", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<link rel="stylesheet" href="/assets/relevantDashboard.css">',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, antDesignSignature);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("javascript variable matching", () => {
+    it("detects Ant Design from antd.version variable", () => {
+      const context = createMockContext({
+        javascriptVariables: {
+          "antd.version": "5.12.0",
+        },
+      });
+
+      const result = applySignature(context, antDesignSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "5.12.0")).toBe(true);
+    });
+  });
+});

--- a/src/signatures/technologies/ant_design.ts
+++ b/src/signatures/technologies/ant_design.ts
@@ -2,14 +2,14 @@ import type { Signature } from "../_types.js";
 
 export const antDesignSignature: Signature = {
   name: "Ant Design",
-  description: "Ant Design is a UI library that can be used with data flow solutions and application frameworks in any React ecosystem.",
+  description:
+    "Ant Design is a UI library that can be used with data flow solutions and application frameworks in any React ecosystem.",
   rule: {
     confidence: "high",
     bodies: [
-      "<[^>]*class=\"ant-(?:btn|col|row|layout|breadcrumb|menu|pagination|steps|select|cascader|checkbox|calendar|form|input-number|input|mention|rate|radio|slider|switch|tree-select|time-picker|transfer|upload|avatar|badge|card|carousel|collapse|list|popover|tooltip|table|tabs|tag|timeline|tree|alert|modal|message|notification|progress|popconfirm|spin|anchor|back-top|divider|drawer)",
-      "<i class=\"anticon anticon-",
-      "href[^>]+antd(?:@|/)?([\\d\\.]+)?(?:.+|)?\\.css",
-      "href[^>]+antd",
+      '<[^>]*class="ant-(?:btn|col|row|layout|breadcrumb|menu|pagination|steps|select|cascader|checkbox|calendar|form|input-number|input|mention|rate|radio|slider|switch|tree-select|time-picker|transfer|upload|avatar|badge|card|carousel|collapse|list|popover|tooltip|table|tabs|tag|timeline|tree|alert|modal|message|notification|progress|popconfirm|spin|anchor|back-top|divider|drawer)',
+      '<i class="anticon anticon-',
+      "<link[^>]+href=[\"'][^\"']*\\bantd\\b(?:@([\\d\\.]+))?[^\"']*\\.css",
     ],
     javascriptVariables: {
       "antd.version": "^([\\d\\.]+)$",

--- a/src/signatures/technologies/ant_design.ts
+++ b/src/signatures/technologies/ant_design.ts
@@ -9,7 +9,7 @@ export const antDesignSignature: Signature = {
     bodies: [
       '<[^>]*class="ant-(?:btn|col|row|layout|breadcrumb|menu|pagination|steps|select|cascader|checkbox|calendar|form|input-number|input|mention|rate|radio|slider|switch|tree-select|time-picker|transfer|upload|avatar|badge|card|carousel|collapse|list|popover|tooltip|table|tabs|tag|timeline|tree|alert|modal|message|notification|progress|popconfirm|spin|anchor|back-top|divider|drawer)',
       '<i class="anticon anticon-',
-      "<link[^>]+href=[\"'][^\"']*\\bantd\\b(?:@([\\d\\.]+))?[^\"']*\\.css",
+      "<link[^>]+href=[\"'][^\"']*?\\bantd\\b(?:[@/]([\\d\\.]+))?[^\"']*\\.css",
     ],
     javascriptVariables: {
       "antd.version": "^([\\d\\.]+)$",

--- a/src/signatures/technologies/swiper.test.ts
+++ b/src/signatures/technologies/swiper.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { applySignature } from "../../analyzer/apply.js";
+import type { Context, Response } from "../../browser/types.js";
+import { swiperSignature } from "./swiper.js";
+
+function createMockContext(
+  overrides: Partial<Pick<Context, "responses">> = {},
+): Context {
+  return {
+    browser: {} as Context["browser"],
+    page: {} as Context["page"],
+    urls: [],
+    responses: [],
+    cookies: [],
+    javascriptVariables: {},
+    timeoutMs: 30000,
+    timeoutOccurred: false,
+    ...overrides,
+  };
+}
+
+function createMockResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    url: "https://example.com",
+    host: "example.com",
+    isFirstParty: true,
+    status: 200,
+    headers: { "content-type": "text/html" },
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("swiperSignature", () => {
+  describe("body matching", () => {
+    it("detects Swiper from the version banner comment", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: "/**\n * Swiper 11.1.14\n * Most modern mobile touch slider\n */",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, swiperSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "11.1.14")).toBe(
+        true,
+      );
+    });
+
+    it("does not detect Swiper from prose that merely mentions the product name", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: "<p>We compared Swiper and other carousel libraries on our blog.</p>",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, swiperSignature);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("URL matching", () => {
+    it("detects Swiper from CDN URL with version", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://cdn.example.com/swiper@11.1.14/swiper-bundle.min.js",
+          }),
+        ],
+      });
+
+      const result = applySignature(context, swiperSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "11.1.14")).toBe(
+        true,
+      );
+    });
+  });
+});

--- a/src/signatures/technologies/swiper.ts
+++ b/src/signatures/technologies/swiper.ts
@@ -8,6 +8,6 @@ export const swiperSignature: Signature = {
   rule: {
     confidence: "high",
     urls: ["swiper[@.-](\\d+\\.\\d+\\.\\d+)?"],
-    bodies: ["Swiper (\\d+\\.\\d+\\.\\d+)?"],
+    bodies: ["Swiper (\\d+\\.\\d+\\.\\d+)"],
   },
 };

--- a/src/signatures/technologies/tailwind_css.test.ts
+++ b/src/signatures/technologies/tailwind_css.test.ts
@@ -85,5 +85,18 @@ describe("tailwindCssSignature", () => {
       const result = applySignature(context, tailwindCssSignature);
       expect(result).toBeUndefined();
     });
+
+    it("does not detect Tailwind from an anchor tag that merely links to a page about Tailwind", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<a href="/blog/category/tailwind-tips">Tailwind Tips</a>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, tailwindCssSignature);
+      expect(result).toBeUndefined();
+    });
   });
 });

--- a/src/signatures/technologies/tailwind_css.ts
+++ b/src/signatures/technologies/tailwind_css.ts
@@ -7,8 +7,8 @@ export const tailwindCssSignature: Signature = {
     confidence: "high",
     bodies: [
       "--tw-(?:rotate|translate|space-x|text-opacity|border-opacity)",
-      "href[^>]+tailwindcss[@|/](?:\\^)?([\\d.]+)(?:/[a-z]+)?/(?:tailwind|base|components|utilities)(?:\\.min)?\\.css",
-      "href[^>]+tailwind",
+      "<link[^>]+href=[\"'][^\"']*tailwindcss[@/](?:\\^)?([\\d.]+)(?:/[a-z]+)?/(?:tailwind|base|components|utilities)(?:\\.min)?\\.css",
+      "<link[^>]+href=[\"'][^\"']*tailwind[^\"']*\\.css",
     ],
     urls: ["\\.tailwindcss(?:tailwind-config-cdn)?\\.(?:com|js)"],
     javascriptVariables: {


### PR DESCRIPTION
## Summary

- Scope the `ant_design` and `tailwind_css` body patterns to `<link>` tag attribute values so they no longer match unrelated `href` + keyword co-occurrences elsewhere in the document (e.g. case-insensitive substring matches in minified JS, or anchor tags that link to pages *about* the library).
- Use `\bantd\b` word boundaries in the ant_design CSS pattern so common filenames like `antd.css` / `antd.min.css` are still detected while sub-word matches (e.g. `antdate.css`, `merchantDashboard.css`) are rejected.
- Require a version number in the `swiper` body pattern — previously the optional group let `Swiper ` alone match any prose that mentioned the product.
- Add unit tests for each signature, including negative cases for the specific false-positive shapes the old patterns allowed.

## Test plan

- [x] `npx vitest run src/signatures` — all signature tests pass (169/169)
- [x] ant_design: positive cases for `ant-*` class, `anticon`, `antd@X.Y.Z` CDN, `antd.css`, `antd.min.css`
- [x] ant_design: negative cases for `antdate.css`, `merchantData`-style sub-word, minified JS with incidental `antD`
- [x] tailwind_css: existing positive cases still pass; new negative case for `<a href="/blog/.../tailwind-tips">`
- [x] swiper: version banner detection, CDN URL detection, prose-mention FP guard