### PR TITLE
feat: detect PHP version from phpinfo during active scan

### DIFF
--- a/src/commands/active_scan_runner.test.ts
+++ b/src/commands/active_scan_runner.test.ts
@@ -4,10 +4,12 @@ import { applyActiveScans } from "./active_scan_runner.js";
 import type { Detection } from "../analyzer/types.js";
 import type { Signature } from "../signatures/_types.js";
 
-const makeRequest = (impl: (url: string) => {
-  status: number;
-  body: string;
-}) => {
+const makeRequest = (
+  impl: (url: string) => {
+    status: number;
+    body: string;
+  },
+) => {
   const get = vi.fn(async (url: string) => {
     const r = impl(url);
     return {
@@ -22,7 +24,9 @@ const makeRequest = (impl: (url: string) => {
 const sig: Signature = {
   name: "Magento",
   rule: { confidence: "high" },
-  activeRules: [{ path: "./magento_version", bodyRegex: "^Magento/(\\S+)" }],
+  activeRules: [
+    { path: "./magento_version", bodyRegexes: ["^Magento/(\\S+)"] },
+  ],
 };
 
 const otherSig: Signature = {
@@ -87,7 +91,7 @@ describe("applyActiveScans", () => {
     expect(detections[0]!.evidences).toEqual([]);
   });
 
-  it("leaves detection unchanged when bodyRegex does not match", async () => {
+  it("leaves detection unchanged when no bodyRegex matches", async () => {
     const detections: Detection[] = [{ name: "Magento", evidences: [] }];
     const { request } = makeRequest(() => ({ status: 200, body: "<html/>" }));
 
@@ -109,7 +113,7 @@ describe("applyActiveScans", () => {
       activeRules: [
         {
           path: "./magento_version",
-          bodyRegex: "^Magento/(\\S+)",
+          bodyRegexes: ["^Magento/(\\S+)"],
           confidence: "low",
         },
       ],
@@ -129,5 +133,59 @@ describe("applyActiveScans", () => {
     );
 
     expect(detections[0]!.evidences![0]!.confidence).toBe("low");
+  });
+
+  it("tries each regex in bodyRegexes and uses the first match", async () => {
+    const sigMulti: Signature = {
+      name: "Multi",
+      rule: { confidence: "high" },
+      activeRules: [
+        {
+          path: "./probe",
+          bodyRegexes: ["^First/(\\S+)", "Second (\\S+)"],
+        },
+      ],
+    };
+    const detections: Detection[] = [{ name: "Multi", evidences: [] }];
+    const { request } = makeRequest(() => ({
+      status: 200,
+      body: "Second 2.0",
+    }));
+
+    await applyActiveScans(
+      "https://example.com/",
+      detections,
+      [sigMulti],
+      request,
+      5000,
+    );
+
+    expect(detections[0]!.evidences).toHaveLength(1);
+    expect(detections[0]!.evidences![0]!.version).toBe("2.0");
+  });
+
+  it("adds no evidence when no regex in bodyRegexes matches", async () => {
+    const sigMulti: Signature = {
+      name: "Multi",
+      rule: { confidence: "high" },
+      activeRules: [
+        {
+          path: "./probe",
+          bodyRegexes: ["^First/(\\S+)", "Second (\\S+)"],
+        },
+      ],
+    };
+    const detections: Detection[] = [{ name: "Multi", evidences: [] }];
+    const { request } = makeRequest(() => ({ status: 200, body: "unrelated" }));
+
+    await applyActiveScans(
+      "https://example.com/",
+      detections,
+      [sigMulti],
+      request,
+      5000,
+    );
+
+    expect(detections[0]!.evidences).toEqual([]);
   });
 });

--- a/src/commands/active_scan_runner.test.ts
+++ b/src/commands/active_scan_runner.test.ts
@@ -188,4 +188,62 @@ describe("applyActiveScans", () => {
 
     expect(detections[0]!.evidences).toEqual([]);
   });
+
+  it("stops probing remaining activeRules once one produces evidence", async () => {
+    const sigMany: Signature = {
+      name: "Many",
+      rule: { confidence: "high" },
+      activeRules: [
+        { path: "./first", bodyRegexes: ["^Many/(\\S+)"] },
+        { path: "./second", bodyRegexes: ["^Many/(\\S+)"] },
+        { path: "./third", bodyRegexes: ["^Many/(\\S+)"] },
+      ],
+    };
+    const detections: Detection[] = [{ name: "Many", evidences: [] }];
+    const { get, request } = makeRequest(() => ({
+      status: 200,
+      body: "Many/1.0",
+    }));
+
+    await applyActiveScans(
+      "https://example.com/",
+      detections,
+      [sigMany],
+      request,
+      5000,
+    );
+
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(detections[0]!.evidences).toHaveLength(1);
+  });
+
+  it("falls through to later activeRules when earlier ones do not match", async () => {
+    const sigMany: Signature = {
+      name: "Many",
+      rule: { confidence: "high" },
+      activeRules: [
+        { path: "./first", bodyRegexes: ["^Many/(\\S+)"] },
+        { path: "./second", bodyRegexes: ["^Many/(\\S+)"] },
+        { path: "./third", bodyRegexes: ["^Many/(\\S+)"] },
+      ],
+    };
+    const detections: Detection[] = [{ name: "Many", evidences: [] }];
+    const { get, request } = makeRequest((url) =>
+      url.endsWith("/second")
+        ? { status: 200, body: "Many/2.0" }
+        : { status: 404, body: "" },
+    );
+
+    await applyActiveScans(
+      "https://example.com/",
+      detections,
+      [sigMany],
+      request,
+      5000,
+    );
+
+    expect(get).toHaveBeenCalledTimes(2);
+    expect(detections[0]!.evidences).toHaveLength(1);
+    expect(detections[0]!.evidences![0]!.version).toBe("2.0");
+  });
 });

--- a/src/commands/active_scan_runner.ts
+++ b/src/commands/active_scan_runner.ts
@@ -27,8 +27,15 @@ export async function applyActiveScans(
       if (!response || response.status !== 200 || !response.body) {
         continue;
       }
-      const result = matchString(response.body, activeRule.bodyRegex);
-      if (!result.hit) continue;
+      let result: ReturnType<typeof matchString> | undefined;
+      for (const regex of activeRule.bodyRegexes) {
+        const candidate = matchString(response.body, regex);
+        if (candidate.hit) {
+          result = candidate;
+          break;
+        }
+      }
+      if (!result) continue;
 
       (detection.evidences ??= []).push({
         type: "body",

--- a/src/commands/active_scan_runner.ts
+++ b/src/commands/active_scan_runner.ts
@@ -45,6 +45,7 @@ export async function applyActiveScans(
         host: response.host,
         sourceUrl: response.url,
       });
+      break;
     }
   }
 }

--- a/src/signatures/_types.ts
+++ b/src/signatures/_types.ts
@@ -27,6 +27,7 @@ export type Signature = {
   cpe?: string;
   runtime?: Runtime;
   rule?: Rule;
+  // First-hit-wins: stops at the first rule that matches.
   activeRules?: ActiveRule[];
   impliedSoftwares?: string[];
 };

--- a/src/signatures/_types.ts
+++ b/src/signatures/_types.ts
@@ -17,7 +17,7 @@ export type Rule = {
 
 export type ActiveRule = {
   path: string;
-  bodyRegex: Regex;
+  bodyRegexes: Regex[];
   confidence?: Confidence;
 };
 

--- a/src/signatures/signatures.test.ts
+++ b/src/signatures/signatures.test.ts
@@ -59,9 +59,7 @@ describe("signatures validation", () => {
       try {
         new RegExp(pattern, "i");
       } catch {
-        throw new Error(
-          `Invalid regex in ${sigName}.${field}: "${pattern}"`,
-        );
+        throw new Error(`Invalid regex in ${sigName}.${field}: "${pattern}"`);
       }
     };
 
@@ -105,11 +103,17 @@ describe("signatures validation", () => {
       }
     });
 
-    it("all activeRules bodyRegex patterns should be valid regex", () => {
+    it("all activeRules bodyRegexes patterns should be valid regex", () => {
       for (const sig of signatures) {
         if (sig.activeRules) {
           for (const [i, rule] of sig.activeRules.entries()) {
-            testRegex(rule.bodyRegex, sig.name, `activeRules[${i}].bodyRegex`);
+            for (const [j, pattern] of rule.bodyRegexes.entries()) {
+              testRegex(
+                pattern,
+                sig.name,
+                `activeRules[${i}].bodyRegexes[${j}]`,
+              );
+            }
           }
         }
       }

--- a/src/signatures/technologies/magento.test.ts
+++ b/src/signatures/technologies/magento.test.ts
@@ -35,23 +35,26 @@ describe("magentoSignature", () => {
 
     it("extracts version from 'Magento/2.4 (Community)'", () => {
       const rule = magentoSignature.activeRules![0]!;
-      const result = matchString("Magento/2.4 (Community)", rule.bodyRegex);
+      const result = matchString(
+        "Magento/2.4 (Community)",
+        rule.bodyRegexes[0]!,
+      );
       expect(result.hit).toBe(true);
       expect(result.version).toBe("2.4");
     });
 
     it("extracts version from 'Magento/2.4.6'", () => {
       const rule = magentoSignature.activeRules![0]!;
-      const result = matchString("Magento/2.4.6", rule.bodyRegex);
+      const result = matchString("Magento/2.4.6", rule.bodyRegexes[0]!);
       expect(result.hit).toBe(true);
       expect(result.version).toBe("2.4.6");
     });
 
     it("does not match unrelated responses", () => {
       const rule = magentoSignature.activeRules![0]!;
-      expect(matchString("<html>not magento</html>", rule.bodyRegex).hit).toBe(
-        false,
-      );
+      expect(
+        matchString("<html>not magento</html>", rule.bodyRegexes[0]!).hit,
+      ).toBe(false);
     });
   });
 });

--- a/src/signatures/technologies/magento.ts
+++ b/src/signatures/technologies/magento.ts
@@ -14,7 +14,7 @@ export const magentoSignature: Signature = {
     },
     urls: ["js/mage", "static/_requirejs", "skin/frontend/"],
     bodies: [
-      "data-requiremodule=\"[^\"]*(?:mage/|Magento_)",
+      'data-requiremodule="[^"]*(?:mage/|Magento_)',
       "text/x-magento-init",
       "data-image-optimizing-origin",
     ],
@@ -34,7 +34,7 @@ export const magentoSignature: Signature = {
   activeRules: [
     {
       path: "/magento_version",
-      bodyRegex: "^Magento/(\\S+)",
+      bodyRegexes: ["^Magento/(\\S+)"],
     },
   ],
   impliedSoftwares: [phpSignature.name, mysqlSignature.name],

--- a/src/signatures/technologies/php.test.ts
+++ b/src/signatures/technologies/php.test.ts
@@ -154,6 +154,31 @@ describe("phpSignature activeRules", () => {
     });
   });
 
+  it("stops probing test.php and phpinfo.php once info.php yields a version", async () => {
+    const detections: Detection[] = [{ name: "PHP", evidences: [] }];
+    const { get, request } = makeRequest((url) =>
+      url.endsWith("/info.php")
+        ? { status: 200, body: phpinfoTableBody("8.1.2") }
+        : { status: 200, body: phpinfoTableBody("9.9.9") },
+    );
+
+    await applyActiveScans(
+      "https://example.com/",
+      detections,
+      [phpSignature],
+      request,
+      5000,
+    );
+
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(get).toHaveBeenCalledWith(
+      "https://example.com/info.php",
+      expect.anything(),
+    );
+    expect(detections[0]!.evidences).toHaveLength(1);
+    expect(detections[0]!.evidences![0]!.version).toBe("8.1.2");
+  });
+
   it("adds no evidence when responses are 200 but body lacks phpinfo marker", async () => {
     const detections: Detection[] = [{ name: "PHP", evidences: [] }];
     const { request } = makeRequest(() => ({

--- a/src/signatures/technologies/php.test.ts
+++ b/src/signatures/technologies/php.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi } from "vitest";
+import type { APIRequestContext } from "playwright";
+import { applyActiveScans } from "../../commands/active_scan_runner.js";
+import type { Detection } from "../../analyzer/types.js";
+import { phpSignature } from "./php.js";
+
+const makeRequest = (
+  impl: (url: string) => { status: number; body: string },
+) => {
+  const get = vi.fn(async (url: string) => {
+    const r = impl(url);
+    return {
+      status: () => r.status,
+      headers: () => ({}),
+      text: async () => r.body,
+    };
+  });
+  return { get, request: { get } as unknown as APIRequestContext };
+};
+
+const phpinfoTableBody = (version: string) =>
+  `<html><body><table>` +
+  `<tr><td class="e">PHP Version</td><td class="v">${version}</td></tr>` +
+  `</table></body></html>`;
+
+const phpinfoTableBodyWithTrailingSpace = (version: string) =>
+  `<html><body><table>` +
+  `<tr><td class="e">PHP Version </td><td class="v">${version} </td></tr>` +
+  `</table></body></html>`;
+
+const phpinfoHeadingBody = (version: string) =>
+  `<html><body><h1 class="p">PHP Version ${version}</h1></body></html>`;
+
+describe("phpSignature activeRules", () => {
+  it("declares probes for info.php, test.php, and phpinfo.php", () => {
+    const paths = phpSignature.activeRules?.map((r) => r.path);
+    expect(paths).toEqual(["/info.php", "/test.php", "/phpinfo.php"]);
+  });
+
+  it("captures version from phpinfo.php table-row body", async () => {
+    const detections: Detection[] = [{ name: "PHP", evidences: [] }];
+    const { request } = makeRequest((url) =>
+      url.endsWith("/phpinfo.php")
+        ? { status: 200, body: phpinfoTableBody("8.1.2") }
+        : { status: 404, body: "" },
+    );
+
+    await applyActiveScans(
+      "https://example.com/",
+      detections,
+      [phpSignature],
+      request,
+      5000,
+    );
+
+    expect(detections[0]!.evidences).toHaveLength(1);
+    expect(detections[0]!.evidences![0]).toMatchObject({
+      type: "body",
+      version: "8.1.2",
+      confidence: "high",
+      sourceUrl: "https://example.com/phpinfo.php",
+    });
+  });
+
+  it("captures version from phpinfo.php table-row body with trailing spaces", async () => {
+    const detections: Detection[] = [{ name: "PHP", evidences: [] }];
+    const { request } = makeRequest((url) =>
+      url.endsWith("/phpinfo.php")
+        ? { status: 200, body: phpinfoTableBodyWithTrailingSpace("8.1.2") }
+        : { status: 404, body: "" },
+    );
+
+    await applyActiveScans(
+      "https://example.com/",
+      detections,
+      [phpSignature],
+      request,
+      5000,
+    );
+
+    expect(detections[0]!.evidences).toHaveLength(1);
+    expect(detections[0]!.evidences![0]).toMatchObject({
+      version: "8.1.2",
+      sourceUrl: "https://example.com/phpinfo.php",
+    });
+  });
+
+  it("captures version from phpinfo.php heading body", async () => {
+    const detections: Detection[] = [{ name: "PHP", evidences: [] }];
+    const { request } = makeRequest((url) =>
+      url.endsWith("/phpinfo.php")
+        ? { status: 200, body: phpinfoHeadingBody("8.2.7") }
+        : { status: 404, body: "" },
+    );
+
+    await applyActiveScans(
+      "https://example.com/",
+      detections,
+      [phpSignature],
+      request,
+      5000,
+    );
+
+    expect(detections[0]!.evidences).toHaveLength(1);
+    expect(detections[0]!.evidences![0]).toMatchObject({
+      version: "8.2.7",
+      sourceUrl: "https://example.com/phpinfo.php",
+    });
+  });
+
+  it("captures version from info.php when phpinfo.php is absent", async () => {
+    const detections: Detection[] = [{ name: "PHP", evidences: [] }];
+    const { request } = makeRequest((url) =>
+      url.endsWith("/info.php")
+        ? { status: 200, body: phpinfoTableBody("7.4.33") }
+        : { status: 404, body: "" },
+    );
+
+    await applyActiveScans(
+      "https://example.com/",
+      detections,
+      [phpSignature],
+      request,
+      5000,
+    );
+
+    expect(detections[0]!.evidences).toHaveLength(1);
+    expect(detections[0]!.evidences![0]).toMatchObject({
+      version: "7.4.33",
+      sourceUrl: "https://example.com/info.php",
+    });
+  });
+
+  it("captures version from test.php when only test.php exposes phpinfo", async () => {
+    const detections: Detection[] = [{ name: "PHP", evidences: [] }];
+    const { request } = makeRequest((url) =>
+      url.endsWith("/test.php")
+        ? { status: 200, body: phpinfoTableBody("8.3.0") }
+        : { status: 404, body: "" },
+    );
+
+    await applyActiveScans(
+      "https://example.com/",
+      detections,
+      [phpSignature],
+      request,
+      5000,
+    );
+
+    expect(detections[0]!.evidences).toHaveLength(1);
+    expect(detections[0]!.evidences![0]).toMatchObject({
+      version: "8.3.0",
+      sourceUrl: "https://example.com/test.php",
+    });
+  });
+
+  it("adds no evidence when responses are 200 but body lacks phpinfo marker", async () => {
+    const detections: Detection[] = [{ name: "PHP", evidences: [] }];
+    const { request } = makeRequest(() => ({
+      status: 200,
+      body: "<html><body>not phpinfo</body></html>",
+    }));
+
+    await applyActiveScans(
+      "https://example.com/",
+      detections,
+      [phpSignature],
+      request,
+      5000,
+    );
+
+    expect(detections[0]!.evidences).toEqual([]);
+  });
+
+  it("does not probe phpinfo paths when PHP is not detected", async () => {
+    const detections: Detection[] = [{ name: "Other", evidences: [] }];
+    const { get, request } = makeRequest(() => ({
+      status: 200,
+      body: phpinfoTableBody("8.1.2"),
+    }));
+
+    await applyActiveScans(
+      "https://example.com/",
+      detections,
+      [phpSignature],
+      request,
+      5000,
+    );
+
+    expect(get).not.toHaveBeenCalled();
+  });
+});

--- a/src/signatures/technologies/php.ts
+++ b/src/signatures/technologies/php.ts
@@ -1,5 +1,10 @@
 import type { Signature } from "../_types.js";
 
+const phpinfoVersionRegexes = [
+  "<h1[^>]*>PHP Version (\\d+\\.\\d+\\.\\d+)",
+  "PHP Version\\s*</td>\\s*<td[^>]*>(\\d+\\.\\d+\\.\\d+)",
+];
+
 export const phpSignature: Signature = {
   name: "PHP",
   description:
@@ -16,4 +21,9 @@ export const phpSignature: Signature = {
       PHPSESSID: ".+",
     },
   },
+  activeRules: [
+    { path: "/info.php", bodyRegexes: phpinfoVersionRegexes },
+    { path: "/test.php", bodyRegexes: phpinfoVersionRegexes },
+    { path: "/phpinfo.php", bodyRegexes: phpinfoVersionRegexes },
+  ],
 };


### PR DESCRIPTION
## Summary

- Detect the PHP version from `phpinfo()` output during active scans. When PHP is detected, probe `/info.php`, `/test.php`, and `/phpinfo.php` (in that order) and extract the version from either the `<h1>PHP Version X.Y.Z</h1>` heading or the `<td>PHP Version</td><td>X.Y.Z</td>` table-row variant of phpinfo output.
- Widen `ActiveRule.bodyRegex: Regex` to `bodyRegexes: Regex[]` so a single path can try multiple patterns. The first matching regex wins within a rule; the first rule that yields evidence short-circuits the remaining rules (priority order).
- Migrate the existing Magento signature to the new field shape.

## Behavior notes

- `activeRules` declaration order is now semantically meaningful (first-hit-wins). For PHP this means a site exposing phpinfo at a well-known path typically costs a single HTTP request instead of three.
- Non-200 responses, empty bodies, and non-matching regexes silently fall through to the next rule.
- Active scans remain opt-in via the `-a` / `--active` flag.

## Test plan

- `npm run build`
- `npm test` (400 passing)
- Runner-level tests cover first-match-wins within `bodyRegexes`, no-match, and short-circuit across `activeRules`.
- PHP-level tests cover both phpinfo variants (heading and table row, including trailing-space form) and verify that an early match on `/info.php` prevents `/test.php` and `/phpinfo.php` from being fetched.
- Manual verification recommended against a site that exposes phpinfo: `whopper detect -a <url>` should produce PHP evidence with `sourceUrl` pointing at the reachable phpinfo path and the extracted `version`.
