### PR TITLE
fix: apply evidence-value length cap to activeRules matches

### DIFF
--- a/src/analyzer/match.test.ts
+++ b/src/analyzer/match.test.ts
@@ -3,7 +3,6 @@ import {
   buildEvidenceValue,
   extractMatchSnippet,
   matchString,
-  truncateBodyForEvidence,
 } from "./match.js";
 
 describe("matchString", () => {
@@ -147,18 +146,5 @@ describe("buildEvidenceValue", () => {
     const empty = { index: undefined, matchLength: undefined };
     expect(buildEvidenceValue("short", empty)).toBe("short");
     expect(buildEvidenceValue("short", empty, "Cookie")).toBe("Cookie: short");
-  });
-});
-
-describe("truncateBodyForEvidence", () => {
-  it("appends ellipsis when the body exceeds 100 characters", () => {
-    const body = "a".repeat(120);
-    expect(truncateBodyForEvidence(body)).toBe(`${"a".repeat(100)}...`);
-  });
-
-  it("returns the body unchanged when it is 100 characters or shorter", () => {
-    expect(truncateBodyForEvidence("Magento/2.4 (Community)")).toBe(
-      "Magento/2.4 (Community)",
-    );
   });
 });

--- a/src/analyzer/match.ts
+++ b/src/analyzer/match.ts
@@ -22,9 +22,6 @@ export const matchString = (value: string, regex: Regex): MatchResult => {
   return { hit: false, version: undefined, index: undefined, matchLength: undefined };
 };
 
-export const truncateBodyForEvidence = (body: string): string =>
-  body.length > 100 ? `${body.substring(0, 100)}...` : body;
-
 export type SnippetOptions = {
   context?: number;
   maxMatchLength?: number;

--- a/src/commands/active_scan_runner.test.ts
+++ b/src/commands/active_scan_runner.test.ts
@@ -217,6 +217,58 @@ describe("applyActiveScans", () => {
     expect(detections[0]!.evidences).toHaveLength(1);
   });
 
+  it("snippets the match instead of truncating the whole body when oversized", async () => {
+    const sigUnanchored: Signature = {
+      name: "Magento",
+      rule: { confidence: "high" },
+      activeRules: [
+        { path: "./magento_version", bodyRegexes: ["Magento/(\\d+\\.\\d+)"] },
+      ],
+    };
+    const detections: Detection[] = [{ name: "Magento", evidences: [] }];
+    const body = `${"a".repeat(300)}Magento/2.4${"b".repeat(300)}`;
+    const { request } = makeRequest(() => ({ status: 200, body }));
+
+    await applyActiveScans(
+      "https://example.com/",
+      detections,
+      [sigUnanchored],
+      request,
+      5000,
+    );
+
+    const value = detections[0]!.evidences![0]!.value;
+    expect(value.startsWith("...")).toBe(true);
+    expect(value.endsWith("...")).toBe(true);
+    expect(value).toContain("Magento/2.4");
+    expect(value.length).toBeLessThan(body.length);
+    expect(detections[0]!.evidences![0]!.version).toBe("2.4");
+  });
+
+  it("keeps the match in evidence even when it sits past the legacy 100-char cutoff", async () => {
+    const sigUnanchored: Signature = {
+      name: "Magento",
+      rule: { confidence: "high" },
+      activeRules: [
+        { path: "./magento_version", bodyRegexes: ["Magento/(\\d+\\.\\d+)"] },
+      ],
+    };
+    const detections: Detection[] = [{ name: "Magento", evidences: [] }];
+    const body = `${"a".repeat(150)}Magento/2.4`;
+    const { request } = makeRequest(() => ({ status: 200, body }));
+
+    await applyActiveScans(
+      "https://example.com/",
+      detections,
+      [sigUnanchored],
+      request,
+      5000,
+    );
+
+    expect(detections[0]!.evidences![0]!.value).toContain("Magento/2.4");
+    expect(detections[0]!.evidences![0]!.version).toBe("2.4");
+  });
+
   it("falls through to later activeRules when earlier ones do not match", async () => {
     const sigMany: Signature = {
       name: "Many",

--- a/src/commands/active_scan_runner.ts
+++ b/src/commands/active_scan_runner.ts
@@ -1,6 +1,6 @@
 import type { APIRequestContext } from "playwright";
 import { fetchActiveRule } from "../browser/active_scan.js";
-import { matchString, truncateBodyForEvidence } from "../analyzer/match.js";
+import { buildEvidenceValue, matchString } from "../analyzer/match.js";
 import type { Detection } from "../analyzer/types.js";
 import type { Signature } from "../signatures/_types.js";
 
@@ -39,7 +39,7 @@ export async function applyActiveScans(
 
       (detection.evidences ??= []).push({
         type: "body",
-        value: truncateBodyForEvidence(response.body),
+        value: buildEvidenceValue(response.body, result),
         version: result.version,
         confidence: activeRule.confidence ?? signature.rule.confidence,
         host: response.host,


### PR DESCRIPTION
## Summary

PR #52 introduced `buildEvidenceValue` to apply a uniform snippet/length-cap
policy (match-centered extraction, oversized-match compression, ellipsis only
when truncated) across url / header / body / cookie / script evidence. The
active-scan path was left out — it still used `truncateBodyForEvidence`, which
blindly clips the response body to the first 100 characters.

That has a real downside: when the matched substring sits past the 100-char
mark (e.g. a phpinfo-style probe response), the evidence ends up containing
only filler text and not the actual match.

This PR routes active-scan body evidence through `buildEvidenceValue` as well,
so the cap policy is consistent everywhere. The now-unused
`truncateBodyForEvidence` helper (and its tests) is removed.

## Changes

- `src/commands/active_scan_runner.ts`: replace `truncateBodyForEvidence(response.body)` with `buildEvidenceValue(response.body, result)` (the `result` from `matchString` is already in scope).
- `src/analyzer/match.ts`: remove `truncateBodyForEvidence` (no remaining callers).
- `src/analyzer/match.test.ts`: drop the corresponding test block.
- `src/commands/active_scan_runner.test.ts`: add tests covering (a) oversized bodies get a match-centered snippet with ellipsis, and (b) a match past the legacy 100-char cutoff is still preserved in the evidence.

## Test plan

- [x] `npm run lint`
- [x] `npm test` (430 passed / 1 skipped; `active_scan_runner.ts` and `match.ts` at 100% coverage)
- [x] `npm run build`
