### PR TITLE
fix: require version adjacent to bootstrap token to avoid CDN-host fa…

### DIFF
--- a/src/signatures/technologies/bootstrap.test.ts
+++ b/src/signatures/technologies/bootstrap.test.ts
@@ -153,6 +153,75 @@ describe("bootstrapSignature", () => {
         result?.evidences?.some((e) => e.version === "4.0.0-rc-1"),
       ).toBe(true);
     });
+
+    it("does not pick up an unrelated library version when the host merely contains 'bootstrap'", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<link rel="stylesheet" href="https://bootstrapcdn.example.com/icon-lib/4.7.0/css/icon-lib.min.css">',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, bootstrapSignature);
+      expect(result).toBeUndefined();
+    });
+
+    it("captures version from a '/bootstrap/x.y.z/' CDN path even when the host contains 'bootstrap'", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<link rel="stylesheet" href="https://bootstrapcdn.example.com/bootstrap/4.5.2/css/bootstrap.min.css">',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, bootstrapSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "4.5.2")).toBe(true);
+    });
+
+    it("captures version from a 'bootstrap@x.y.z' package path", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<link rel="stylesheet" href="https://cdn.example.com/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, bootstrapSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "5.3.2")).toBe(true);
+    });
+
+    it("captures version from a 'twitter-bootstrap/x.y.z' path", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<link rel="stylesheet" href="https://cdn.example.com/ajax/libs/twitter-bootstrap/3.4.1/css/bootstrap.min.css">',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, bootstrapSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "3.4.1")).toBe(true);
+    });
+
+    it("captures version from a 'bootstrap.bundle.min.js' reference loaded via 'bootstrap@x.y.z'", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<script src="https://cdn.example.com/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, bootstrapSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.some((e) => e.version === "5.3.0")).toBe(true);
+    });
   });
 
   describe("javascript variable matching", () => {

--- a/src/signatures/technologies/bootstrap.ts
+++ b/src/signatures/technologies/bootstrap.ts
@@ -9,8 +9,8 @@ export const bootstrapSignature: Signature = {
     confidence: "high",
     bodies: [
       "Bootstrap v(\\d+\\.\\d+\\.\\d+(?:-[a-zA-Z0-9.-]+)?)",
-      "bootstrap[^\"'\\s<>]*?(\\d+\\.\\d+\\.\\d+(?:-[a-zA-Z0-9.-]+)?)[^\"'\\s<>]*?\\.min\\.css",
-      "bootstrap[^\"'\\s<>]*?(\\d+\\.\\d+\\.\\d+(?:-[a-zA-Z0-9.-]+)?)[^\"'\\s<>]*?\\.min\\.js",
+      "bootstrap[-/@.]?(\\d+\\.\\d+\\.\\d+(?:-[a-zA-Z0-9.-]+)?)[^\"'\\s<>]*?\\.min\\.css",
+      "bootstrap[-/@.]?(\\d+\\.\\d+\\.\\d+(?:-[a-zA-Z0-9.-]+)?)[^\"'\\s<>]*?\\.min\\.js",
     ],
     javascriptVariables: {
       "bootstrap.Alert.VERSION": "(\\d+\\.\\d+\\.\\d+(?:-[a-zA-Z0-9.-]+)?)",


### PR DESCRIPTION
## Summary

The Bootstrap signature could report a bogus detection — e.g. `Bootstrap 4.7.0` — for pages that don't actually use Bootstrap, when a CDN host whose name merely contains the substring `bootstrap` serves an *unrelated* library's versioned `.min.css` / `.min.js`. The version of that unrelated library was being captured as if it were Bootstrap's.

## Root cause

The two body patterns in `src/signatures/technologies/bootstrap.ts` allowed any run of non-quote / non-whitespace / non-bracket characters between the literal `bootstrap` and the captured version:

```
bootstrap[^"'\s<>]*?(\d+\.\d+\.\d+(?:-[a-zA-Z0-9.-]+)?)[^"'\s<>]*?\.min\.css
bootstrap[^"'\s<>]*?(\d+\.\d+\.\d+(?:-[a-zA-Z0-9.-]+)?)[^"'\s<>]*?\.min\.js
```

So `<link href="https://<bootstrap-named-host>/<other-lib>/<x.y.z>/.../<other-lib>.min.css">` matched, with the *other* library's `x.y.z` reported as the Bootstrap version.

## Fix

Require the version to sit immediately next to the `bootstrap` token, optionally separated by a single `-`, `.`, `/`, or `@`:

```
bootstrap[-/@.]?(\d+\.\d+\.\d+(?:-[a-zA-Z0-9.-]+)?)[^"'\s<>]*?\.min\.css
bootstrap[-/@.]?(\d+\.\d+\.\d+(?:-[a-zA-Z0-9.-]+)?)[^"'\s<>]*?\.min\.js
```

This only drops matches where unrelated path segments sit between `bootstrap` and the version — i.e. exactly the false-positive shape. Every real-world Bootstrap reference form still matches, because they all glue the version directly to a `bootstrap`, `bootstrap-`, `bootstrap.`, `bootstrap/`, or `bootstrap@` token:

- `bootstrap-x.y.z.min.css`, `bootstrap.x.y.z.min.css`, `bootstrapx.y.z.min.css` (local filenames)
- `/bootstrap/x.y.z/.../bootstrap.min.css` (CDN path style)
- `bootstrap@x.y.z/.../bootstrap.min.css` (npm/package style)
- `twitter-bootstrap/x.y.z/.../bootstrap.min.css`
- `bootstrap@x.y.z/.../bootstrap.bundle.min.js`

The `Bootstrap v(\d+...)` body pattern and the `javascriptVariables` rules are unchanged.

## Tests

Added regression tests in `src/signatures/technologies/bootstrap.test.ts`:

- **Negative** — a `<link>` to a `bootstrap`-substring host serving a different library's versioned `.min.css` no longer produces a detection.
- **Positive** (must keep working) — `/bootstrap/x.y.z/`, `bootstrap@x.y.z`, `twitter-bootstrap/x.y.z`, and `bootstrap.bundle.min.js` via `bootstrap@x.y.z` all still report the correct version.

All pre-existing tests (`bootstrap-4.0.0.min.css`, `bootstrap4.0.0-beta2.min.css`, Popper / jQuery coexistence, `Bootstrap v` header comments, SemVer pre-release identifiers, JS variables) continue to pass.

## Verification

```bash
npm test
# Test Files  73 passed (73)
# Tests       467 passed | 1 skipped (468)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
