### PR TITLE
fix: cap post-load cookie/JS extraction with a hard timeout

### DIFF
--- a/src/browser/index.test.ts
+++ b/src/browser/index.test.ts
@@ -162,6 +162,7 @@ describe("openPage", () => {
 
       expect(mockPage.goto).toHaveBeenCalledWith("https://example.com", {
         waitUntil: "load",
+        timeout: 10000,
       });
     });
 
@@ -1633,7 +1634,7 @@ describe("openPage", () => {
       const result = await openPage("https://example.com", 10000, []);
 
       expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to extract cookies"),
+        expect.stringContaining("Extraction failed"),
       );
       expect(result.cookies).toEqual([]);
     });

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -20,6 +20,13 @@ const MAX_REDIRECT_HOPS = 20;
 const NETWORK_IDLE_THRESHOLD_MS = 2000;
 // Polling interval (ms) for the idle-decision loop.
 const NETWORK_IDLE_POLL_INTERVAL_MS = 200;
+// Default hard budget (ms) for the post-load extraction phase (cookies + JS
+// variables). Heavy SPA pages (e.g. continuous WebGL / requestAnimationFrame
+// loops, autoplaying video) can keep page.evaluate() blocked for many times
+// the navigation timeout. Without a separate budget here, the overall scan
+// can run for several minutes even after `goto` has already exhausted its
+// own timeout. Overridable via OpenPageOptions.extractionTimeoutMs.
+const DEFAULT_EXTRACTION_TIMEOUT_MS = 10000;
 
 function colorizeStatusCode(statusCode: number): string {
   const code = String(statusCode);
@@ -55,6 +62,7 @@ export async function openPage(
     extraHTTPHeaders,
     blockCrossDomainRedirect = false,
     networkIdleThresholdMs = NETWORK_IDLE_THRESHOLD_MS,
+    extractionTimeoutMs = DEFAULT_EXTRACTION_TIMEOUT_MS,
   } = options;
 
   const pageHost = getHostFromUrl(url);
@@ -308,7 +316,12 @@ export async function openPage(
   // so resolve goto at the `load` event (onload fired) and wait for
   // secondary requests triggered by deferred scripts using our own
   // idle-decision loop below.
-  const goto = page.goto(url, { waitUntil: "load" });
+  //
+  // Pass `timeout` explicitly so goto stops trying once our budget is up;
+  // otherwise it would continue in the background until Playwright's default
+  // 30s navigation timeout, leaving subsequent page.* calls blocked on an
+  // unresolved navigation.
+  const goto = page.goto(url, { waitUntil: "load", timeout: timeoutMs });
 
   const result = await Promise.race([
     goto.then(() => "loaded").catch((e) => e.message),
@@ -376,14 +389,16 @@ export async function openPage(
     if (idleWaitTimedOut) {
       timeoutOccurred = true;
       logger.warn(
-        `Timeout of ${timeoutMs}ms exceeded while waiting for network idle after load on ${url}`,
+        `Timeout of ${timeoutMs.toLocaleString("en-US")}ms exceeded while waiting for network idle after load on ${url}`,
       );
     } else {
       logger.info("Page loaded successfully");
     }
   } else if (result === "timeout") {
     timeoutOccurred = true;
-    logger.warn(`Timeout of ${timeoutMs}ms exceeded while loading ${url}`);
+    logger.warn(
+      `Timeout of ${timeoutMs.toLocaleString("en-US")}ms exceeded while loading ${url}`,
+    );
   } else if (blockedByRedirectPolicy) {
     // Already logged by the route handler as "Blocked redirect by policy"
   } else {
@@ -401,8 +416,30 @@ export async function openPage(
   let cookies: Context["cookies"] = [];
   let javascriptVariables: Record<string, unknown> = {};
 
+  // Bound the extraction phase with a hard budget. page.evaluate() in
+  // particular can block for far longer than the navigation timeout on
+  // pages with a saturated main thread (heavy animation, video decoding),
+  // so without this race the overall scan can hang for minutes after the
+  // navigation budget has already been exhausted.
+  const extractionDeadline = Date.now() + extractionTimeoutMs;
+  const withDeadline = async <T>(p: Promise<T>, label: string): Promise<T> => {
+    const remaining = Math.max(0, extractionDeadline - Date.now());
+    return Promise.race([
+      p,
+      sleep(remaining).then(() => {
+        throw new Error(
+          `${label} timeout (${extractionTimeoutMs.toLocaleString("en-US")}ms)`,
+        );
+      }),
+    ]);
+  };
+
   try {
-    cookies = (await page.context().cookies()).map((cookie) => {
+    const rawCookies = await withDeadline(
+      page.context().cookies(),
+      "cookies",
+    );
+    cookies = rawCookies.map((cookie) => {
       const cookieHost = cookie.domain.replace(/^\./, "").toLowerCase();
       return {
         host: cookieHost,
@@ -418,21 +455,23 @@ export async function openPage(
       };
     });
 
-    javascriptVariables = await page.evaluate(
-      ({ varNames, extractFn }) => {
-        // Re-create the function in browser context
-        const fn = new Function("return " + extractFn)();
-        return fn(window, varNames);
-      },
-      {
-        varNames: javascriptVariableNames,
-        extractFn: extractJsVariables.toString(),
-      },
+    javascriptVariables = await withDeadline(
+      page.evaluate(
+        ({ varNames, extractFn }) => {
+          // Re-create the function in browser context
+          const fn = new Function("return " + extractFn)();
+          return fn(window, varNames);
+        },
+        {
+          varNames: javascriptVariableNames,
+          extractFn: extractJsVariables.toString(),
+        },
+      ),
+      "js variables",
     );
-  } catch {
-    logger.warn(
-      "Failed to extract cookies or JavaScript variables (page context may have been destroyed)",
-    );
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    logger.warn(`Extraction failed: ${message.split("\n")[0]}`);
   }
 
   return {

--- a/src/browser/types.ts
+++ b/src/browser/types.ts
@@ -35,6 +35,7 @@ export type OpenPageOptions = {
   extraHTTPHeaders?: Record<string, string> | undefined;
   blockCrossDomainRedirect?: boolean | undefined;
   networkIdleThresholdMs?: number | undefined;
+  extractionTimeoutMs?: number | undefined;
 };
 
 export type Context = {

--- a/src/commands/detect.test.ts
+++ b/src/commands/detect.test.ts
@@ -165,6 +165,7 @@ describe("detectCommand", () => {
           extraHTTPHeaders: undefined,
           blockCrossDomainRedirect: false,
           networkIdleThresholdMs: 2000,
+          extractionTimeoutMs: 10000,
         },
       );
     });

--- a/src/commands/detect.ts
+++ b/src/commands/detect.ts
@@ -48,6 +48,12 @@ export const detectCommand = (): Command => {
       2000,
     )
     .option(
+      "--extraction-timeout <ms>",
+      "Timeout in milliseconds for the post-load cookie / JS variable extraction phase (default: 10000)",
+      (v: string) => Number(v),
+      10000,
+    )
+    .option(
       "-a, --active",
       "Enable active scanning (sends additional requests to technology-specific paths)",
       false,
@@ -65,6 +71,7 @@ export const detectCommand = (): Command => {
           header: string[];
           blockCrossDomainRedirect: boolean;
           idleTimeout: number;
+          extractionTimeout: number;
           active: boolean;
         },
       ) => {
@@ -107,6 +114,7 @@ export const detectCommand = (): Command => {
                 : undefined,
               blockCrossDomainRedirect: options.blockCrossDomainRedirect,
               networkIdleThresholdMs: options.idleTimeout,
+              extractionTimeoutMs: options.extractionTimeout,
             },
           );
           const detections = analyze(context, signatures);


### PR DESCRIPTION
## Summary

- `page.goto` already enforced a navigation timeout, but `page.context().cookies()` and `page.evaluate()` ran with **no time budget** afterwards. On SPAs whose main thread is saturated (continuous WebGL / `requestAnimationFrame` loops, autoplaying media), `page.evaluate()` could block for **several minutes** even after the navigation budget had been exhausted — hanging the whole scan.
- Wrap the post-load cookie + JS variable extraction phase with a separate hard budget via `Promise.race` (default **10,000 ms**), and pass `timeout: timeoutMs` explicitly to `page.goto` so it stops cleanly at our budget instead of leaking up to Playwright's default 30s.
- Expose `--extraction-timeout <ms>` so the budget is configurable per scan.
- Format `ms` values with thousand-separators in warn logs for readability (matches the existing `Timeout set to 10,000ms` style).

## Reproduction / verification

Repro'd on a heavy SPA (continuous WebGL / `requestAnimationFrame` loop plus autoplaying media).

| Before | After |
|---|---|
| Hung for 3+ minutes (still running when killed at 180s shell timeout) | Completes in ~21s with default settings, detects expected technologies |

The extraction-phase timeout fires gracefully on heavy SPAs:

```
[WARN] Timeout of 10,000ms exceeded while loading <url>
[WARN] Extraction failed: js variables timeout (10,000ms)
```

Signatures matching on `headers` / `bodies` / `urls` are unaffected by an extraction timeout (those are captured during navigation via the response listener). Only `cookies` / `javascriptVariables` rules lose evidence on a timeout, which was the previous behavior under pathological conditions anyway.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 467 passed / 1 skipped
- [x] Manual scan of the previously-hanging heavy SPA now completes within budget
- [x] Manual scan of `https://example.com` and `https://www.github.com` shows no regression in detected technologies
- [x] `--extraction-timeout 2000` override behaves as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)