### PR TITLE
feat(signatures): add Movable Type detection

### DIFF
--- a/src/signatures/index.ts
+++ b/src/signatures/index.ts
@@ -434,6 +434,7 @@ import { onepressSocialLockerSignature } from "./technologies/onepress_social_lo
 import { wpStatisticsSignature } from "./technologies/wp_statistics.js";
 import { pwaSignature } from "./technologies/pwa.js";
 import { stripeSignature } from "./technologies/stripe.js";
+import { movableTypeSignature } from "./technologies/movable_type.js";
 
 export const signatures: Signature[] = [
   addToAnySignature,
@@ -870,4 +871,5 @@ export const signatures: Signature[] = [
   wpStatisticsSignature,
   pwaSignature,
   stripeSignature,
+  movableTypeSignature,
 ];

--- a/src/signatures/technologies/movable_type.test.ts
+++ b/src/signatures/technologies/movable_type.test.ts
@@ -138,4 +138,8 @@ describe("movableTypeSignature", () => {
   it("uses the Six Apart Movable Type CPE 2.2 identifier", () => {
     expect(movableTypeSignature.cpe).toBe("cpe:/a:sixapart:movable_type");
   });
+
+  it("implies Perl as the underlying runtime", () => {
+    expect(movableTypeSignature.impliedSoftwares).toContain("Perl");
+  });
 });

--- a/src/signatures/technologies/movable_type.test.ts
+++ b/src/signatures/technologies/movable_type.test.ts
@@ -51,6 +51,17 @@ describe("movableTypeSignature", () => {
       expect(result.version).toBe("7.9.7");
     });
 
+    it("extracts the mt.js version regardless of quoting or trailing params", () => {
+      const verRegex = bodies.find((r) => r.includes("mt\\.js"))!;
+      const singleQuoted = matchString(
+        "<script src='/mt-static/mt.js?v=7.9.7'></script>",
+        verRegex,
+      );
+      expect(singleQuoted.version).toBe("7.9.7");
+      const extraParams = matchString('"/mt-static/mt.js?v=7.9.7&cb=1"', verRegex);
+      expect(extraParams.version).toBe("7.9.7");
+    });
+
     it("does not match an escaped generator example quoted in an article", () => {
       const html =
         'Movable Type emits &lt;meta name="generator" ' +

--- a/src/signatures/technologies/movable_type.test.ts
+++ b/src/signatures/technologies/movable_type.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { matchString } from "../../analyzer/match.js";
+import { movableTypeSignature } from "./movable_type.js";
+
+describe("movableTypeSignature", () => {
+  describe("rule (passive, public-facing markers)", () => {
+    const bodies = movableTypeSignature.rule?.bodies ?? [];
+    const urls = movableTypeSignature.rule?.urls ?? [];
+    const generatorRegex = bodies.find((r) => r.includes("generator"))!;
+
+    it("matches the generator meta tag without a version", () => {
+      const html = '<meta name="generator" content="Movable Type" />';
+      const result = matchString(html, generatorRegex);
+      expect(result.hit).toBe(true);
+      expect(result.version).toBeUndefined();
+    });
+
+    it("extracts the version from the generator meta tag", () => {
+      const html =
+        '<meta name="generator" content="Movable Type Pro 7.9.1" />';
+      const result = matchString(html, generatorRegex);
+      expect(result.hit).toBe(true);
+      expect(result.version).toBe("7.9.1");
+    });
+
+    it("matches mt-static asset URLs", () => {
+      const url = "https://example.com/mt-static/themes-base/blog.css";
+      expect(urls.some((r) => matchString(url, r).hit)).toBe(true);
+    });
+
+    it("matches the admin image marker", () => {
+      const html = '<a href="mt.cgi"><img alt="Movable Type" src="logo.png">';
+      expect(bodies.some((r) => matchString(html, r).hit)).toBe(true);
+    });
+
+    it("extracts the version from the mt-static mt.js asset reference", () => {
+      const verRegex = bodies.find((r) => r.includes("mt\\.js"))!;
+      const result = matchString(
+        '<script src="/mt-static/mt.js?v=7.9.7"></script>',
+        verRegex,
+      );
+      expect(result.hit).toBe(true);
+      expect(result.version).toBe("7.9.7");
+    });
+
+    it("does not match an escaped generator example quoted in an article", () => {
+      const html =
+        'Movable Type emits &lt;meta name="generator" ' +
+        'content="Movable Type 7"&gt; in the head.';
+      expect(bodies.some((r) => matchString(html, r).hit)).toBe(false);
+    });
+
+    it("does not match an unrelated page", () => {
+      const html =
+        '<html><head><title>Some Blog</title>' +
+        '<meta name="generator" content="WordPress 6.5" /></head></html>';
+      expect(bodies.some((r) => matchString(html, r).hit)).toBe(false);
+    });
+  });
+
+  describe("activeRules (mt.cgi admin probe)", () => {
+    const rules = movableTypeSignature.activeRules ?? [];
+
+    it("probes the root and common install dirs with logout mode", () => {
+      expect(rules.map((r) => r.path)).toEqual([
+        "/mt.cgi?__mode=logout",
+        "/mt/mt.cgi?__mode=logout",
+        "/cgi-bin/mt/mt.cgi?__mode=logout",
+        "/blog/mt.cgi?__mode=logout",
+      ]);
+    });
+
+    it("detects the MT v2, v3 and v4 admin-page markers", () => {
+      const regexes = rules[0]!.bodyRegexes;
+      const v2 = "<html><head><title>MOVABLE TYPE</title></head></html>";
+      const v3 = '<a href="mt.cgi"><img alt="Movable Type" src="x">';
+      const v4 = "<title>Sign in | Movable Type</title>";
+      for (const html of [v2, v3, v4]) {
+        expect(regexes.some((r) => matchString(html, r).hit)).toBe(true);
+      }
+    });
+
+    it("extracts the version from the mt.js asset reference", () => {
+      const regex = rules[0]!.bodyRegexes.find((r) => r.includes("mt\\.js"))!;
+      const result = matchString('src="/mt.js?v=5.2.6"', regex);
+      expect(result.hit).toBe(true);
+      expect(result.version).toBe("5.2.6");
+    });
+
+    it("extracts the version from the 'Version x.y' marker (MT v2/v3)", () => {
+      const regex = rules[0]!.bodyRegexes.find((r) => r.includes("Version"))!;
+      const result = matchString("<b>Version 3.2</b>", regex);
+      expect(result.hit).toBe(true);
+      expect(result.version).toBe("3.2");
+    });
+
+    it("keeps a non-numeric version suffix (e.g. Japanese editions)", () => {
+      const regex = rules[0]!.bodyRegexes.find((r) => r.includes("Version"))!;
+      const result = matchString("<b>Version 3.36-ja</b>", regex);
+      expect(result.hit).toBe(true);
+      expect(result.version).toBe("3.36-ja");
+    });
+
+    it("does not over-capture across multiple <b> tags", () => {
+      const regex = rules[0]!.bodyRegexes.find((r) => r.includes("Version"))!;
+      const result = matchString("<b>Version 3.2</b> x <b>y</b>", regex);
+      expect(result.hit).toBe(true);
+      expect(result.version).toBe("3.2");
+    });
+
+    it("does not match an unrelated response", () => {
+      const probe = rules[0]!;
+      expect(
+        probe.bodyRegexes.some((r) => matchString("<html>not mt</html>", r).hit),
+      ).toBe(false);
+    });
+  });
+
+  it("uses the Six Apart Movable Type CPE 2.2 identifier", () => {
+    expect(movableTypeSignature.cpe).toBe("cpe:/a:sixapart:movable_type");
+  });
+});

--- a/src/signatures/technologies/movable_type.test.ts
+++ b/src/signatures/technologies/movable_type.test.ts
@@ -23,6 +23,14 @@ describe("movableTypeSignature", () => {
       expect(result.version).toBe("7.9.1");
     });
 
+    it("matches a single-quoted generator meta tag", () => {
+      const html =
+        "<meta name='generator' content='Movable Type Pro 7.9.1' />";
+      const result = matchString(html, generatorRegex);
+      expect(result.hit).toBe(true);
+      expect(result.version).toBe("7.9.1");
+    });
+
     it("matches mt-static asset URLs", () => {
       const url = "https://example.com/mt-static/themes-base/blog.css";
       expect(urls.some((r) => matchString(url, r).hit)).toBe(true);

--- a/src/signatures/technologies/movable_type.ts
+++ b/src/signatures/technologies/movable_type.ts
@@ -42,9 +42,10 @@ export const movableTypeSignature: Signature = {
       // generator meta tag emitted by the default templates, e.g.
       // <meta name="generator" content="Movable Type Pro 7.9.1" />.
       // Anchored to a literal <meta tag so escaped examples (&lt;meta ...) in
-      // articles about MT don't match. The trailing optional group captures
-      // the version when present.
-      '<meta[^>]*name="generator"[^>]*content="Movable Type[^"0-9]*([0-9]+(?:\\.[0-9]+)*)?',
+      // articles about MT don't match; accepts single or double quotes like the
+      // other generator signatures. The trailing optional group captures the
+      // version when present.
+      "<meta[^>]+name=[\"']generator[\"'][^>]+content=[\"']Movable Type[^\"'0-9]*([0-9]+(?:\\.[0-9]+)*)?",
       'mt\\.cgi"><img alt="Movable Type"', // admin marker, specific enough for passive use
       // Versioned mt.js asset, e.g. src="/mt-static/mt.js?v=7.9.7". On the admin
       // page this is often the only detection + version source (the mt-static

--- a/src/signatures/technologies/movable_type.ts
+++ b/src/signatures/technologies/movable_type.ts
@@ -1,4 +1,5 @@
 import type { ActiveRule, Signature } from "../_types.js";
+import { perlSignature } from "./perl.js";
 
 // Probe common install dirs for the mt.cgi admin page. The logout mode avoids
 // the redirect to mt-update.cgi on installs that need updating. Each probe
@@ -55,4 +56,5 @@ export const movableTypeSignature: Signature = {
     ],
   },
   activeRules,
+  impliedSoftwares: [perlSignature.name], // Movable Type is a Perl CGI application
 };

--- a/src/signatures/technologies/movable_type.ts
+++ b/src/signatures/technologies/movable_type.ts
@@ -5,7 +5,7 @@ import type { ActiveRule, Signature } from "../_types.js";
 // mirrors the three admin-page markers (MT v2/v3/v4); the version-bearing
 // patterns come first so the version is captured when available.
 const adminPageRegexes = [
-  '/mt\\.js\\?v=([0-9.]+)"', // version (MT v4)
+  '/mt\\.js\\?v=([0-9]+(?:\\.[0-9]+)*)', // version (MT v4)
   // version (MT v2.x / v3.x). Capture from the first digit up to the next tag
   // so non-numeric suffixes (e.g. "3.36-ja" on Japanese editions) are kept
   // without greedily spanning later </b> tags.
@@ -49,8 +49,9 @@ export const movableTypeSignature: Signature = {
       'mt\\.cgi"><img alt="Movable Type"', // admin marker, specific enough for passive use
       // Versioned mt.js asset, e.g. src="/mt-static/mt.js?v=7.9.7". On the admin
       // page this is often the only detection + version source (the mt-static
-      // URL rule may miss it when subresources aren't captured).
-      '/mt\\.js\\?v=([0-9.]+)"',
+      // URL rule may miss it when subresources aren't captured). No trailing
+      // delimiter so single/double quotes and extra query params all work.
+      '/mt\\.js\\?v=([0-9]+(?:\\.[0-9]+)*)',
     ],
   },
   activeRules,

--- a/src/signatures/technologies/movable_type.ts
+++ b/src/signatures/technologies/movable_type.ts
@@ -1,0 +1,56 @@
+import type { ActiveRule, Signature } from "../_types.js";
+
+// Probe common install dirs for the mt.cgi admin page. The logout mode avoids
+// the redirect to mt-update.cgi on installs that need updating. Each probe
+// mirrors the three admin-page markers (MT v2/v3/v4); the version-bearing
+// patterns come first so the version is captured when available.
+const adminPageRegexes = [
+  '/mt\\.js\\?v=([0-9.]+)"', // version (MT v4)
+  // version (MT v2.x / v3.x). Capture from the first digit up to the next tag
+  // so non-numeric suffixes (e.g. "3.36-ja" on Japanese editions) are kept
+  // without greedily spanning later </b> tags.
+  "<b>Version ([0-9][^<]*)</b>",
+  "<title>MOVABLE TYPE", // MT v2 marker
+  'mt\\.cgi"><img alt="Movable Type"', // MT v3 marker
+  "Movable Type</title>", // MT v4 marker
+];
+
+const activeRules: ActiveRule[] = [
+  "/mt.cgi?__mode=logout", // root install (common)
+  "/mt/mt.cgi?__mode=logout",
+  "/cgi-bin/mt/mt.cgi?__mode=logout",
+  "/blog/mt.cgi?__mode=logout",
+].map((path) => ({ path, bodyRegexes: adminPageRegexes }));
+
+// Detects Movable Type from public-facing pages (generator meta tag, mt-static
+// assets) and, once detected, confirms/extracts the version via the mt.cgi
+// admin page probed by the active rules above.
+export const movableTypeSignature: Signature = {
+  name: "Movable Type",
+  description:
+    "Movable Type is a weblog publishing system written in Perl by Six Apart.",
+  cpe: "cpe:/a:sixapart:movable_type", // CPE 2.2
+  rule: {
+    // Passive markers that appear on public-facing pages, so detection (and the
+    // active mt.cgi probe, which only runs for already-detected technologies)
+    // can fire without hitting the admin login page.
+    confidence: "high",
+    urls: [
+      "/mt-static/", // default StaticWebPath, referenced by public templates
+    ],
+    bodies: [
+      // generator meta tag emitted by the default templates, e.g.
+      // <meta name="generator" content="Movable Type Pro 7.9.1" />.
+      // Anchored to a literal <meta tag so escaped examples (&lt;meta ...) in
+      // articles about MT don't match. The trailing optional group captures
+      // the version when present.
+      '<meta[^>]*name="generator"[^>]*content="Movable Type[^"0-9]*([0-9]+(?:\\.[0-9]+)*)?',
+      'mt\\.cgi"><img alt="Movable Type"', // admin marker, specific enough for passive use
+      // Versioned mt.js asset, e.g. src="/mt-static/mt.js?v=7.9.7". On the admin
+      // page this is often the only detection + version source (the mt-static
+      // URL rule may miss it when subresources aren't captured).
+      '/mt\\.js\\?v=([0-9.]+)"',
+    ],
+  },
+  activeRules,
+};


### PR DESCRIPTION
## Summary

Adds a signature to detect **Movable Type** (Six Apart's Perl weblog/CMS platform).

## Detection

**Passive (public-facing pages):**
- `generator` meta tag, e.g. `<meta name="generator" content="Movable Type Pro 7.9.1">` — anchored to a literal `<meta` tag so escaped examples in articles don't false-match; extracts the version when present.
- `/mt-static/` asset URLs (default StaticWebPath).
- Versioned `mt.js` reference, e.g. `src="/mt-static/mt.js?v=7.9.7"` — also yields the version.
- Admin image marker `mt.cgi"><img alt="Movable Type"`.

**Active (version enrichment):** probes the `mt.cgi` admin page (logout mode) under the root and common install dirs (`/`, `/mt`, `/cgi-bin/mt`, `/blog`), extracting the version from the `mt.js` query or the admin `Version x.y` string (non-numeric suffixes such as Japanese-edition `-ja` are preserved).

- CPE: `cpe:/a:sixapart:movable_type` (CPE 2.2)

## Tests

`src/signatures/technologies/movable_type.test.ts` — 15 cases covering each passive marker, version extraction, the active probe paths, escaped-example false-positive guard, and over-capture guards. Full suite passes (482 tests), lint and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)