### PR TITLE
[codex] fix publish lint on generated files

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -4,6 +4,7 @@ import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([
+  { ignores: ["dist/**", "coverage/**"] },
   { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: globals.browser } },
   tseslint.configs.recommended,
 ]);


### PR DESCRIPTION
## Summary
- Ignore generated `dist/**` and `coverage/**` paths in ESLint config.
- Prevent the publish workflow's `npm version` preversion hook from linting test/build outputs.

## Root cause
The publish workflow runs `npm test` before `npm version`. Tests generate `coverage/` and may build `dist/`; then `npm version` runs `preversion`, which executes `npm run lint`. Because ESLint was scanning the whole repository, generated files caused `no-undef` failures on `process`.

## Validation
- `npm run lint`
- `npm run clean`
- `npm test`
- `npm run lint` after tests generated `dist/` and `coverage/`
