### PR TITLE
feat(signatures): improve Drupal detection accuracy

### DIFF
--- a/src/signatures/technologies/drupal.test.ts
+++ b/src/signatures/technologies/drupal.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from "vitest";
+import type { APIRequestContext } from "playwright";
+import { applyActiveScans } from "../../commands/active_scan_runner.js";
+import type { Detection } from "../../analyzer/types.js";
+import { drupalSignature } from "./drupal.js";
+
+const makeRequest = (
+  impl: (url: string) => { status: number; body: string },
+) => {
+  const get = vi.fn(async (url: string) => {
+    const r = impl(url);
+    return {
+      status: () => r.status,
+      headers: () => ({}),
+      text: async () => r.body,
+    };
+  });
+  return { get, request: { get } as unknown as APIRequestContext };
+};
+
+const changelog = (version: string, date: string) =>
+  `Drupal ${version}, ${date}\n` +
+  `----------------------\n` +
+  `- Fixed a bunch of things.\n`;
+
+const installPage = (version: string) =>
+  `<html><body><span class="site-version">${version}</span></body></html>`;
+
+describe("drupalSignature activeRules", () => {
+  it("declares probes for /CHANGELOG.txt, /core/CHANGELOG.txt, then /core/install.php", () => {
+    const paths = drupalSignature.activeRules?.map((r) => r.path);
+    expect(paths).toEqual([
+      "/CHANGELOG.txt",
+      "/core/CHANGELOG.txt",
+      "/core/install.php",
+    ]);
+  });
+
+  it("captures version from /CHANGELOG.txt (Drupal 7 layout)", async () => {
+    const detections: Detection[] = [{ name: "Drupal", evidences: [] }];
+    const { request } = makeRequest((url) =>
+      url.endsWith("/CHANGELOG.txt") && !url.endsWith("/core/CHANGELOG.txt")
+        ? { status: 200, body: changelog("7.35", "2015-03-18") }
+        : { status: 404, body: "" },
+    );
+
+    await applyActiveScans(
+      "https://example.com/",
+      detections,
+      [drupalSignature],
+      request,
+      5000,
+    );
+
+    expect(detections[0]!.evidences).toHaveLength(1);
+    expect(detections[0]!.evidences![0]).toMatchObject({
+      type: "body",
+      version: "7.35",
+      confidence: "high",
+      sourceUrl: "https://example.com/CHANGELOG.txt",
+    });
+  });
+
+  it("captures version from /core/CHANGELOG.txt when root CHANGELOG.txt is absent (Drupal 8+)", async () => {
+    const detections: Detection[] = [{ name: "Drupal", evidences: [] }];
+    const { request } = makeRequest((url) =>
+      url.endsWith("/core/CHANGELOG.txt")
+        ? { status: 200, body: changelog("9.4.5", "2022-08-03") }
+        : { status: 404, body: "" },
+    );
+
+    await applyActiveScans(
+      "https://example.com/",
+      detections,
+      [drupalSignature],
+      request,
+      5000,
+    );
+
+    expect(detections[0]!.evidences).toHaveLength(1);
+    expect(detections[0]!.evidences![0]).toMatchObject({
+      version: "9.4.5",
+      sourceUrl: "https://example.com/core/CHANGELOG.txt",
+    });
+  });
+
+  it("falls back to /core/install.php site-version span when no CHANGELOG.txt exists", async () => {
+    const detections: Detection[] = [{ name: "Drupal", evidences: [] }];
+    const { request } = makeRequest((url) =>
+      url.endsWith("/core/install.php")
+        ? { status: 200, body: installPage("10.1.0") }
+        : { status: 404, body: "" },
+    );
+
+    await applyActiveScans(
+      "https://example.com/",
+      detections,
+      [drupalSignature],
+      request,
+      5000,
+    );
+
+    expect(detections[0]!.evidences).toHaveLength(1);
+    expect(detections[0]!.evidences![0]).toMatchObject({
+      version: "10.1.0",
+      sourceUrl: "https://example.com/core/install.php",
+    });
+  });
+
+  it("does not probe any path when Drupal is not detected", async () => {
+    const detections: Detection[] = [{ name: "Other", evidences: [] }];
+    const { get, request } = makeRequest(() => ({
+      status: 200,
+      body: changelog("9.4.5", "2022-08-03"),
+    }));
+
+    await applyActiveScans(
+      "https://example.com/",
+      detections,
+      [drupalSignature],
+      request,
+      5000,
+    );
+
+    expect(get).not.toHaveBeenCalled();
+  });
+});

--- a/src/signatures/technologies/drupal.ts
+++ b/src/signatures/technologies/drupal.ts
@@ -1,6 +1,12 @@
 import type { Signature } from "../_types.js";
 import { phpSignature } from "./php.js";
 
+// CHANGELOG.txt starts with the newest release line, e.g. "Drupal 7.35, 2015-03-18".
+// Requiring the trailing date guards against matching unrelated "Drupal X" prose.
+const drupalChangelogVersionRegexes = [
+  "Drupal\\s+(\\d+\\.\\d+(?:\\.\\d+)?(?:-[a-z0-9.]+)?),\\s*20\\d\\d",
+];
+
 export const drupalSignature: Signature = {
   name: "Drupal",
   description: "Drupal is a free and open-source web content management framework.",
@@ -10,16 +16,28 @@ export const drupalSignature: Signature = {
     headers: {
       Expires: "19 Nov 1978",
       "X-Drupal-Cache": "",
+      "X-Drupal-Dynamic-Cache": "",
       "X-Generator": "^Drupal(?:\\s([\\d.]+))?",
     },
     bodies: [
       "<(?:link|style)[^>]+\"/sites/(?:default|all)/(?:themes|modules)/",
       "<meta[^>]+name=[\"']generator[\"'][^>]+content=[\"']Drupal(?:\\s([\\d.]+))?",
+      "Drupal\\.settings",
+      "data-drupal-selector=[\"']drupal-settings-json",
     ],
     urls: ["drupal\\.js"],
     javascriptVariables: {
       Drupal: "",
+      drupalSettings: "",
     },
   },
+  activeRules: [
+    { path: "/CHANGELOG.txt", bodyRegexes: drupalChangelogVersionRegexes },
+    { path: "/core/CHANGELOG.txt", bodyRegexes: drupalChangelogVersionRegexes },
+    {
+      path: "/core/install.php",
+      bodyRegexes: ["<span class=[\"']site-version[\"']>([0-9.a-z-]+)</span>"],
+    },
+  ],
   impliedSoftwares: [phpSignature.name],
 };


### PR DESCRIPTION
## Summary

Enhance the Drupal signature with markers for modern Drupal (8/9/10/11) and add active version-probing rules (run only with `--active`) to improve detection accuracy.

## Changes

### Passive `rule` enhancements
- header: `X-Drupal-Dynamic-Cache` (strong Drupal 8+ indicator)
- body: `Drupal.settings` (Drupal 7) and `data-drupal-selector="drupal-settings-json"` (Drupal 8+ settings JSON)
- javascriptVariable: `drupalSettings` (`window.drupalSettings`, Drupal 8+)

These markers are all Drupal-specific, so they increase coverage without raising false positives.

### New activeRules (run only with `--active`)
For precise version extraction, tried in first-hit-wins order:
- `/CHANGELOG.txt` (Drupal < 8)
- `/core/CHANGELOG.txt` (Drupal 8+) — extracts version from the `Drupal X.Y.Z, YYYY` line
- `/core/install.php` `site-version` span (fallback)

### Tests
Add `drupal.test.ts` covering activeRules path order, version extraction from CHANGELOG.txt / core install.php, and the guard that no request is sent when Drupal is not detected.

## Verification

- `npm run lint` / `npm run build` / `npm run test` (490 passing, including 5 new)
- Confirmed against a live Drupal 11 site (passive scan): the three new markers (`data-drupal-selector` / `X-Drupal-Dynamic-Cache` / `drupalSettings`) match and Drupal is detected with high confidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)