### PR TITLE
feat: block media (video/audio) requests by default during scans

### DIFF
--- a/src/browser/index.test.ts
+++ b/src/browser/index.test.ts
@@ -349,6 +349,41 @@ describe("openPage", () => {
       });
     });
 
+    it("should record blocked media as a body-less response to preserve URL detection", async () => {
+      let routeHandler: (route: unknown) => Promise<void> = async () => {};
+      mockPage.route.mockImplementation(
+        async (
+          _pattern: string,
+          handler: (route: unknown) => Promise<void>,
+        ) => {
+          routeHandler = handler;
+        },
+      );
+
+      const result = await openPage("https://example.com", 10000, []);
+
+      await routeHandler({
+        request: () => ({
+          resourceType: () => "media",
+          isNavigationRequest: () => false,
+          frame: () => mockMainFrame,
+          url: () => "https://example.com/intro.mov",
+        }),
+        continue: vi.fn(() => Promise.resolve()),
+        abort: vi.fn(() => Promise.resolve()),
+      });
+
+      // URL signatures match against responses[].url (analyzer/apply.ts), so the
+      // blocked media URL must still appear in responses (body-less) so that
+      // URL-based detection on a media URL is not silently lost.
+      const blocked = result.responses.find(
+        (response) => response.url === "https://example.com/intro.mov",
+      );
+      expect(blocked).toBeDefined();
+      expect(blocked?.body).toBeUndefined();
+      expect(blocked?.isFirstParty).toBe(true);
+    });
+
     it("should not abort media requests when blockMedia is false", async () => {
       let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(

--- a/src/browser/index.test.ts
+++ b/src/browser/index.test.ts
@@ -7,7 +7,6 @@ vi.mock("playwright", () => {
     on: vi.fn(),
     off: vi.fn(),
     route: vi.fn(),
-    unroute: vi.fn(() => Promise.resolve()),
     mainFrame: vi.fn(),
     goto: vi.fn(),
     context: vi.fn(),
@@ -60,7 +59,6 @@ describe("openPage", () => {
     on: ReturnType<typeof vi.fn>;
     off: ReturnType<typeof vi.fn>;
     route: ReturnType<typeof vi.fn>;
-    unroute: ReturnType<typeof vi.fn>;
     mainFrame: ReturnType<typeof vi.fn>;
     goto: ReturnType<typeof vi.fn>;
     context: ReturnType<typeof vi.fn>;
@@ -85,7 +83,6 @@ describe("openPage", () => {
       on: vi.fn(),
       off: vi.fn(),
       route: vi.fn(),
-      unroute: vi.fn(() => Promise.resolve()),
       mainFrame: vi.fn(),
       goto: vi.fn(() => Promise.resolve()),
       context: vi.fn(),

--- a/src/browser/index.test.ts
+++ b/src/browser/index.test.ts
@@ -226,6 +226,7 @@ describe("openPage", () => {
       const fulfillMock = vi.fn(() => Promise.resolve());
       await routeHandler({
         request: () => ({
+          resourceType: () => "document",
           isNavigationRequest: () => true,
           frame: () => mockMainFrame,
           url: () => "https://www.example.com",
@@ -266,6 +267,7 @@ describe("openPage", () => {
       const fulfillMock = vi.fn(() => Promise.resolve());
       await routeHandler({
         request: () => ({
+          resourceType: () => "document",
           isNavigationRequest: () => true,
           frame: () => mockMainFrame,
           url: () => "https://example.net",
@@ -300,9 +302,74 @@ describe("openPage", () => {
       const abortMock = vi.fn(() => Promise.resolve());
       await routeHandler({
         request: () => ({
+          resourceType: () => "document",
           isNavigationRequest: () => false,
           frame: () => mockMainFrame,
           url: () => "https://example.net/script.js",
+        }),
+        continue: continueMock,
+        abort: abortMock,
+      });
+
+      expect(continueMock).toHaveBeenCalledTimes(1);
+      expect(abortMock).not.toHaveBeenCalled();
+    });
+
+    it("should abort media requests by default and record them in urls", async () => {
+      let routeHandler: (route: unknown) => Promise<void> = async () => {};
+      mockPage.route.mockImplementation(
+        async (
+          _pattern: string,
+          handler: (route: unknown) => Promise<void>,
+        ) => {
+          routeHandler = handler;
+        },
+      );
+
+      const result = await openPage("https://example.com", 10000, []);
+
+      const continueMock = vi.fn(() => Promise.resolve());
+      const abortMock = vi.fn(() => Promise.resolve());
+      await routeHandler({
+        request: () => ({
+          resourceType: () => "media",
+          isNavigationRequest: () => false,
+          frame: () => mockMainFrame,
+          url: () => "https://example.com/intro.mov",
+        }),
+        continue: continueMock,
+        abort: abortMock,
+      });
+
+      expect(abortMock).toHaveBeenCalledWith("blockedbyclient");
+      expect(continueMock).not.toHaveBeenCalled();
+      expect(result.urls).toContainEqual({
+        url: "https://example.com/intro.mov",
+        error: "blocked: media",
+      });
+    });
+
+    it("should not abort media requests when blockMedia is false", async () => {
+      let routeHandler: (route: unknown) => Promise<void> = async () => {};
+      mockPage.route.mockImplementation(
+        async (
+          _pattern: string,
+          handler: (route: unknown) => Promise<void>,
+        ) => {
+          routeHandler = handler;
+        },
+      );
+
+      await openPage("https://example.com", 10000, [], { blockMedia: false });
+
+      const continueMock = vi.fn(() => Promise.resolve());
+      const abortMock = vi.fn(() => Promise.resolve());
+      await routeHandler({
+        request: () => ({
+          resourceType: () => "media",
+          isNavigationRequest: () => false,
+          frame: () => mockMainFrame,
+          url: () => "https://example.com/intro.mov",
         }),
         continue: continueMock,
         abort: abortMock,
@@ -331,6 +398,7 @@ describe("openPage", () => {
       const abortMock = vi.fn(() => Promise.resolve());
       await routeHandler({
         request: () => ({
+          resourceType: () => "document",
           isNavigationRequest: () => true,
           frame: () => ({ id: "iframe-1" }),
           url: () => "https://example.net/embedded",
@@ -366,6 +434,7 @@ describe("openPage", () => {
       // first top-level navigation
       await routeHandler({
         request: () => ({
+          resourceType: () => "document",
           isNavigationRequest: () => true,
           frame: () => mockMainFrame,
           url: () => "https://example.com",
@@ -378,6 +447,7 @@ describe("openPage", () => {
       // second top-level navigation with invalid URL should still continue
       await routeHandler({
         request: () => ({
+          resourceType: () => "document",
           isNavigationRequest: () => true,
           frame: () => mockMainFrame,
           url: () => "not-a-url",
@@ -419,6 +489,7 @@ describe("openPage", () => {
       const fulfillMock = vi.fn(() => Promise.resolve());
       await routeHandler({
         request: () => ({
+          resourceType: () => "document",
           isNavigationRequest: () => true,
           frame: () => mockMainFrame,
           url: () => "https://app.example.com",
@@ -430,6 +501,7 @@ describe("openPage", () => {
       });
       await routeHandler({
         request: () => ({
+          resourceType: () => "document",
           isNavigationRequest: () => true,
           frame: () => mockMainFrame,
           url: () => "https://cdn.example.com",
@@ -473,6 +545,7 @@ describe("openPage", () => {
       const fulfillMock = vi.fn(() => Promise.resolve());
       await routeHandler({
         request: () => ({
+          resourceType: () => "document",
           isNavigationRequest: () => true,
           frame: () => mockMainFrame,
           url: () => "https://www.example.com",
@@ -522,6 +595,7 @@ describe("openPage", () => {
       const fulfillMock = vi.fn(() => Promise.resolve());
       await routeHandler({
         request: () => ({
+          resourceType: () => "document",
           isNavigationRequest: () => true,
           frame: () => mockMainFrame,
           url: () => "https://example.com",
@@ -566,6 +640,7 @@ describe("openPage", () => {
       const fulfillMock = vi.fn(() => Promise.resolve());
       await routeHandler({
         request: () => ({
+          resourceType: () => "document",
           isNavigationRequest: () => true,
           frame: () => mockMainFrame,
           url: () => "https://example.com",
@@ -610,6 +685,7 @@ describe("openPage", () => {
       const fulfillMock = vi.fn(() => Promise.resolve());
       await routeHandler({
         request: () => ({
+          resourceType: () => "document",
           isNavigationRequest: () => true,
           frame: () => mockMainFrame,
           url: () => "https://example.com",
@@ -654,6 +730,7 @@ describe("openPage", () => {
       const fulfillMock = vi.fn(() => Promise.resolve());
       await routeHandler({
         request: () => ({
+          resourceType: () => "document",
           isNavigationRequest: () => true,
           frame: () => mockMainFrame,
           url: () => "https://example.com",
@@ -689,6 +766,7 @@ describe("openPage", () => {
       const fetchMock = vi.fn(() => Promise.reject("string error"));
       await routeHandler({
         request: () => ({
+          resourceType: () => "document",
           isNavigationRequest: () => true,
           frame: () => mockMainFrame,
           url: () => "https://example.com",
@@ -741,6 +819,7 @@ describe("openPage", () => {
 
       await routeHandler({
         request: () => ({
+          resourceType: () => "document",
           isNavigationRequest: () => true,
           frame: () => mockMainFrame,
           url: () => "https://example.com",
@@ -755,6 +834,7 @@ describe("openPage", () => {
       const continueMock = vi.fn(() => Promise.resolve());
       await routeHandler({
         request: () => ({
+          resourceType: () => "document",
           isNavigationRequest: () => true,
           frame: () => mockMainFrame,
           url: () => "https://example.com/page",
@@ -803,6 +883,7 @@ describe("openPage", () => {
 
       await routeHandler({
         request: () => ({
+          resourceType: () => "document",
           isNavigationRequest: () => true,
           frame: () => mockMainFrame,
           url: () => "https://example.com",
@@ -817,6 +898,7 @@ describe("openPage", () => {
       for (let i = 0; i < 20; i++) {
         await routeHandler({
           request: () => ({
+            resourceType: () => "document",
             isNavigationRequest: () => true,
             frame: () => mockMainFrame,
             url: () => "https://example.com/page",
@@ -832,6 +914,7 @@ describe("openPage", () => {
       const abortMock = vi.fn(() => Promise.resolve());
       await routeHandler({
         request: () => ({
+          resourceType: () => "document",
           isNavigationRequest: () => true,
           frame: () => mockMainFrame,
           url: () => "https://example.com/page",
@@ -878,6 +961,7 @@ describe("openPage", () => {
 
       await routeHandler({
         request: () => ({
+          resourceType: () => "document",
           isNavigationRequest: () => true,
           frame: () => mockMainFrame,
           url: () => "https://example.com",
@@ -922,6 +1006,7 @@ describe("openPage", () => {
 
       await routeHandler({
         request: () => ({
+          resourceType: () => "document",
           isNavigationRequest: () => true,
           frame: () => mockMainFrame,
           url: () => "https://example.com",
@@ -969,6 +1054,7 @@ describe("openPage", () => {
 
       await routeHandler({
         request: () => ({
+          resourceType: () => "document",
           isNavigationRequest: () => true,
           frame: () => mockMainFrame,
           url: () => "https://example.com",
@@ -1020,6 +1106,7 @@ describe("openPage", () => {
       const fulfillMock = vi.fn(() => Promise.resolve());
       await routeHandler({
         request: () => ({
+          resourceType: () => "document",
           isNavigationRequest: () => true,
           frame: () => mockMainFrame,
           url: () => "https://example.com",
@@ -1085,6 +1172,7 @@ describe("openPage", () => {
       const fulfillMock = vi.fn(() => Promise.resolve());
       await routeHandler({
         request: () => ({
+          resourceType: () => "document",
           isNavigationRequest: () => true,
           frame: () => mockMainFrame,
           url: () => "https://example.com",
@@ -1153,6 +1241,7 @@ describe("openPage", () => {
         .mockResolvedValueOnce(mock200Response);
       await routeHandler({
         request: () => ({
+          resourceType: () => "document",
           isNavigationRequest: () => true,
           frame: () => mockMainFrame,
           url: () => "https://example.com",
@@ -1212,6 +1301,7 @@ describe("openPage", () => {
         .mockResolvedValueOnce(mock200Response);
       await routeHandler({
         request: () => ({
+          resourceType: () => "document",
           isNavigationRequest: () => true,
           frame: () => mockMainFrame,
           url: () => "https://example.com",
@@ -1253,6 +1343,7 @@ describe("openPage", () => {
       const fulfillMock = vi.fn(() => Promise.resolve());
       await routeHandler({
         request: () => ({
+          resourceType: () => "document",
           isNavigationRequest: () => true,
           frame: () => mockMainFrame,
           url: () => "https://example.com",
@@ -1308,6 +1399,7 @@ describe("openPage", () => {
       // Use a data: URL that getHostFromUrl returns null for
       await routeHandler({
         request: () => ({
+          resourceType: () => "document",
           isNavigationRequest: () => true,
           frame: () => mockMainFrame,
           url: () => "https://example.com",
@@ -1467,6 +1559,7 @@ describe("openPage", () => {
           headers: () => ({}),
           text: () => textPromise,
           request: () => ({
+            resourceType: () => "document",
             isNavigationRequest: () => false,
             frame: () => null,
           }),
@@ -1508,6 +1601,7 @@ describe("openPage", () => {
           headers: () => ({}),
           text: () => neverResolves,
           request: () => ({
+            resourceType: () => "document",
             isNavigationRequest: () => false,
             frame: () => null,
           }),
@@ -1562,6 +1656,7 @@ describe("openPage", () => {
         // Route handler records a fetch error
         await routeHandler({
           request: () => ({
+            resourceType: () => "document",
             isNavigationRequest: () => true,
             frame: () => mockMainFrame,
             url: () => "https://example.com",
@@ -1600,6 +1695,7 @@ describe("openPage", () => {
         // Simulate the route handler blocking a cross-host redirect
         await routeHandler({
           request: () => ({
+            resourceType: () => "document",
             isNavigationRequest: () => true,
             frame: () => mockMainFrame,
             url: () => "https://other.example",
@@ -1752,6 +1848,7 @@ describe("openPage", () => {
           headers: () => ({ "content-type": "application/json" }),
           text: () => Promise.resolve('{"data": "test"}'),
           request: () => ({
+            resourceType: () => "document",
             isNavigationRequest: () => false,
             frame: () => null,
           }),
@@ -1798,6 +1895,7 @@ describe("openPage", () => {
           headers: () => ({ "content-type": "application/octet-stream" }),
           text: () => Promise.reject(new Error("Cannot read binary")),
           request: () => ({
+            resourceType: () => "document",
             isNavigationRequest: () => false,
             frame: () => null,
           }),
@@ -1839,6 +1937,7 @@ describe("openPage", () => {
           headers: () => ({ "content-type": "text/javascript" }),
           text: () => Promise.resolve("console.log('ok')"),
           request: () => ({
+            resourceType: () => "document",
             isNavigationRequest: () => false,
             frame: () => null,
           }),
@@ -1878,6 +1977,7 @@ describe("openPage", () => {
           headers: () => ({ "content-type": "text/html" }),
           text: () => Promise.resolve("<html></html>"),
           request: () => ({
+            resourceType: () => "document",
             isNavigationRequest: () => true,
             frame: () => mockMainFrame,
           }),
@@ -1913,6 +2013,7 @@ describe("openPage", () => {
           headers: () => ({ "content-type": "text/css" }),
           text: () => Promise.resolve("body {}"),
           request: () => ({
+            resourceType: () => "document",
             isNavigationRequest: () => false,
             frame: () => null,
           }),

--- a/src/browser/index.test.ts
+++ b/src/browser/index.test.ts
@@ -319,30 +319,30 @@ describe("openPage", () => {
     });
 
     it("should abort media requests by default and record them in urls", async () => {
-      let routeHandler: (route: unknown) => Promise<void> = async () => {};
+      const continueMock = vi.fn(() => Promise.resolve());
+      const abortMock = vi.fn(() => Promise.resolve());
+      // Invoke the handler during route registration, i.e. while the capture
+      // phase is still live (before the snapshot is frozen), matching the
+      // timing of a real media request.
       mockPage.route.mockImplementation(
         async (
           _pattern: string,
           handler: (route: unknown) => Promise<void>,
         ) => {
-          routeHandler = handler;
+          await handler({
+            request: () => ({
+              resourceType: () => "media",
+              isNavigationRequest: () => false,
+              frame: () => mockMainFrame,
+              url: () => "https://example.com/intro.mov",
+            }),
+            continue: continueMock,
+            abort: abortMock,
+          });
         },
       );
 
       const result = await openPage("https://example.com", 10000, []);
-
-      const continueMock = vi.fn(() => Promise.resolve());
-      const abortMock = vi.fn(() => Promise.resolve());
-      await routeHandler({
-        request: () => ({
-          resourceType: () => "media",
-          isNavigationRequest: () => false,
-          frame: () => mockMainFrame,
-          url: () => "https://example.com/intro.mov",
-        }),
-        continue: continueMock,
-        abort: abortMock,
-      });
 
       expect(abortMock).toHaveBeenCalledWith("blockedbyclient");
       expect(continueMock).not.toHaveBeenCalled();
@@ -353,28 +353,25 @@ describe("openPage", () => {
     });
 
     it("should record blocked media as a body-less response to preserve URL detection", async () => {
-      let routeHandler: (route: unknown) => Promise<void> = async () => {};
       mockPage.route.mockImplementation(
         async (
           _pattern: string,
           handler: (route: unknown) => Promise<void>,
         ) => {
-          routeHandler = handler;
+          await handler({
+            request: () => ({
+              resourceType: () => "media",
+              isNavigationRequest: () => false,
+              frame: () => mockMainFrame,
+              url: () => "https://example.com/intro.mov",
+            }),
+            continue: vi.fn(() => Promise.resolve()),
+            abort: vi.fn(() => Promise.resolve()),
+          });
         },
       );
 
       const result = await openPage("https://example.com", 10000, []);
-
-      await routeHandler({
-        request: () => ({
-          resourceType: () => "media",
-          isNavigationRequest: () => false,
-          frame: () => mockMainFrame,
-          url: () => "https://example.com/intro.mov",
-        }),
-        continue: vi.fn(() => Promise.resolve()),
-        abort: vi.fn(() => Promise.resolve()),
-      });
 
       // URL signatures match against responses[].url (analyzer/apply.ts), so the
       // blocked media URL must still appear in responses (body-less) so that
@@ -387,13 +384,40 @@ describe("openPage", () => {
       expect(blocked?.isFirstParty).toBe(true);
     });
 
-    it("should unroute the route handler after the capture phase", async () => {
-      // The media-block branch mutates urls/responses; the handler must be
-      // removed once the capture snapshot is frozen so late/lazy media requests
-      // cannot keep appending to it.
-      await openPage("https://example.com", 10000, []);
+    it("should keep aborting media after capture but stop recording it", async () => {
+      // After the capture snapshot is frozen the route handler stays installed
+      // so media is still aborted (autoplay / lazy media during cookie / JS
+      // extraction would otherwise reintroduce the cost this blocking avoids),
+      // but it must no longer append to the now-frozen urls/responses set.
+      let routeHandler: (route: unknown) => Promise<void> = async () => {};
+      mockPage.route.mockImplementation(
+        async (
+          _pattern: string,
+          handler: (route: unknown) => Promise<void>,
+        ) => {
+          routeHandler = handler;
+        },
+      );
 
-      expect(mockPage.unroute).toHaveBeenCalledWith("**/*");
+      const result = await openPage("https://example.com", 10000, []);
+      const urlsBefore = result.urls.length;
+      const responsesBefore = result.responses.length;
+
+      const abortMock = vi.fn(() => Promise.resolve());
+      await routeHandler({
+        request: () => ({
+          resourceType: () => "media",
+          isNavigationRequest: () => false,
+          frame: () => mockMainFrame,
+          url: () => "https://example.com/late.mov",
+        }),
+        continue: vi.fn(() => Promise.resolve()),
+        abort: abortMock,
+      });
+
+      expect(abortMock).toHaveBeenCalledWith("blockedbyclient");
+      expect(result.urls.length).toBe(urlsBefore);
+      expect(result.responses.length).toBe(responsesBefore);
     });
 
     it("should not abort media requests when blockMedia is false", async () => {

--- a/src/browser/index.test.ts
+++ b/src/browser/index.test.ts
@@ -7,6 +7,7 @@ vi.mock("playwright", () => {
     on: vi.fn(),
     off: vi.fn(),
     route: vi.fn(),
+    unroute: vi.fn(() => Promise.resolve()),
     mainFrame: vi.fn(),
     goto: vi.fn(),
     context: vi.fn(),
@@ -59,6 +60,7 @@ describe("openPage", () => {
     on: ReturnType<typeof vi.fn>;
     off: ReturnType<typeof vi.fn>;
     route: ReturnType<typeof vi.fn>;
+    unroute: ReturnType<typeof vi.fn>;
     mainFrame: ReturnType<typeof vi.fn>;
     goto: ReturnType<typeof vi.fn>;
     context: ReturnType<typeof vi.fn>;
@@ -83,6 +85,7 @@ describe("openPage", () => {
       on: vi.fn(),
       off: vi.fn(),
       route: vi.fn(),
+      unroute: vi.fn(() => Promise.resolve()),
       mainFrame: vi.fn(),
       goto: vi.fn(() => Promise.resolve()),
       context: vi.fn(),
@@ -382,6 +385,15 @@ describe("openPage", () => {
       expect(blocked).toBeDefined();
       expect(blocked?.body).toBeUndefined();
       expect(blocked?.isFirstParty).toBe(true);
+    });
+
+    it("should unroute the route handler after the capture phase", async () => {
+      // The media-block branch mutates urls/responses; the handler must be
+      // removed once the capture snapshot is frozen so late/lazy media requests
+      // cannot keep appending to it.
+      await openPage("https://example.com", 10000, []);
+
+      expect(mockPage.unroute).toHaveBeenCalledWith("**/*");
     });
 
     it("should not abort media requests when blockMedia is false", async () => {

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -414,6 +414,13 @@ export async function openPage(
   page.off("requestfinished", onRequestFinished);
   page.off("requestfailed", onRequestFailed);
   page.off("response", onResponse);
+  // Remove the route handler too so the frozen capture set cannot be mutated by
+  // late/lazy media requests after this point (the media-block branch pushes to
+  // `urls`/`responses`; leaving it installed would bloat memory and make the
+  // snapshot non-deterministic, e.g. during active scans).
+  await page.unroute("**/*").catch((e) => {
+    logger.debug(`Failed to unroute after capture: ${e}`);
+  });
 
   logger.info(`${responses.length} responses captured`);
   if (result === "loaded") {

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -63,6 +63,7 @@ export async function openPage(
     blockCrossDomainRedirect = false,
     networkIdleThresholdMs = NETWORK_IDLE_THRESHOLD_MS,
     extractionTimeoutMs = DEFAULT_EXTRACTION_TIMEOUT_MS,
+    blockMedia = true,
   } = options;
 
   const pageHost = getHostFromUrl(url);
@@ -87,6 +88,22 @@ export async function openPage(
 
   await page.route("**/*", async (route) => {
     const request = route.request();
+
+    // Drop media (video / audio) requests up front when enabled. These
+    // rarely contribute to technology detection (signatures match on URLs,
+    // bodies, headers, cookies, or JS variables) but can dominate the
+    // page's main-thread / network budget — autoplaying videos in
+    // particular keep the scan running long after the meaningful
+    // resources have loaded. Recording the URL in `urls` preserves the
+    // audit trail of what would have been fetched.
+    if (blockMedia && request.resourceType() === "media") {
+      const blockedUrl = request.url();
+      logger.debug(`Blocked media resource: ${blockedUrl}`);
+      urls.push({ url: blockedUrl, error: "blocked: media" });
+      await route.abort("blockedbyclient");
+      return;
+    }
+
     if (
       !request.isNavigationRequest() ||
       request.frame() !== page.mainFrame()

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -100,6 +100,20 @@ export async function openPage(
       const blockedUrl = request.url();
       logger.debug(`Blocked media resource: ${blockedUrl}`);
       urls.push({ url: blockedUrl, error: "blocked: media" });
+      // URL signatures are matched only against `context.responses[].url`
+      // (see analyzer/apply.ts), not the `urls` audit log. Aborting the
+      // request would otherwise drop it from `responses` and turn any
+      // media-URL-based detection into a false negative. Record a body-less
+      // response so URL matching is preserved while we still skip the
+      // (irrelevant and costly) media body.
+      const blockedHost = getHostFromUrl(blockedUrl) ?? "";
+      responses.push({
+        url: blockedUrl,
+        host: blockedHost,
+        isFirstParty: blockedHost ? isFirstPartyHost(pageHost, blockedHost) : false,
+        status: 0,
+        headers: {},
+      });
       await route.abort("blockedbyclient");
       return;
     }

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -81,10 +81,19 @@ export async function openPage(
   const page = await context.newPage();
 
   let blockedByRedirectPolicy = false;
+  // Once the capture phase ends we keep the route handler installed (so media
+  // is still aborted for the rest of the scan) but stop appending to the
+  // frozen urls/responses snapshot. Guards the media branch's pushes below.
+  let captureFrozen = false;
   let lastNavigationUrl = url;
   let inspectedUrls = new Set<string>();
   let reentryCount = 0;
   const preInspectedUrls = new Set<string>();
+  // Declared before the route handler so its media-block branch can push to
+  // them (the handler is a closure over these; the network-idle listeners
+  // below also share them).
+  const urls: UrlEntry[] = [];
+  const responses: Response[] = [];
 
   await page.route("**/*", async (route) => {
     const request = route.request();
@@ -98,22 +107,32 @@ export async function openPage(
     // audit trail of what would have been fetched.
     if (blockMedia && request.resourceType() === "media") {
       const blockedUrl = request.url();
-      logger.debug(`Blocked media resource: ${blockedUrl}`);
-      urls.push({ url: blockedUrl, error: "blocked: media" });
-      // URL signatures are matched only against `context.responses[].url`
-      // (see analyzer/apply.ts), not the `urls` audit log. Aborting the
-      // request would otherwise drop it from `responses` and turn any
-      // media-URL-based detection into a false negative. Record a body-less
-      // response so URL matching is preserved while we still skip the
-      // (irrelevant and costly) media body.
-      const blockedHost = getHostFromUrl(blockedUrl) ?? "";
-      responses.push({
-        url: blockedUrl,
-        host: blockedHost,
-        isFirstParty: blockedHost ? isFirstPartyHost(pageHost, blockedHost) : false,
-        status: 0,
-        headers: {},
-      });
+      // Always abort media, even after the capture phase is frozen: autoplay
+      // or lazy media that starts during the post-load cookie / JS extraction
+      // phase would otherwise reintroduce the main-thread / network cost this
+      // blocking is meant to avoid. We only *record* the block while capture
+      // is live — once frozen, pushing would mutate the returned snapshot
+      // (see the capture-freeze point below) non-deterministically.
+      if (!captureFrozen) {
+        logger.debug(`Blocked media resource: ${blockedUrl}`);
+        urls.push({ url: blockedUrl, error: "blocked: media" });
+        // URL signatures are matched only against `context.responses[].url`
+        // (see analyzer/apply.ts), not the `urls` audit log. Aborting the
+        // request would otherwise drop it from `responses` and turn any
+        // media-URL-based detection into a false negative. Record a body-less
+        // response so URL matching is preserved while we still skip the
+        // (irrelevant and costly) media body.
+        const blockedHost = getHostFromUrl(blockedUrl) ?? "";
+        responses.push({
+          url: blockedUrl,
+          host: blockedHost,
+          isFirstParty: blockedHost
+            ? isFirstPartyHost(pageHost, blockedHost)
+            : false,
+          status: 0,
+          headers: {},
+        });
+      }
       await route.abort("blockedbyclient");
       return;
     }
@@ -255,8 +274,6 @@ export async function openPage(
     await route.fulfill({ response: firstResponse });
   });
 
-  const urls: UrlEntry[] = [];
-  const responses: Response[] = [];
   // Timestamp of the most recent network activity (request sent or
   // response received). Used by the custom idle-decision loop below.
   let lastNetworkActivityAt = Date.now();
@@ -414,13 +431,14 @@ export async function openPage(
   page.off("requestfinished", onRequestFinished);
   page.off("requestfailed", onRequestFailed);
   page.off("response", onResponse);
-  // Remove the route handler too so the frozen capture set cannot be mutated by
-  // late/lazy media requests after this point (the media-block branch pushes to
-  // `urls`/`responses`; leaving it installed would bloat memory and make the
-  // snapshot non-deterministic, e.g. during active scans).
-  await page.unroute("**/*").catch((e) => {
-    logger.debug(`Failed to unroute after capture: ${e}`);
-  });
+  // Freeze the capture. We intentionally keep the route handler installed so
+  // media requests are still aborted for the remainder of the scan (cookie / JS
+  // extraction can trigger autoplay / lazy media, whose main-thread / network
+  // cost is exactly what this blocking avoids). The `captureFrozen` guard stops
+  // the media branch from appending to the now-frozen `urls`/`responses`
+  // snapshot, so late/lazy requests can neither bloat memory nor make the
+  // returned capture non-deterministic.
+  captureFrozen = true;
 
   logger.info(`${responses.length} responses captured`);
   if (result === "loaded") {

--- a/src/browser/types.ts
+++ b/src/browser/types.ts
@@ -36,6 +36,7 @@ export type OpenPageOptions = {
   blockCrossDomainRedirect?: boolean | undefined;
   networkIdleThresholdMs?: number | undefined;
   extractionTimeoutMs?: number | undefined;
+  blockMedia?: boolean | undefined;
 };
 
 export type Context = {

--- a/src/commands/detect.test.ts
+++ b/src/commands/detect.test.ts
@@ -204,6 +204,17 @@ describe("detectCommand", () => {
       );
     });
 
+    it("should pass blockMedia false when --no-block-media is provided", async () => {
+      await runCommand(["--no-block-media"]);
+
+      expect(openPage).toHaveBeenCalledWith(
+        "https://example.com",
+        10000,
+        expect.any(Array),
+        expect.objectContaining({ blockMedia: false }),
+      );
+    });
+
     it("should pass custom idle-timeout when provided", async () => {
       await runCommand(["--idle-timeout", "500"]);
 

--- a/src/commands/detect.test.ts
+++ b/src/commands/detect.test.ts
@@ -166,6 +166,7 @@ describe("detectCommand", () => {
           blockCrossDomainRedirect: false,
           networkIdleThresholdMs: 2000,
           extractionTimeoutMs: 10000,
+          blockMedia: true,
         },
       );
     });

--- a/src/commands/detect.ts
+++ b/src/commands/detect.ts
@@ -54,6 +54,10 @@ export const detectCommand = (): Command => {
       10000,
     )
     .option(
+      "--no-block-media",
+      "Do not abort media (video/audio) requests during the scan",
+    )
+    .option(
       "-a, --active",
       "Enable active scanning (sends additional requests to technology-specific paths)",
       false,
@@ -72,6 +76,7 @@ export const detectCommand = (): Command => {
           blockCrossDomainRedirect: boolean;
           idleTimeout: number;
           extractionTimeout: number;
+          blockMedia: boolean;
           active: boolean;
         },
       ) => {
@@ -115,6 +120,7 @@ export const detectCommand = (): Command => {
               blockCrossDomainRedirect: options.blockCrossDomainRedirect,
               networkIdleThresholdMs: options.idleTimeout,
               extractionTimeoutMs: options.extractionTimeout,
+              blockMedia: options.blockMedia,
             },
           );
           const detections = analyze(context, signatures);


### PR DESCRIPTION
## Summary

Revives the closed #59 (media block) on top of current `main`, and fixes the URL-detection regression the Codex review flagged there.

Media resources (video / audio) rarely contribute to technology detection — signatures match on URLs, bodies, headers, cookies, or JS variables — but their bandwidth and especially their main-thread cost (autoplaying `<video>` decode, large `.mov` / `.mp4` downloads) can dominate the per-scan budget on heavy SPAs and squeeze the post-load cookie / JS extraction phase introduced in #58.

- Abort `media` requests up front in the route handler (`request.resourceType() === "media"`).
- Add `--no-block-media` to opt out per scan; default is to block. `OpenPageOptions.blockMedia` toggles it programmatically.
- Record the blocked URL in `urls` as `{ url, error: "blocked: media" }` for the audit trail.

## Fix vs. the previous #59

The Codex review on #59 correctly noted that aborting media drops the URL from `context.responses`, and URL signatures (`rule.urls`) are matched **only** against `context.responses[].url` in `analyzer/apply.ts` — not the `urls` audit log. So media-URL-based detections would become false negatives by default.

This PR records the blocked media URL as a **body-less response** (empty headers, no body) in `context.responses`, so URL matching is preserved while the irrelevant, costly media body is still skipped. Header / body / cookie rules are unaffected (empty headers / no body simply don't match).

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 488 passed / 1 skipped
- [x] New test: blocked media is recorded as a body-less response so URL detection is preserved
- [x] Existing tests: media → `abort("blockedbyclient")` + URL recorded; `--no-block-media` → request continues

🤖 Generated with [Claude Code](https://claude.com/claude-code)