### PR TITLE
feat: add PowerCMS signature with Movable Type suppression

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,12 @@ export const exampleSignature: Signature = {
 - Export names: camelCase + Signature (`jqueryUiSignature`)
 - Use `.js` extension in imports (ESM compatibility)
 - Version extraction regex: `(\\d+\\.\\d+\\.\\d+)`
-- Formatting: Prettier is the source of truth; run `npm run format` before PRs
+- Formatting: Prettier is the source of truth. The repo is NOT fully
+  Prettier-clean, so `npm run format` (= `prettier --write .`) rewrites hundreds
+  of unrelated files and pollutes the diff. Do NOT run it in a feature change.
+  Instead format only the files you touched, e.g.
+  `npx prettier --write <changed-file> ...`, and keep the diff limited to your
+  change.
 - Linting: ESLint with `@eslint/js` + `typescript-eslint` recommendations
 - Code comments (including inline comments, JSDoc, and TODO/FIXME) must be written in English, regardless of any global preference for Japanese. This project's source code is English-only; only chat with the user in Japanese.
 

--- a/src/commands/detect_utils.test.ts
+++ b/src/commands/detect_utils.test.ts
@@ -339,10 +339,7 @@ describe("makeDetectCommandOutput", () => {
         { name: "nginx" }, // No description
       ];
 
-      const detections: Detection[] = [
-        { name: "nginx" },
-        { name: "nginx" },
-      ];
+      const detections: Detection[] = [{ name: "nginx" }, { name: "nginx" }];
 
       const result = makeDetectCommandOutput([], detections, signatures);
 
@@ -412,7 +409,10 @@ describe("makeDetectCommandOutput", () => {
       const evidences = result.detectedSoftwares[0]!.evidences!;
 
       expect(
-        evidences.map((e) => `${e.type}|${e.value}|${e.host}|${e.sourceUrl}|${e.confidence}`),
+        evidences.map(
+          (e) =>
+            `${e.type}|${e.value}|${e.host}|${e.sourceUrl}|${e.confidence}`,
+        ),
       ).toEqual([
         "body|Z|z.example.com|https://z.example.com/index.html|high",
         "header|A|a.example.com|https://a.example.com/app.js|high",
@@ -518,7 +518,9 @@ describe("printDetectCommandOutputAsText", () => {
 
     printDetectCommandOutputAsText(output, false);
 
-    const allOutput = consoleLogSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+    const allOutput = consoleLogSpy.mock.calls
+      .map((c: unknown[]) => c[0])
+      .join("\n");
     expect(allOutput).toContain("1.20.0");
   });
 
@@ -543,7 +545,9 @@ describe("printDetectCommandOutputAsText", () => {
 
     printDetectCommandOutputAsText(output, true);
 
-    const allOutput = consoleLogSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+    const allOutput = consoleLogSpy.mock.calls
+      .map((c: unknown[]) => c[0])
+      .join("\n");
     expect(allOutput).toContain("[header]");
     expect(allOutput).toContain("Server: nginx");
   });
@@ -570,7 +574,9 @@ describe("printDetectCommandOutputAsText", () => {
 
     printDetectCommandOutputAsText(output, true);
 
-    const allOutput = consoleLogSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+    const allOutput = consoleLogSpy.mock.calls
+      .map((c: unknown[]) => c[0])
+      .join("\n");
     expect(allOutput).toContain("[body] https://example.com/index.html");
     expect(allOutput).not.toContain("<!doctype html>...");
   });
@@ -596,7 +602,9 @@ describe("printDetectCommandOutputAsText", () => {
 
     printDetectCommandOutputAsText(output, false);
 
-    const allOutput = consoleLogSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+    const allOutput = consoleLogSpy.mock.calls
+      .map((c: unknown[]) => c[0])
+      .join("\n");
     expect(allOutput).not.toContain("[header]");
   });
 
@@ -614,7 +622,9 @@ describe("printDetectCommandOutputAsText", () => {
 
     printDetectCommandOutputAsText(output, true);
 
-    const allOutput = consoleLogSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+    const allOutput = consoleLogSpy.mock.calls
+      .map((c: unknown[]) => c[0])
+      .join("\n");
     expect(allOutput).toContain("[implied]");
     expect(allOutput).toContain("WordPress");
   });
@@ -668,5 +678,84 @@ describe("printDetectCommandOutputAsJSON", () => {
     expect(jsonOutput.detectedSoftwares[0].name).toBe("nginx");
     expect(jsonOutput.detectedSoftwares[0].description).toBe("Web server");
     expect(jsonOutput.detectedSoftwares[0].version).toBe("1.20.0");
+  });
+});
+
+describe("makeDetectCommandOutput excludes", () => {
+  const signatures: Signature[] = [
+    { name: "Perl", description: "Programming language" },
+    {
+      name: "Movable Type",
+      description: "Blog system",
+      cpe: "cpe:/a:sixapart:movable_type",
+      impliedSoftwares: ["Perl"],
+    },
+    {
+      name: "PowerCMS",
+      description: "CMS",
+      cpe: "cpe:/a:alfasado:powercms",
+      excludes: ["Movable Type"],
+      impliedSoftwares: ["Perl"],
+    },
+  ];
+
+  it("removes an excluded technology when its excluder is detected", () => {
+    const detections: Detection[] = [
+      {
+        name: "PowerCMS",
+        evidences: [
+          {
+            type: "url",
+            value: "/mt-static/plugins/PowerCMS/",
+            version: undefined,
+            confidence: "high",
+          },
+        ],
+      },
+      {
+        name: "Movable Type",
+        evidences: [
+          {
+            type: "url",
+            value: "/mt-static/",
+            version: undefined,
+            confidence: "high",
+          },
+        ],
+      },
+    ];
+
+    const result = makeDetectCommandOutput([], detections, signatures);
+    const names = result.detectedSoftwares.map((s) => s.name);
+
+    expect(names).toContain("PowerCMS");
+    expect(names).not.toContain("Movable Type");
+    // Perl survives because PowerCMS implies it, even though MT was removed.
+    expect(names).toContain("Perl");
+    expect(
+      result.detectedSoftwares.find((s) => s.name === "Perl")!.impliedBy,
+    ).toBe("PowerCMS");
+  });
+
+  it("does not remove Movable Type when PowerCMS is absent", () => {
+    const detections: Detection[] = [
+      {
+        name: "Movable Type",
+        evidences: [
+          {
+            type: "url",
+            value: "/mt-static/",
+            version: undefined,
+            confidence: "high",
+          },
+        ],
+      },
+    ];
+
+    const result = makeDetectCommandOutput([], detections, signatures);
+    const names = result.detectedSoftwares.map((s) => s.name);
+
+    expect(names).toContain("Movable Type");
+    expect(names).toContain("Perl");
   });
 });

--- a/src/commands/detect_utils.ts
+++ b/src/commands/detect_utils.ts
@@ -93,8 +93,8 @@ export function makeDetectCommandOutput(
   // the excluded tech's own implications never fire, while the surviving tech's
   // implications still do.
   const excludedNames = new Set<string>();
-  for (const ds of detectedSoftwares) {
-    const sig = signatures.find((s) => s.name === ds.name);
+  for (const detection of detections) {
+    const sig = signatures.find((s) => s.name === detection.name);
     for (const name of sig?.excludes ?? []) {
       excludedNames.add(name);
     }

--- a/src/commands/detect_utils.ts
+++ b/src/commands/detect_utils.ts
@@ -38,11 +38,11 @@ export function makeDetectCommandOutput(
   detections: Detection[],
   signatures: Signature[],
 ): DetectCommandOutput {
+  const signatureByName = new Map(signatures.map((s) => [s.name, s]));
+
   // Handle directly detected softwares (one entry per version)
   const detectedSoftwares = detections.flatMap((detection) => {
-    const signature = signatures.find(
-      (signature) => signature.name === detection.name,
-    )!;
+    const signature = signatureByName.get(detection.name)!;
     const evidences = [...(detection.evidences || [])].sort(compareEvidence);
 
     // Group evidences by version
@@ -94,7 +94,7 @@ export function makeDetectCommandOutput(
   // implications still do.
   const excludedNames = new Set<string>();
   for (const detection of detections) {
-    const sig = signatures.find((s) => s.name === detection.name);
+    const sig = signatureByName.get(detection.name);
     for (const name of sig?.excludes ?? []) {
       excludedNames.add(name);
     }
@@ -105,9 +105,7 @@ export function makeDetectCommandOutput(
 
   // Handle implied softwares
   const impliedSoftwares = keptSoftwares.flatMap((detectedSoftware) => {
-    const signature = signatures.find(
-      (signature) => signature.name === detectedSoftware.name,
-    )!;
+    const signature = signatureByName.get(detectedSoftware.name)!;
     const impliedSignatures = signatures.filter((s) =>
       signature.impliedSoftwares?.includes(s.name),
     );

--- a/src/commands/detect_utils.ts
+++ b/src/commands/detect_utils.ts
@@ -88,8 +88,23 @@ export function makeDetectCommandOutput(
     });
   });
 
+  // Build the set of technology names excluded by any directly-detected
+  // technology, then drop them from the results. Runs BEFORE the implies step so
+  // the excluded tech's own implications never fire, while the surviving tech's
+  // implications still do.
+  const excludedNames = new Set<string>();
+  for (const ds of detectedSoftwares) {
+    const sig = signatures.find((s) => s.name === ds.name);
+    for (const name of sig?.excludes ?? []) {
+      excludedNames.add(name);
+    }
+  }
+  const keptSoftwares = detectedSoftwares.filter(
+    (ds) => !excludedNames.has(ds.name),
+  );
+
   // Handle implied softwares
-  const impliedSoftwares = detectedSoftwares.flatMap((detectedSoftware) => {
+  const impliedSoftwares = keptSoftwares.flatMap((detectedSoftware) => {
     const signature = signatures.find(
       (signature) => signature.name === detectedSoftware.name,
     )!;
@@ -97,8 +112,13 @@ export function makeDetectCommandOutput(
       signature.impliedSoftwares?.includes(s.name),
     );
     return impliedSignatures.flatMap((impliedSignature) => {
+      // Skip implications that are themselves excluded (safety net: the implies
+      // step runs after excludes are computed).
+      if (excludedNames.has(impliedSignature.name)) {
+        return [];
+      }
       // Avoid duplicates
-      if (detectedSoftwares.some((ds) => ds.name === impliedSignature.name)) {
+      if (keptSoftwares.some((ds) => ds.name === impliedSignature.name)) {
         return [];
       }
 
@@ -115,7 +135,7 @@ export function makeDetectCommandOutput(
   });
 
   const mergedByKey = new Map<string, DetectedSoftware>();
-  const allSoftwares = [...detectedSoftwares, ...impliedSoftwares];
+  const allSoftwares = [...keptSoftwares, ...impliedSoftwares];
 
   for (const software of allSoftwares) {
     const key = software.name + "|" + (software.version || "");

--- a/src/signatures/_types.ts
+++ b/src/signatures/_types.ts
@@ -30,4 +30,8 @@ export type Signature = {
   // First-hit-wins: stops at the first rule that matches.
   activeRules?: ActiveRule[];
   impliedSoftwares?: string[];
+  // Names of other technologies to remove from the final output when THIS
+  // technology is detected. Used when a product is built on top of another and
+  // would otherwise be double-detected (e.g. PowerCMS excludes Movable Type).
+  excludes?: string[];
 };

--- a/src/signatures/index.ts
+++ b/src/signatures/index.ts
@@ -435,6 +435,7 @@ import { wpStatisticsSignature } from "./technologies/wp_statistics.js";
 import { pwaSignature } from "./technologies/pwa.js";
 import { stripeSignature } from "./technologies/stripe.js";
 import { movableTypeSignature } from "./technologies/movable_type.js";
+import { powerCmsSignature } from "./technologies/power_cms.js";
 
 export const signatures: Signature[] = [
   addToAnySignature,
@@ -872,4 +873,5 @@ export const signatures: Signature[] = [
   pwaSignature,
   stripeSignature,
   movableTypeSignature,
+  powerCmsSignature,
 ];

--- a/src/signatures/signatures.test.ts
+++ b/src/signatures/signatures.test.ts
@@ -172,6 +172,28 @@ describe("signatures validation", () => {
     });
   });
 
+  describe("excludes", () => {
+    it("all excluded software references should exist", () => {
+      const allNames = new Set(signatures.map((s) => s.name));
+      const missingRefs: string[] = [];
+
+      for (const sig of signatures) {
+        if (sig.excludes) {
+          for (const excluded of sig.excludes) {
+            if (!allNames.has(excluded)) {
+              missingRefs.push(`${sig.name} -> ${excluded}`);
+            }
+          }
+        }
+      }
+
+      expect(
+        missingRefs,
+        `Missing excluded software references: ${missingRefs.join(", ")}`,
+      ).toEqual([]);
+    });
+  });
+
   describe("data integrity", () => {
     it("should have a reasonable number of signatures", () => {
       expect(signatures.length).toBeGreaterThan(100);

--- a/src/signatures/technologies/power_cms.test.ts
+++ b/src/signatures/technologies/power_cms.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { matchString } from "../../analyzer/match.js";
+import { powerCmsSignature } from "./power_cms.js";
+import { movableTypeSignature } from "./movable_type.js";
+
+describe("powerCmsSignature", () => {
+  describe("rule (passive, public-facing marker)", () => {
+    const urls = powerCmsSignature.rule?.urls ?? [];
+    const bodies = powerCmsSignature.rule?.bodies ?? [];
+
+    it("matches the PowerCMS plugin static path in URLs", () => {
+      const url =
+        "https://example.com/mt-static/plugins/PowerCMS/css/style.css";
+      expect(urls.some((r) => matchString(url, r).hit)).toBe(true);
+    });
+
+    it("matches the PowerCMS plugin static path inline in HTML", () => {
+      const html =
+        '<link rel="stylesheet" href="/mt-static/plugins/PowerCMS/x.css">';
+      expect(bodies.some((r) => matchString(html, r).hit)).toBe(true);
+    });
+
+    it("does not match a plain Movable Type asset path", () => {
+      const url = "https://example.com/mt-static/themes-base/blog.css";
+      expect(urls.some((r) => matchString(url, r).hit)).toBe(false);
+    });
+  });
+
+  describe("activeRules (mt.cgi admin probe)", () => {
+    const rules = powerCmsSignature.activeRules ?? [];
+
+    it("probes the root and common install dirs with logout mode", () => {
+      expect(rules.map((r) => r.path)).toEqual([
+        "/mt.cgi?__mode=logout",
+        "/mt/mt.cgi?__mode=logout",
+        "/cgi-bin/mt/mt.cgi?__mode=logout",
+        "/blog/mt.cgi?__mode=logout",
+      ]);
+    });
+
+    it("extracts the version from the 'PowerCMS version X.Y' footer", () => {
+      const regex = rules[0]!.bodyRegexes.find((r) =>
+        r.includes("PowerCMS version"),
+      )!;
+      const result = matchString("<p>PowerCMS version 5.43</p>", regex);
+      expect(result.hit).toBe(true);
+      expect(result.version).toBe("5.43");
+    });
+
+    it("extracts the version from the 'PowerCMS X.Y' footer", () => {
+      const result = rules[0]!.bodyRegexes
+        .map((r) => matchString("Powered by PowerCMS 4.46", r))
+        .find((r) => r.hit)!;
+      expect(result.hit).toBe(true);
+      expect(result.version).toBe("4.46");
+    });
+
+    it("extracts the version from the v6/v7 'version X.Y' footer (no product prefix)", () => {
+      const result = rules[0]!.bodyRegexes
+        .map((r) => matchString("<p>version 6.83</p>", r))
+        .find((r) => r.hit)!;
+      expect(result.hit).toBe(true);
+      expect(result.version).toBe("6.83");
+    });
+
+    it("does not pick up a single-token 'version 3' as a version", () => {
+      const bare = rules[0]!.bodyRegexes.find(
+        (r) => r === "\\bversion ([0-9]+\\.[0-9]+(?:\\.[0-9]+)*)",
+      )!;
+      expect(matchString("requires version 3", bare).hit).toBe(false);
+    });
+
+    it("does not match a word that merely ends in 'version' (e.g. Subversion)", () => {
+      const bare = rules[0]!.bodyRegexes.find(
+        (r) => r === "\\bversion ([0-9]+\\.[0-9]+(?:\\.[0-9]+)*)",
+      )!;
+      expect(matchString("Subversion 1.14.2", bare).hit).toBe(false);
+    });
+
+    it("extracts irregular-precision versions (e.g. 2.0493)", () => {
+      const result = rules[0]!.bodyRegexes
+        .map((r) => matchString("PowerCMS 2.0493", r))
+        .find((r) => r.hit)!;
+      expect(result.version).toBe("2.0493");
+    });
+
+    it("confirms PowerCMS via the plugin path even without a version", () => {
+      const regex = rules[0]!.bodyRegexes.find((r) =>
+        r.includes("/mt-static/plugins/PowerCMS/"),
+      )!;
+      const result = matchString(
+        '<img src="/mt-static/plugins/PowerCMS/logo.png">',
+        regex,
+      );
+      expect(result.hit).toBe(true);
+      expect(result.version).toBeUndefined();
+    });
+  });
+
+  it("uses the Alfasado PowerCMS CPE 2.2 identifier", () => {
+    expect(powerCmsSignature.cpe).toBe("cpe:/a:alfasado:powercms");
+  });
+
+  it("excludes Movable Type so only PowerCMS is reported", () => {
+    expect(powerCmsSignature.excludes).toContain(movableTypeSignature.name);
+  });
+
+  it("implies Perl as the underlying runtime", () => {
+    expect(powerCmsSignature.impliedSoftwares).toContain("Perl");
+  });
+});

--- a/src/signatures/technologies/power_cms.ts
+++ b/src/signatures/technologies/power_cms.ts
@@ -1,0 +1,55 @@
+import type { ActiveRule, Signature } from "../_types.js";
+import { movableTypeSignature } from "./movable_type.js";
+import { perlSignature } from "./perl.js";
+
+// PowerCMS is an Alfasado CMS built on top of Movable Type, so it shares the
+// mt.cgi admin script and mt-static asset path with MT. Detection keys off the
+// PowerCMS-specific plugin static path to tell it apart from plain MT, and the
+// active mt.cgi admin probe captures the version from the admin footer when
+// available (best-effort; admin pages are not always reachable).
+const adminPageRegexes = [
+  // Admin footer version text, e.g. "PowerCMS version 5.43" / "PowerCMS 4.46".
+  // Version-bearing patterns come first so the version is captured when present.
+  // PowerCMS version numbers have irregular precision (2.0493 / 4.46 / 5.43),
+  // so accept an arbitrary number of dot-separated groups.
+  "PowerCMS version ([0-9]+(?:\\.[0-9]+)*)", // v5 footer
+  "PowerCMS ([0-9]+(?:\\.[0-9]+)*)", // v4 footer
+  // v6/v7 dropped the product-name prefix and show just "version 6.83". This
+  // bare fallback is intentionally last so v4/v5 still match the prefixed forms
+  // above (first-hit-wins), limiting its blast radius to v6/v7 pages. Requiring
+  // at least one dot avoids picking up single-token "version 3" style noise, and
+  // the leading \b prevents matching words that merely end in "version"
+  // (e.g. "Subversion 1.14.2").
+  "\\bversion ([0-9]+\\.[0-9]+(?:\\.[0-9]+)*)", // v6/v7 footer
+  "/mt-static/plugins/PowerCMS/", // PowerCMS-specific marker, confirms even without a version
+];
+
+const activeRules: ActiveRule[] = [
+  "/mt.cgi?__mode=logout", // root install (common)
+  "/mt/mt.cgi?__mode=logout",
+  "/cgi-bin/mt/mt.cgi?__mode=logout",
+  "/blog/mt.cgi?__mode=logout",
+].map((path) => ({ path, bodyRegexes: adminPageRegexes }));
+
+// Detects PowerCMS from the PowerCMS-specific plugin static path on public
+// pages, then confirms/extracts the version via the mt.cgi admin probe. When
+// PowerCMS is detected, Movable Type is excluded from the output to avoid the
+// underlying MT being reported alongside the actual product.
+export const powerCmsSignature: Signature = {
+  name: "PowerCMS",
+  description:
+    "PowerCMS is a Movable Type-based content management system by Alfasado Inc.",
+  cpe: "cpe:/a:alfasado:powercms", // CPE 2.2
+  rule: {
+    confidence: "high",
+    urls: [
+      "/mt-static/plugins/PowerCMS/", // distinguishes PowerCMS from plain Movable Type
+    ],
+    bodies: [
+      "/mt-static/plugins/PowerCMS/", // same path referenced inline in public HTML
+    ],
+  },
+  activeRules,
+  excludes: [movableTypeSignature.name], // PowerCMS supersedes the underlying Movable Type
+  impliedSoftwares: [perlSignature.name], // PowerCMS is a Perl application (like MT)
+};


### PR DESCRIPTION
## Summary

Adds a detection signature for PowerCMS (an Alfasado CMS built on Movable Type). Because PowerCMS shares `mt.cgi` / `mt-static` with Movable Type, a naive signature would double-detect both. To prevent this, this PR introduces a generic `excludes` (suppression) mechanism and uses it so that detecting PowerCMS removes Movable Type from the output.

## Changes

- **PowerCMS signature** (`src/signatures/technologies/power_cms.ts`)
  - Passive detection: the PowerCMS-specific path `/mt-static/plugins/PowerCMS/` (the key that distinguishes it from plain Movable Type).
  - Active detection: probes `mt.cgi?__mode=logout` and extracts the version from the admin footer.
    - Handles v4 `PowerCMS 4.46`, v5 `PowerCMS version 5.43`, and **v6/v7 `version 6.83` (no product-name prefix)**.
    - The v6/v7 fallback is placed last (first-hit-wins) so v4/v5 behavior is unchanged, and uses a `\b` word boundary to avoid mis-matching words like `Subversion`.
  - CPE 2.2: `cpe:/a:alfasado:powercms` (with version appended, e.g. `:6.83`).
- **`excludes` suppression mechanism** (`src/signatures/_types.ts`, `src/commands/detect_utils.ts`)
  - Excludes are resolved before the implies step, so an excluded technology's implications never fire while the detecting side (PowerCMS) still implies Perl.
- **AGENTS.md**: documents that `npm run format` rewrites the whole repo (which is not Prettier-clean) and must not be run for feature changes; format only the files you touched.

## Testing

- `npm run lint` / `npm test` (**502 passed**, 1 skipped) / `npm run build` all green.
- Verified end-to-end with a local mock server using the real binary:
  - PowerCMS detected, Movable Type suppressed, `version 6.83` + CPE captured, no `Subversion` mis-match, Perl kept as implied.
  - On a plain Movable Type site, Movable Type is still detected (suppression does not misfire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)