### PR TITLE
fix: tighten Neve body pattern to avoid WordPress over-detection

### DIFF
--- a/src/analyzer/utils.test.ts
+++ b/src/analyzer/utils.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { demoteConfidence, maxConfidence } from "./utils.js";
+
+describe("maxConfidence", () => {
+  it("returns high when any confidence is high", () => {
+    expect(maxConfidence(["low", "high", "medium"])).toBe("high");
+  });
+
+  it("returns medium when the highest is medium", () => {
+    expect(maxConfidence(["low", "medium", "low"])).toBe("medium");
+  });
+
+  it("returns low when all are low", () => {
+    expect(maxConfidence(["low", "low"])).toBe("low");
+  });
+
+  it("returns low for an empty list", () => {
+    expect(maxConfidence([])).toBe("low");
+  });
+});
+
+describe("demoteConfidence", () => {
+  it("demotes high to medium", () => {
+    expect(demoteConfidence("high")).toBe("medium");
+  });
+
+  it("demotes medium to low", () => {
+    expect(demoteConfidence("medium")).toBe("low");
+  });
+
+  it("keeps low at low", () => {
+    expect(demoteConfidence("low")).toBe("low");
+  });
+});

--- a/src/analyzer/utils.ts
+++ b/src/analyzer/utils.ts
@@ -9,3 +9,16 @@ export const maxConfidence = (confidences: Confidence[]): Confidence => {
   }
   return "low";
 };
+
+// Lower a confidence by one level. Used for implied (indirectly detected)
+// softwares, which should never be reported with the same confidence as the
+// direct detection that implied them.
+export const demoteConfidence = (confidence: Confidence): Confidence => {
+  if (confidence === "high") {
+    return "medium";
+  }
+  if (confidence === "medium") {
+    return "low";
+  }
+  return "low";
+};

--- a/src/commands/detect_utils.test.ts
+++ b/src/commands/detect_utils.test.ts
@@ -181,6 +181,51 @@ describe("makeDetectCommandOutput", () => {
       expect(php?.impliedBy).toBe("WordPress");
     });
 
+    it("should demote implied confidence one level below its parent", () => {
+      const detections: Detection[] = [
+        {
+          name: "WordPress",
+          evidences: [
+            {
+              type: "body",
+              value: "wp-content",
+              version: undefined,
+              confidence: "high",
+            },
+          ],
+        },
+      ];
+
+      const result = makeDetectCommandOutput([], detections, baseSignatures);
+
+      const php = result.detectedSoftwares.find((s) => s.name === "PHP");
+      // WordPress is detected at high, so its implications are reported at medium.
+      expect(php?.confidence).toBe("medium");
+    });
+
+    it("should carry the parent's evidences onto implied softwares", () => {
+      const detections: Detection[] = [
+        {
+          name: "WordPress",
+          evidences: [
+            {
+              type: "body",
+              value: "wp-content",
+              version: undefined,
+              confidence: "high",
+            },
+          ],
+        },
+      ];
+
+      const result = makeDetectCommandOutput([], detections, baseSignatures);
+
+      const php = result.detectedSoftwares.find((s) => s.name === "PHP");
+      expect(php?.impliedBy).toBe("WordPress");
+      expect(php?.evidences).toBeDefined();
+      expect(php!.evidences!.map((e) => e.value)).toContain("wp-content");
+    });
+
     it("should not duplicate when software is both detected and implied", () => {
       const detections: Detection[] = [
         {
@@ -281,7 +326,9 @@ describe("makeDetectCommandOutput", () => {
       expect(js).toBeDefined();
       expect(js!.impliedBy).toContain("React");
       expect(js!.impliedBy).toContain("Vue");
-      expect(js!.confidence).toBe("high"); // Should use highest confidence
+      // Implied confidences are demoted from their parents (React high -> medium,
+      // Vue medium -> low), then merged to the highest of the two.
+      expect(js!.confidence).toBe("medium");
     });
 
     it("should create separate entries when same software has different versions", () => {

--- a/src/commands/detect_utils.ts
+++ b/src/commands/detect_utils.ts
@@ -3,7 +3,7 @@ import type { Confidence, Signature } from "../signatures/_types.js";
 import type { Detection, Evidence } from "../analyzer/types.js";
 import type { DetectCommandOutput, DetectedSoftware } from "./detect_types.js";
 import type { UrlEntry } from "../browser/types.js";
-import { maxConfidence } from "../analyzer/utils.js";
+import { demoteConfidence, maxConfidence } from "../analyzer/utils.js";
 
 export function colorizeConfidence(confidence: Confidence): string {
   switch (confidence) {
@@ -122,11 +122,19 @@ export function makeDetectCommandOutput(
 
       const impliedSoftware: DetectedSoftware = {
         name: impliedSignature.name,
-        confidence: detectedSoftware.confidence,
+        // Implied softwares are detected indirectly, so they are reported one
+        // confidence level below the direct detection that implied them.
+        confidence: demoteConfidence(detectedSoftware.confidence),
         impliedBy: detectedSoftware.name,
       };
       if (impliedSignature.description) {
         impliedSoftware.description = impliedSignature.description;
+      }
+      // Carry over the parent's evidences so the report can show what led to
+      // the implication. The per-evidence confidence stays as-is; only the
+      // aggregate confidence above is demoted.
+      if (detectedSoftware.evidences?.length) {
+        impliedSoftware.evidences = detectedSoftware.evidences;
       }
       return [impliedSoftware];
     });

--- a/src/signatures/technologies/neve.test.ts
+++ b/src/signatures/technologies/neve.test.ts
@@ -71,6 +71,23 @@ describe("neveSignature", () => {
       const result = applySignature(context, neveSignature);
       expect(result).toBeUndefined();
     });
+
+    it("does not detect Neve from a minified JS body where 'neve' is only a substring", () => {
+      // "whenever" contains the substring "neve", and ".css" appears later in
+      // the same run of non-whitespace characters. A loose "neve\\S*\\.css"
+      // pattern would falsely match here even though there is no Neve theme.
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            headers: { "content-type": "application/javascript" },
+            body: 'var whenever=1,x=load("assets/app.min.css");',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, neveSignature);
+      expect(result).toBeUndefined();
+    });
   });
 
   describe("url matching", () => {

--- a/src/signatures/technologies/neve.ts
+++ b/src/signatures/technologies/neve.ts
@@ -8,7 +8,7 @@ export const neveSignature: Signature = {
   rule: {
     confidence: "high",
     urls: ["themes/neve\\S*\\.js(?:\\?ver=([0-9.]+))?"],
-    bodies: ["neve\\S*\\.css", "(?<![\\w-])neve-theme(?![\\w-])"],
+    bodies: ["themes/neve[\\w./-]*\\.css", "(?<![\\w-])neve-theme(?![\\w-])"],
   },
   impliedSoftwares: [wordpressSignature.name],
 };


### PR DESCRIPTION
## Summary

The Neve theme body pattern `neve\S*\.css` was too loose: `\S*` greedily spans a whole run of non-whitespace characters, so any token that contains the substring `neve` followed later by `.css` matched. Minified JavaScript frequently triggers this — for example the word `whenever` contains `neve`, and a `.css` string appears in the same token. Because body matching allows first-party JavaScript, this produced false-positive **Neve** detections, which in turn implied **WordPress** at high confidence with no supporting evidence.

## Changes

1. **Tighten the Neve body pattern** to require the canonical theme path (`themes/neve...`), matching the existing `themes/neve\S*\.js` url rule and restricting the trailing characters to path characters (`[\w./-]*`):
   - before: `neve\S*\.css`
   - after: `themes/neve[\w./-]*\.css`
2. **Demote implied confidence.** Add `demoteConfidence` in `src/analyzer/utils.ts` and report implied (indirectly detected) softwares one level below the direct detection that implied them (high→medium, medium→low, low→low). Implications are less certain than direct hits and should not inherit the parent's confidence.
3. **Attach evidence to implied softwares.** Carry the parent detection's `evidences` onto the implied entry so the report can show what led to the implication. `impliedBy` is kept to mark it as an indirect detection.

## Reproduction

Given a first-party JavaScript response such as:

```js
var whenever=1,x=load("assets/app.min.css");
```

- Before: matches `neve\S*\.css` → Neve detected → WordPress implied.
- After: no `themes/neve` path present → no match → no false positive.

## Tests

- `src/signatures/technologies/neve.test.ts`: new regression test for the minified JS case; existing positive cases (`neve-theme` class, `themes/neve` css/js) still pass.
- `src/analyzer/utils.test.ts`: new unit tests for `demoteConfidence` and `maxConfidence`.
- `src/commands/detect_utils.test.ts`: added tests for confidence demotion and evidence inheritance; updated the multi-source merge expectation to the new (demoted) confidence.

`npm test`, `npm run lint`, and `prettier` on the touched files all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)