### PR TITLE
fix: ignore out-of-scope URLs in server-runtime body matching

### DIFF
--- a/src/analyzer/apply.test.ts
+++ b/src/analyzer/apply.test.ts
@@ -280,6 +280,30 @@ describe("applySignature", () => {
       const result = applySignature(context, signature);
       expect(result).toBeUndefined();
     });
+
+    it("does not strip out-of-scope URLs for client-runtime signatures", () => {
+      // No headers/cookies -> runtime is inferred as "client", so the
+      // out-of-scope URL scoping (which is server-runtime only) must not apply.
+      const signature: Signature = {
+        name: "SomeClientLib",
+        rule: {
+          confidence: "medium",
+          bodies: ["wp-content"],
+        },
+      };
+
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            headers: { "content-type": "text/html" },
+            body: '"https://external.example/wp-content/plugins/foo/bar.js"',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, signature);
+      expect(result).toBeDefined();
+    });
   });
 
   describe("URL matching", () => {

--- a/src/analyzer/apply.ts
+++ b/src/analyzer/apply.ts
@@ -1,8 +1,8 @@
 import type { Context, Response } from "../browser/types.js";
 import type { Runtime, Signature } from "../signatures/_types.js";
 import type { Detection, Evidence } from "./types.js";
-import { buildEvidenceValue, matchString } from "./match.js";
-import { stripOutOfScopeUrls } from "./scope.js";
+import { buildEvidenceValue, matchString, matchStringOutsideSpans } from "./match.js";
+import { outOfScopeUrlSpans } from "./scope.js";
 
 function isFirstPartyResponse(response: Response): boolean {
   return response.isFirstParty ?? true;
@@ -126,27 +126,27 @@ export const applySignature = (
 
   // Match bodies
   if (rule?.bodies) {
-    // For server-runtime signatures, drop out-of-scope absolute URLs from
-    // first-party bodies so a third-party URL quoted inside a first-party file
-    // is not treated as evidence that the target runs this technology. The
+    // For server-runtime signatures, ignore body pattern hits that fall inside
+    // an out-of-scope URL quoted within a first-party file, so a third-party
+    // URL is not treated as evidence that the target runs this technology. The
     // in-scope host set is derived from the first-party responses themselves.
+    // The body is not modified, so matches are neither created nor destroyed.
     const inScopeHosts =
       runtime === "server"
         ? [...new Set(firstPartyResponses.map((response) => response.host))]
         : [];
-    const effectiveBodyCache = new Map<Response, string>();
-    const getEffectiveBody = (response: Response): string => {
-      const cached = effectiveBodyCache.get(response);
+    const excludedSpanCache = new Map<Response, Array<[number, number]>>();
+    const excludedSpansFor = (response: Response): Array<[number, number]> => {
+      if (runtime !== "server") {
+        return [];
+      }
+      const cached = excludedSpanCache.get(response);
       if (cached !== undefined) {
         return cached;
       }
-      const rawBody = response.body ?? "";
-      const effective =
-        runtime === "server" && rawBody
-          ? stripOutOfScopeUrls(rawBody, inScopeHosts)
-          : rawBody;
-      effectiveBodyCache.set(response, effective);
-      return effective;
+      const spans = outOfScopeUrlSpans(response.body ?? "", inScopeHosts);
+      excludedSpanCache.set(response, spans);
+      return spans;
     };
 
     for (const regex of rule.bodies) {
@@ -155,11 +155,15 @@ export const applySignature = (
           continue;
         }
 
-        const body = getEffectiveBody(response);
+        const body = response.body ?? "";
         if (!body) {
           continue;
         }
-        const result = matchString(body, regex);
+        const result = matchStringOutsideSpans(
+          body,
+          regex,
+          excludedSpansFor(response),
+        );
         if (!result.hit) {
           continue;
         }

--- a/src/analyzer/apply.ts
+++ b/src/analyzer/apply.ts
@@ -2,6 +2,7 @@ import type { Context, Response } from "../browser/types.js";
 import type { Runtime, Signature } from "../signatures/_types.js";
 import type { Detection, Evidence } from "./types.js";
 import { buildEvidenceValue, matchString } from "./match.js";
+import { stripOutOfScopeUrls } from "./scope.js";
 
 function isFirstPartyResponse(response: Response): boolean {
   return response.isFirstParty ?? true;
@@ -125,13 +126,36 @@ export const applySignature = (
 
   // Match bodies
   if (rule?.bodies) {
+    // For server-runtime signatures, drop out-of-scope absolute URLs from
+    // first-party bodies so a third-party URL quoted inside a first-party file
+    // is not treated as evidence that the target runs this technology. The
+    // in-scope host set is derived from the first-party responses themselves.
+    const inScopeHosts =
+      runtime === "server"
+        ? [...new Set(firstPartyResponses.map((response) => response.host))]
+        : [];
+    const effectiveBodyCache = new Map<Response, string>();
+    const getEffectiveBody = (response: Response): string => {
+      const cached = effectiveBodyCache.get(response);
+      if (cached !== undefined) {
+        return cached;
+      }
+      const rawBody = response.body ?? "";
+      const effective =
+        runtime === "server" && rawBody
+          ? stripOutOfScopeUrls(rawBody, inScopeHosts)
+          : rawBody;
+      effectiveBodyCache.set(response, effective);
+      return effective;
+    };
+
     for (const regex of rule.bodies) {
       for (const response of allResponses) {
         if (!isBodyMatchAllowed(response, runtime)) {
           continue;
         }
 
-        const body = response.body ?? "";
+        const body = getEffectiveBody(response);
         if (!body) {
           continue;
         }

--- a/src/analyzer/match.test.ts
+++ b/src/analyzer/match.test.ts
@@ -3,7 +3,37 @@ import {
   buildEvidenceValue,
   extractMatchSnippet,
   matchString,
+  matchStringOutsideSpans,
 } from "./match.js";
+
+describe("matchStringOutsideSpans", () => {
+  it("behaves like matchString when there are no excluded spans", () => {
+    const result = matchStringOutsideSpans("has wp-content here", "wp-content", []);
+    expect(result.hit).toBe(true);
+    expect(result.index).toBe(4);
+  });
+
+  it("skips a match that falls inside an excluded span", () => {
+    const value = 'x="https://external.example/wp-content/a.js"';
+    const span: [number, number] = [3, value.length - 1];
+    const result = matchStringOutsideSpans(value, "wp-content", [span]);
+    expect(result.hit).toBe(false);
+  });
+
+  it("returns the next match outside the excluded span", () => {
+    // First "wp-content" is inside the span; the second one is outside.
+    const value = "AAwp-contentAA /wp-content/theme";
+    const result = matchStringOutsideSpans(value, "wp-content", [[0, 12]]);
+    expect(result.hit).toBe(true);
+    expect(result.index).toBe(16);
+  });
+
+  it("keeps the captured version group for an allowed match", () => {
+    const result = matchStringOutsideSpans("nginx/1.20.0", "nginx/([\\d.]+)", []);
+    expect(result.hit).toBe(true);
+    expect(result.version).toBe("1.20.0");
+  });
+});
 
 describe("matchString", () => {
   describe("basic matching", () => {

--- a/src/analyzer/match.ts
+++ b/src/analyzer/match.ts
@@ -22,6 +22,48 @@ export const matchString = (value: string, regex: Regex): MatchResult => {
   return { hit: false, version: undefined, index: undefined, matchLength: undefined };
 };
 
+/**
+ * Like {@link matchString}, but returns the first match that does not overlap
+ * any of `excludedSpans` (half-open `[start, end)` character ranges). The value
+ * is matched as-is, so no match can be created or destroyed by the exclusion —
+ * matches that merely fall inside an excluded range are skipped in favour of the
+ * next one. With no excluded spans it is equivalent to {@link matchString}.
+ */
+export const matchStringOutsideSpans = (
+  value: string,
+  regex: Regex,
+  excludedSpans: Array<[number, number]>,
+): MatchResult => {
+  if (excludedSpans.length === 0) {
+    return matchString(value, regex);
+  }
+
+  const regexExp = new RegExp(regex, "gi");
+  let match: RegExpExecArray | null;
+  while ((match = regexExp.exec(value)) !== null) {
+    if (match[0].length === 0) {
+      // Guard against zero-width matches looping forever.
+      regexExp.lastIndex++;
+      continue;
+    }
+    const start = match.index;
+    const end = start + match[0].length;
+    const overlapsExcluded = excludedSpans.some(
+      ([spanStart, spanEnd]) => start < spanEnd && end > spanStart,
+    );
+    if (!overlapsExcluded) {
+      return {
+        hit: true,
+        version: match.length > 1 ? match[1] : undefined,
+        index: match.index,
+        matchLength: match[0].length,
+      };
+    }
+  }
+
+  return { hit: false, version: undefined, index: undefined, matchLength: undefined };
+};
+
 export type SnippetOptions = {
   context?: number;
   maxMatchLength?: number;

--- a/src/analyzer/scope.test.ts
+++ b/src/analyzer/scope.test.ts
@@ -49,6 +49,11 @@ describe("outOfScopeUrlSpans", () => {
     expect(spannedText(body, ["example.com"])).toEqual([outOfScope]);
   });
 
+  it("spans an out-of-scope URL including its query and fragment", () => {
+    const url = "https://external.example/a?p=wp-json#wp-content";
+    expect(spannedText(`x="${url}"`, ["example.com"])).toEqual([url]);
+  });
+
   it("does not span a URL without an identifiable host", () => {
     // Unparseable and empty-authority (`https://./...`) URLs cannot be proven
     // out of scope, so they are not excluded.

--- a/src/analyzer/scope.test.ts
+++ b/src/analyzer/scope.test.ts
@@ -1,76 +1,62 @@
 import { describe, it, expect } from "vitest";
-import { stripOutOfScopeUrls } from "./scope.js";
+import { outOfScopeUrlSpans } from "./scope.js";
 
-describe("stripOutOfScopeUrls", () => {
-  it("removes an out-of-scope absolute URL", () => {
-    const body = '"https://external.example/wp-content/plugins/foo/bar.js"';
-    const result = stripOutOfScopeUrls(body, ["example.com"]);
-    expect(result.includes("wp-content")).toBe(false);
-    expect(result.includes("external.example")).toBe(false);
+function spannedText(body: string, inScopeHosts: string[]): string[] {
+  return outOfScopeUrlSpans(body, inScopeHosts).map(([start, end]) =>
+    body.slice(start, end),
+  );
+}
+
+describe("outOfScopeUrlSpans", () => {
+  it("spans an out-of-scope absolute URL", () => {
+    const url = "https://external.example/wp-content/plugins/foo/bar.js";
+    expect(spannedText(`"${url}"`, ["example.com"])).toEqual([url]);
   });
 
-  it("keeps an in-scope absolute URL", () => {
+  it("does not span an in-scope absolute URL", () => {
     const body = '<link href="https://example.com/wp-content/themes/foo.css">';
-    const result = stripOutOfScopeUrls(body, ["example.com"]);
-    expect(result.includes("wp-content")).toBe(true);
+    expect(outOfScopeUrlSpans(body, ["example.com"])).toEqual([]);
   });
 
   it("treats a subdomain of the in-scope host as in scope", () => {
     const body = '<script src="https://cdn.example.com/wp-includes/js/a.js">';
-    const result = stripOutOfScopeUrls(body, ["example.com"]);
-    expect(result.includes("wp-includes")).toBe(true);
+    expect(outOfScopeUrlSpans(body, ["example.com"])).toEqual([]);
   });
 
-  it("keeps relative paths untouched", () => {
+  it("does not span relative paths", () => {
     const body = '<link href="/wp-content/themes/foo/style.css">';
-    const result = stripOutOfScopeUrls(body, ["example.com"]);
-    expect(result).toBe(body);
+    expect(outOfScopeUrlSpans(body, ["example.com"])).toEqual([]);
   });
 
-  it("returns the body unchanged when no in-scope hosts are known", () => {
+  it("returns no spans when no in-scope hosts are known", () => {
     const body = '"https://external.example/wp-content/plugins/foo/bar.js"';
-    const result = stripOutOfScopeUrls(body, []);
-    expect(result).toBe(body);
+    expect(outOfScopeUrlSpans(body, [])).toEqual([]);
   });
 
-  it("removes only the out-of-scope URL when both are present", () => {
-    const body =
-      '"https://external.example/wp-json/x" and "https://example.com/wp-content/y"';
-    const result = stripOutOfScopeUrls(body, ["example.com"]);
-    expect(result.includes("wp-json")).toBe(false);
-    expect(result.includes("wp-content")).toBe(true);
+  it("spans an out-of-scope protocol-relative URL", () => {
+    const url = "//external.example/wp-content/plugins/foo/bar.js";
+    expect(spannedText(`"${url}"`, ["example.com"])).toEqual([url]);
   });
 
-  it("removes an out-of-scope protocol-relative URL", () => {
-    const body = '"//external.example/wp-content/plugins/foo/bar.js"';
-    const result = stripOutOfScopeUrls(body, ["example.com"]);
-    expect(result.includes("wp-content")).toBe(false);
+  it("does not span an in-scope protocol-relative URL", () => {
+    const body = '"//example.com/wp-includes/js/a.js"';
+    expect(outOfScopeUrlSpans(body, ["example.com"])).toEqual([]);
   });
 
-  it("keeps an in-scope protocol-relative URL", () => {
-    const body = '<script src="//example.com/wp-includes/js/a.js">';
-    const result = stripOutOfScopeUrls(body, ["example.com"]);
-    expect(result.includes("wp-includes")).toBe(true);
+  it("spans only the out-of-scope URL when both are present", () => {
+    const outOfScope = "https://external.example/wp-json/x";
+    const body = `"${outOfScope}" and "https://example.com/wp-content/y"`;
+    expect(spannedText(body, ["example.com"])).toEqual([outOfScope]);
   });
 
-  it("removes query and fragment belonging to an out-of-scope URL", () => {
-    const body = 'x="https://external.example/a?p=wp-json#wp-content"';
-    const result = stripOutOfScopeUrls(body, ["example.com"]);
-    expect(result.includes("wp-json")).toBe(false);
-    expect(result.includes("wp-content")).toBe(false);
-  });
-
-  it("leaves a token untouched when it does not parse to a host", () => {
-    const body = "see https://[ for details";
-    const result = stripOutOfScopeUrls(body, ["example.com"]);
-    expect(result).toBe(body);
-  });
-
-  it("leaves a URL with an empty host untouched", () => {
-    // `https://./...` parses to an empty hostname; without a real host we
-    // cannot prove it is out of scope, so it must not be stripped.
-    const body = '"https://./wp-content/themes/foo/style.css"';
-    const result = stripOutOfScopeUrls(body, ["example.com"]);
-    expect(result).toBe(body);
+  it("does not span a URL without an identifiable host", () => {
+    // Unparseable and empty-authority (`https://./...`) URLs cannot be proven
+    // out of scope, so they are not excluded.
+    expect(outOfScopeUrlSpans("see https://[ here", ["example.com"])).toEqual(
+      [],
+    );
+    expect(
+      outOfScopeUrlSpans('"https://./wp-content/x"', ["example.com"]),
+    ).toEqual([]);
   });
 });

--- a/src/analyzer/scope.test.ts
+++ b/src/analyzer/scope.test.ts
@@ -65,4 +65,12 @@ describe("stripOutOfScopeUrls", () => {
     const result = stripOutOfScopeUrls(body, ["example.com"]);
     expect(result).toBe(body);
   });
+
+  it("leaves a URL with an empty host untouched", () => {
+    // `https://./...` parses to an empty hostname; without a real host we
+    // cannot prove it is out of scope, so it must not be stripped.
+    const body = '"https://./wp-content/themes/foo/style.css"';
+    const result = stripOutOfScopeUrls(body, ["example.com"]);
+    expect(result).toBe(body);
+  });
 });

--- a/src/analyzer/scope.test.ts
+++ b/src/analyzer/scope.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { stripOutOfScopeUrls } from "./scope.js";
+
+describe("stripOutOfScopeUrls", () => {
+  it("removes an out-of-scope absolute URL", () => {
+    const body = '"https://external.example/wp-content/plugins/foo/bar.js"';
+    const result = stripOutOfScopeUrls(body, ["example.com"]);
+    expect(result.includes("wp-content")).toBe(false);
+    expect(result.includes("external.example")).toBe(false);
+  });
+
+  it("keeps an in-scope absolute URL", () => {
+    const body = '<link href="https://example.com/wp-content/themes/foo.css">';
+    const result = stripOutOfScopeUrls(body, ["example.com"]);
+    expect(result.includes("wp-content")).toBe(true);
+  });
+
+  it("treats a subdomain of the in-scope host as in scope", () => {
+    const body = '<script src="https://cdn.example.com/wp-includes/js/a.js">';
+    const result = stripOutOfScopeUrls(body, ["example.com"]);
+    expect(result.includes("wp-includes")).toBe(true);
+  });
+
+  it("keeps relative paths untouched", () => {
+    const body = '<link href="/wp-content/themes/foo/style.css">';
+    const result = stripOutOfScopeUrls(body, ["example.com"]);
+    expect(result).toBe(body);
+  });
+
+  it("returns the body unchanged when no in-scope hosts are known", () => {
+    const body = '"https://external.example/wp-content/plugins/foo/bar.js"';
+    const result = stripOutOfScopeUrls(body, []);
+    expect(result).toBe(body);
+  });
+
+  it("removes only the out-of-scope URL when both are present", () => {
+    const body =
+      '"https://external.example/wp-json/x" and "https://example.com/wp-content/y"';
+    const result = stripOutOfScopeUrls(body, ["example.com"]);
+    expect(result.includes("wp-json")).toBe(false);
+    expect(result.includes("wp-content")).toBe(true);
+  });
+
+  it("removes an out-of-scope protocol-relative URL", () => {
+    const body = '"//external.example/wp-content/plugins/foo/bar.js"';
+    const result = stripOutOfScopeUrls(body, ["example.com"]);
+    expect(result.includes("wp-content")).toBe(false);
+  });
+
+  it("keeps an in-scope protocol-relative URL", () => {
+    const body = '<script src="//example.com/wp-includes/js/a.js">';
+    const result = stripOutOfScopeUrls(body, ["example.com"]);
+    expect(result.includes("wp-includes")).toBe(true);
+  });
+
+  it("removes query and fragment belonging to an out-of-scope URL", () => {
+    const body = 'x="https://external.example/a?p=wp-json#wp-content"';
+    const result = stripOutOfScopeUrls(body, ["example.com"]);
+    expect(result.includes("wp-json")).toBe(false);
+    expect(result.includes("wp-content")).toBe(false);
+  });
+
+  it("leaves a token untouched when it does not parse to a host", () => {
+    const body = "see https://[ for details";
+    const result = stripOutOfScopeUrls(body, ["example.com"]);
+    expect(result).toBe(body);
+  });
+});

--- a/src/analyzer/scope.ts
+++ b/src/analyzer/scope.ts
@@ -1,0 +1,49 @@
+import { getHostFromUrl, isFirstPartyHost } from "../browser/utils.js";
+
+// Matches absolute http(s) URLs and protocol-relative URLs (`//host/...`),
+// stopping at characters that commonly delimit a URL inside HTML/JS/CSS
+// (whitespace, quotes, backticks, angle brackets, parentheses, backslashes).
+// Tokens that do not parse to a host are left untouched (see below), so a bare
+// `//foo` in a comment is only ever removed when it resolves to an out-of-scope
+// host, and removing text can never introduce a new match.
+const ABSOLUTE_URL_PATTERN = /(?:https?:)?\/\/[^\s"'`<>()\\]+/gi;
+
+/**
+ * Removes absolute URLs whose host is out of scope (i.e. not first-party to the
+ * scanned target) from a response body.
+ *
+ * A server-runtime signature is meant to answer "does the scanned site itself
+ * run this technology?". A first-party file (e.g. a bundled `.min.js`) can quote
+ * an unrelated third-party URL as a plain string; matching a body pattern such
+ * as `wp-content` against that string wrongly attributes another site's
+ * technology to the target. Stripping out-of-scope URLs before matching removes
+ * that source of over-detection.
+ *
+ * In-scope absolute URLs and relative paths (e.g. `/wp-content/...`) are left
+ * untouched, so genuine first-party references still match. When the in-scope
+ * host set is unknown (empty), the body is returned unchanged.
+ */
+export function stripOutOfScopeUrls(
+  body: string,
+  inScopeHosts: string[],
+): string {
+  if (inScopeHosts.length === 0) {
+    return body;
+  }
+
+  return body.replace(ABSOLUTE_URL_PATTERN, (match) => {
+    // Give protocol-relative URLs a scheme so the host can be parsed.
+    const normalized = match.startsWith("//") ? `https:${match}` : match;
+    const host = getHostFromUrl(normalized);
+    if (host === undefined) {
+      // Not a parseable URL host; leave it as-is.
+      return match;
+    }
+    const inScope = inScopeHosts.some((inScopeHost) =>
+      isFirstPartyHost(inScopeHost, host),
+    );
+    // Replace with a single space so surrounding tokens do not merge across the
+    // removed URL.
+    return inScope ? match : " ";
+  });
+}

--- a/src/analyzer/scope.ts
+++ b/src/analyzer/scope.ts
@@ -35,8 +35,10 @@ export function stripOutOfScopeUrls(
     // Give protocol-relative URLs a scheme so the host can be parsed.
     const normalized = match.startsWith("//") ? `https:${match}` : match;
     const host = getHostFromUrl(normalized);
-    if (host === undefined) {
-      // Not a parseable URL host; leave it as-is.
+    if (!host) {
+      // No identifiable host (unparseable, or an empty authority such as
+      // `https:///path`); leave it untouched so that only URLs that provably
+      // point at an out-of-scope host are removed.
       return match;
     }
     const inScope = inScopeHosts.some((inScopeHost) =>

--- a/src/analyzer/scope.ts
+++ b/src/analyzer/scope.ts
@@ -3,49 +3,50 @@ import { getHostFromUrl, isFirstPartyHost } from "../browser/utils.js";
 // Matches absolute http(s) URLs and protocol-relative URLs (`//host/...`),
 // stopping at characters that commonly delimit a URL inside HTML/JS/CSS
 // (whitespace, quotes, backticks, angle brackets, parentheses, backslashes).
-// Tokens that do not parse to a host are left untouched (see below), so a bare
-// `//foo` in a comment is only ever removed when it resolves to an out-of-scope
-// host, and removing text can never introduce a new match.
 const ABSOLUTE_URL_PATTERN = /(?:https?:)?\/\/[^\s"'`<>()\\]+/gi;
 
+// A half-open character range [start, end) within a body.
+export type UrlSpan = [start: number, end: number];
+
 /**
- * Removes absolute URLs whose host is out of scope (i.e. not first-party to the
- * scanned target) from a response body.
+ * Returns the character spans of absolute / protocol-relative URLs in `body`
+ * whose host is out of scope (i.e. not first-party to the scanned target).
  *
- * A server-runtime signature is meant to answer "does the scanned site itself
- * run this technology?". A first-party file (e.g. a bundled `.min.js`) can quote
- * an unrelated third-party URL as a plain string; matching a body pattern such
- * as `wp-content` against that string wrongly attributes another site's
- * technology to the target. Stripping out-of-scope URLs before matching removes
- * that source of over-detection.
+ * Used by server-runtime body matching to reject pattern hits that fall inside a
+ * third-party URL quoted within a first-party file (e.g. `wp-content` inside an
+ * unrelated site's URL). The body itself is never modified, so no match can be
+ * created or destroyed across the excluded region.
  *
- * In-scope absolute URLs and relative paths (e.g. `/wp-content/...`) are left
- * untouched, so genuine first-party references still match. When the in-scope
- * host set is unknown (empty), the body is returned unchanged.
+ * URLs without an identifiable host (unparseable, or an empty authority such as
+ * `https://./...`) are not treated as out of scope, so only provably
+ * out-of-scope URLs are excluded. When the in-scope host set is unknown (empty),
+ * no spans are returned.
  */
-export function stripOutOfScopeUrls(
+export function outOfScopeUrlSpans(
   body: string,
   inScopeHosts: string[],
-): string {
+): UrlSpan[] {
   if (inScopeHosts.length === 0) {
-    return body;
+    return [];
   }
 
-  return body.replace(ABSOLUTE_URL_PATTERN, (match) => {
+  const spans: UrlSpan[] = [];
+  const regex = new RegExp(ABSOLUTE_URL_PATTERN.source, "gi");
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(body)) !== null) {
+    const url = match[0];
     // Give protocol-relative URLs a scheme so the host can be parsed.
-    const normalized = match.startsWith("//") ? `https:${match}` : match;
+    const normalized = url.startsWith("//") ? `https:${url}` : url;
     const host = getHostFromUrl(normalized);
     if (!host) {
-      // No identifiable host (unparseable, or an empty authority such as
-      // `https:///path`); leave it untouched so that only URLs that provably
-      // point at an out-of-scope host are removed.
-      return match;
+      continue;
     }
     const inScope = inScopeHosts.some((inScopeHost) =>
       isFirstPartyHost(inScopeHost, host),
     );
-    // Replace with a single space so surrounding tokens do not merge across the
-    // removed URL.
-    return inScope ? match : " ";
-  });
+    if (!inScope) {
+      spans.push([match.index, match.index + url.length]);
+    }
+  }
+  return spans;
 }

--- a/src/analyzer/scope.ts
+++ b/src/analyzer/scope.ts
@@ -31,7 +31,8 @@ export function outOfScopeUrlSpans(
   }
 
   const spans: UrlSpan[] = [];
-  const regex = new RegExp(ABSOLUTE_URL_PATTERN.source, "gi");
+  // Copy source and flags from the shared pattern (fresh lastIndex, no divergence).
+  const regex = new RegExp(ABSOLUTE_URL_PATTERN);
   let match: RegExpExecArray | null;
   while ((match = regex.exec(body)) !== null) {
     const url = match[0];

--- a/src/signatures/technologies/wordpress.test.ts
+++ b/src/signatures/technologies/wordpress.test.ts
@@ -101,5 +101,34 @@ describe("wordpressSignature", () => {
       const result = applySignature(context, wordpressSignature);
       expect(result).toBeDefined();
     });
+
+    it("does not detect WordPress from a third-party URL quoted inside a first-party script", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            url: "https://example.com/js/app.min.js",
+            host: "example.com",
+            headers: { "content-type": "application/javascript" },
+            body: '"https://external.example/wp-content/plugins/foo/bar.js"',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, wordpressSignature);
+      expect(result).toBeUndefined();
+    });
+
+    it("detects WordPress from an in-scope absolute wp-content URL", () => {
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<link href="https://example.com/wp-content/themes/foo/style.css">',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, wordpressSignature);
+      expect(result).toBeDefined();
+    });
   });
 });

--- a/src/signatures/technologies/wordpress.test.ts
+++ b/src/signatures/technologies/wordpress.test.ts
@@ -130,5 +130,23 @@ describe("wordpressSignature", () => {
       const result = applySignature(context, wordpressSignature);
       expect(result).toBeDefined();
     });
+
+    it("does not read a version across an out-of-scope URL between the tokens", () => {
+      // "WordPress" and "6.4.2" are separated by an out-of-scope URL. Because
+      // the URL is excluded by span (not replaced with whitespace), the version
+      // pattern must not bridge the two into a spurious 6.4.2 detection. An
+      // in-scope relative path still yields a WordPress detection.
+      const context = createMockContext({
+        responses: [
+          createMockResponse({
+            body: '<link href="/wp-content/style.css"> WordPress https://external.example/a/b.js 6.4.2',
+          }),
+        ],
+      });
+
+      const result = applySignature(context, wordpressSignature);
+      expect(result).toBeDefined();
+      expect(result?.evidences?.every((e) => e.version !== "6.4.2")).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Problem

Server-runtime signatures (e.g. WordPress) match body patterns such as `wp-content` against the full response body. When a first-party file (e.g. a bundled `.min.js`) quotes an unrelated third-party URL — one that points at a different site — as a plain string, that string was matched and treated as evidence that the target itself runs the technology, producing a high-confidence false positive (and implied PHP/MySQL).

The `runtime: "server"` filter only checks whether the *file* is served first-party; it does not check the host referenced by URL strings inside the body.

## Fix

For server-runtime body matching, compute the character spans of out-of-scope URLs in the body (`outOfScopeUrlSpans`) and skip any pattern hit that overlaps one (`matchStringOutsideSpans`). A URL is in scope when its host is first-party to the scanned target (registrable-domain match); the in-scope host set is derived from the first-party responses. The body is matched as-is (never rewritten), so matches are neither created nor destroyed across the excluded region. As a result:

- Third-party URLs quoted inside first-party files no longer match.
- Relative paths (`/wp-content/...`), in-scope URLs, and everything else still match, preserving genuine detections.
- Client-runtime matching (e.g. CDN-hosted libraries) is unchanged.

## Tests

- `src/analyzer/scope.test.ts` — `outOfScopeUrlSpans` (in/out of scope, protocol-relative, relative paths, query/fragment, unparseable/empty host).
- `src/analyzer/match.test.ts` — `matchStringOutsideSpans` (span exclusion, next-match-outside-span, version capture).
- `src/signatures/technologies/wordpress.test.ts` — negative (third-party URL not detected), positive (in-scope absolute URL detected), and no version bridging across an out-of-scope URL.
- `src/analyzer/apply.test.ts` — client-runtime bodies are not scoped.
- Full suite: 572 passed / 1 skipped. `tsc` and eslint clean.
